### PR TITLE
Support fulfilling available orders with tolerance for failures

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -2,11 +2,13 @@ module.exports = {
   skipFiles: [
     'interfaces/AbridgedProxyInterfaces.sol',
     'interfaces/AbridgedTokenInterfaces.sol',
+    'interfaces/ConsiderationDelegatedInterface.sol',
     'interfaces/ConsiderationEventsAndErrors.sol',
     'interfaces/ConsiderationInterface.sol',
     'interfaces/EIP1271Interface.sol',
     'lib/ConsiderationEnums.sol',
     'lib/ConsiderationStructs.sol',
+    'test/DelegatedDomainSeparatorTester.sol',
     'test/EIP1271Wallet.sol',
     'test/Reenterer.sol',
     'test/TestERC1155.sol',

--- a/contracts/Consideration.sol
+++ b/contracts/Consideration.sol
@@ -14,12 +14,14 @@ import {
     OrderParameters,
     OrderComponents,
     Fulfillment,
+    FulfillmentComponent,
     Execution,
     Order,
     AdvancedOrder,
     OrderStatus,
     CriteriaResolver,
-    BatchExecution
+    BatchExecution,
+    FulfillmentDetail
 } from "./lib/ConsiderationStructs.sol";
 
 import { ConsiderationInternal } from "./lib/ConsiderationInternal.sol";
@@ -443,54 +445,83 @@ contract Consideration is ConsiderationInterface, ConsiderationInternal {
      * @notice Attempt to fill a group of orders, fully or partially, with an
      *         arbitrary number of items for offer and consideration per order
      *         alongside criteria resolvers containing specific token
-     *         identifiers and associated proofs. Any order that has already
-     *         been fully filled or cancelled, or where an offer item cannot be
-     *         successfully transferred to the fulfiller, will be skipped. If an
-     *         order is skipped, all state changes for that order (including any
-     *         previously transferred offer items for that order) will be rolled
-     *         back and any unapplied criteria resolvers referencing that order
-     *         will be ignored. The fulfiller must then transfer each
-     *         consideration item on the remaining orders to the intended
-     *         recipient — note that a failing transfer of a consideration item
-     *         from the fulfiller will cause the entire transaction to revert.
+     *         identifiers and associated proofs. Any order that is not
+     *         currently active, has already been fully filled, or has been
+     *         cancelled will be omitted. Remaining offer and consideration
+     *         items will then be aggregated where possible as indicated by the
+     *         supplied offer and consideration component arrays and aggregated
+     *         items will be transferred to the fulfiller or to each intended
+     *         recipient, respectively. Note that a failing item transfer or an
+     *         issue with order formatting will cause the entire batch to fail.
      *
-     * @param advancedOrders    The orders to fulfill along with the fraction of
-     *                          those orders to attempt to fill. Note that both
-     *                          the offerer and the fulfiller must first approve
-     *                          this contract (or their proxy if indicated by
-     *                          the order) to transfer any relevant tokens on
-     *                          their behalf and that contracts must implement
-     *                          `onERC1155Received` in order to receive ERC1155
-     *                          tokens as consideration. Also note that all
-     *                          offer and consideration components must have no
-     *                          remainder after multiplication of the respective
-     *                          amount with the supplied fraction for an order's
-     *                          partial fill amount to be considered valid.
-     * @param criteriaResolvers An array where each element contains a reference
-     *                          to a specific offer or consideration, a token
-     *                          identifier, and a proof that the supplied token
-     *                          identifier is contained in the merkle root held
-     *                          by the item in question's criteria element. Note
-     *                          that an empty criteria indicates that any
-     *                          (transferrable) token identifier on the token in
-     *                          question is valid and that no associated proof
-     *                          needs to be supplied.
-     * @param useFulfillerProxy A flag indicating whether to source approvals
-     *                          for fulfilled tokens from an associated proxy.
+     * @param advancedOrders            The orders to fulfill along with the
+     *                                  fraction of those orders to attempt to
+     *                                  fill. Note that both the offerer and the
+     *                                  fulfiller must first approve this
+     *                                  contract (or their proxy if indicated by
+     *                                  the order) to transfer any relevant
+     *                                  tokens on their behalf and that
+     *                                  contracts must implement
+     *                                  `onERC1155Received` in order to receive
+     *                                  ERC1155 tokens as consideration. Also
+     *                                  note that all offer and consideration
+     *                                  components must have no remainder after
+     *                                  multiplication of the respective amount
+     *                                  with the supplied fraction for an
+     *                                  order's partial fill amount to be
+     *                                  considered valid.
+     * @param criteriaResolvers         An array where each element contains a
+     *                                  reference to a specific offer or
+     *                                  consideration, a token identifier, and a
+     *                                  proof that the supplied token identifier
+     *                                  is contained in the merkle root held by
+     *                                  the item in question's criteria element.
+     *                                  Note that an empty criteria indicates
+     *                                  that any (transferrable) token
+     *                                  identifier on the token in question is
+     *                                  valid and that no associated proof needs
+     *                                  to be supplied.
+     * @param offerFulfillments         An array of FulfillmentComponent arrays
+     *                                  indicating which offer items to attempt
+     *                                  to aggregate when preparing executions.
+     * @param considerationFulfillments An array of FulfillmentComponent arrays
+     *                                  indicating which consideration items to
+     *                                  attempt to aggregate when preparing
+     *                                  executions.
+     * @param useFulfillerProxy         A flag indicating whether to source
+     *                                  approvals for fulfilled tokens from an
+     *                                  associated proxy.
      *
-     * @return statuses An array of booleans indicating whether each order has
-     *                  been fulfilled.
+     * @return fulfillmentDetails A array of FulfillmentDetail structs, each
+     *                            indicating whether the associated order has
+     *                            been fulfilled and whether a proxy was used.
+     * @return standardExecutions An array of elements indicating the sequence
+     *                            of non-batch transfers performed as part of
+     *                            matching the given orders.
+     * @return batchExecutions    An array of elements indicating the sequence
+     *                            of batch transfers performed as part of
+     *                            matching the given orders.
      */
     function fulfillAvailableAdvancedOrders(
         AdvancedOrder[] calldata advancedOrders,
         CriteriaResolver[] calldata criteriaResolvers,
+        FulfillmentComponent[][] calldata offerFulfillments,
+        FulfillmentComponent[][] calldata considerationFulfillments,
         bool useFulfillerProxy
-    ) external payable override returns (bool[] memory statuses) {
+    ) external payable override returns (
+        FulfillmentDetail[] memory fulfillmentDetails,
+        Execution[] memory standardExecutions,
+        BatchExecution[] memory batchExecutions
+    ) {
         // Reference "unused" variables to silence compiler warnings.
         advancedOrders;
         criteriaResolvers;
+        offerFulfillments;
+        considerationFulfillments;
         useFulfillerProxy;
-        statuses;
+        fulfillmentDetails;
+        standardExecutions;
+        batchExecutions;
 
         // Read delegated logic contract from runtime code and place on stack.
         address delegated = _DELEGATED;
@@ -575,16 +606,19 @@ contract Consideration is ConsiderationInterface, ConsiderationInternal {
         );
 
         // Validate orders, apply amounts, & determine if they utilize proxies.
-        bool[] memory useProxyPerOrder = _validateOrdersAndPrepareToFulfill(
-            advancedOrders,
-            new CriteriaResolver[](0) // No criteria resolvers are supplied.
+        FulfillmentDetail[] memory fulfillOrdersAndUseProxy = (
+            _validateOrdersAndPrepareToFulfill(
+                advancedOrders,
+                new CriteriaResolver[](0), // No criteria resolvers supplied.
+                true // Signifies that invalid orders should revert.
+            )
         );
 
         // Fulfill the orders using the supplied fulfillments.
         return _fulfillAdvancedOrders(
             advancedOrders,
             fulfillments,
-            useProxyPerOrder
+            fulfillOrdersAndUseProxy
         );
     }
 
@@ -636,16 +670,19 @@ contract Consideration is ConsiderationInterface, ConsiderationInternal {
         BatchExecution[] memory batchExecutions
     ) {
         // Validate orders, apply amounts, & determine if they utilize proxies.
-        bool[] memory useProxyPerOrder = _validateOrdersAndPrepareToFulfill(
-            advancedOrders,
-            criteriaResolvers
+        FulfillmentDetail[] memory fulfillOrdersAndUseProxy = (
+            _validateOrdersAndPrepareToFulfill(
+                advancedOrders,
+                criteriaResolvers,
+                true // Signifies that invalid orders should revert.
+            )
         );
 
         // Fulfill the orders using the supplied fulfillments.
         return _fulfillAdvancedOrders(
             advancedOrders,
             fulfillments,
-            useProxyPerOrder
+            fulfillOrdersAndUseProxy
         );
     }
 
@@ -756,7 +793,8 @@ contract Consideration is ConsiderationInterface, ConsiderationInternal {
                 _verifyOrderStatus(
                     orderHash,
                     orderStatus,
-                    false // Signifies that partially filled orders are valid.
+                    false, // Signifies that partially filled orders are valid.
+                    true // Signifies to revert if the order is invalid.
                 );
 
                 // If the order has not already been validated...

--- a/contracts/interfaces/ConsiderationDelegatedInterface.sol
+++ b/contracts/interfaces/ConsiderationDelegatedInterface.sol
@@ -3,7 +3,11 @@ pragma solidity 0.8.12;
 
 import {
     AdvancedOrder,
-    CriteriaResolver
+    CriteriaResolver,
+    FulfillmentComponent,
+    FulfillmentDetail,
+    Execution,
+    BatchExecution
 } from "../lib/ConsiderationStructs.sol";
 
 interface ConsiderationDelegatedInterface {
@@ -13,49 +17,73 @@ interface ConsiderationDelegatedInterface {
      *         or partially, with an arbitrary number of items for offer and
      *         consideration per order alongside criteria resolvers containing
      *         specific token identifiers and associated proofs. Any order that
-     *         has already been fully filled or cancelled, or where an offer
-     *         item cannot be successfully transferred to the fulfiller, will be
-     *         skipped. If an order is skipped, all state changes for that order
-     *         (including any previously transferred offer items for that order)
-     *         will be rolled back and any unapplied criteria resolvers
-     *         referencing that order will be ignored. The fulfiller must then
-     *         transfer each consideration item on the remaining orders to the
-     *         intended recipient — note that a failing transfer of a
-     *         consideration item from the fulfiller will cause the entire
-     *         transaction to revert.
+     *         is not currently active, has already been fully filled, or has
+     *         been cancelled will be omitted. Remaining offer and consideration
+     *         items will then be aggregated where possible as indicated by the
+     *         supplied offer and consideration component arrays and aggregated
+     *         items will be transferred to the fulfiller or to each intended
+     *         recipient, respectively. Note that a failing item transfer or an
+     *         issue with order formatting will cause the entire batch to fail.
      *
-     * @param advancedOrders    The orders to fulfill along with the fraction of
-     *                          those orders to attempt to fill. Note that both
-     *                          the offerer and the fulfiller must first approve
-     *                          this contract (or their proxy if indicated by
-     *                          the order) to transfer any relevant tokens on
-     *                          their behalf and that contracts must implement
-     *                          `onERC1155Received` in order to receive ERC1155
-     *                          tokens as consideration. Also note that all
-     *                          offer and consideration components must have no
-     *                          remainder after multiplication of the respective
-     *                          amount with the supplied fraction for an order's
-     *                          partial fill amount to be considered valid.
-     * @param criteriaResolvers An array where each element contains a reference
-     *                          to a specific offer or consideration, a token
-     *                          identifier, and a proof that the supplied token
-     *                          identifier is contained in the merkle root held
-     *                          by the item in question's criteria element. Note
-     *                          that an empty criteria indicates that any
-     *                          (transferrable) token identifier on the token in
-     *                          question is valid and that no associated proof
-     *                          needs to be supplied.
-     * @param useFulfillerProxy A flag indicating whether to source approvals
-     *                          for fulfilled tokens from an associated proxy.
+     * @param advancedOrders            The orders to fulfill along with the
+     *                                  fraction of those orders to attempt to
+     *                                  fill. Note that both the offerer and the
+     *                                  fulfiller must first approve this
+     *                                  contract (or their proxy if indicated by
+     *                                  the order) to transfer any relevant
+     *                                  tokens on their behalf and that
+     *                                  contracts must implement
+     *                                  `onERC1155Received` in order to receive
+     *                                  ERC1155 tokens as consideration. Also
+     *                                  note that all offer and consideration
+     *                                  components must have no remainder after
+     *                                  multiplication of the respective amount
+     *                                  with the supplied fraction for an
+     *                                  order's partial fill amount to be
+     *                                  considered valid.
+     * @param criteriaResolvers         An array where each element contains a
+     *                                  reference to a specific offer or
+     *                                  consideration, a token identifier, and a
+     *                                  proof that the supplied token identifier
+     *                                  is contained in the merkle root held by
+     *                                  the item in question's criteria element.
+     *                                  Note that an empty criteria indicates
+     *                                  that any (transferrable) token
+     *                                  identifier on the token in question is
+     *                                  valid and that no associated proof needs
+     *                                  to be supplied.
+     * @param offerFulfillments         An array of FulfillmentComponent arrays
+     *                                  indicating which offer items to attempt
+     *                                  to aggregate when preparing executions.
+     * @param considerationFulfillments An array of FulfillmentComponent arrays
+     *                                  indicating which consideration items to
+     *                                  attempt to aggregate when preparing
+     *                                  executions.
+     * @param useFulfillerProxy         A flag indicating whether to source
+     *                                  approvals for fulfilled tokens from an
+     *                                  associated proxy.
      *
-     * @return statuses An array of booleans indicating whether each order has
-     *                  been fulfilled.
+     * @return fulfillmentDetails A array of FulfillmentDetail structs, each
+     *                            indicating whether the associated order has
+     *                            been fulfilled and whether a proxy was used.
+     * @return standardExecutions An array of elements indicating the sequence
+     *                            of non-batch transfers performed as part of
+     *                            matching the given orders.
+     * @return batchExecutions    An array of elements indicating the sequence
+     *                            of batch transfers performed as part of
+     *                            matching the given orders.
      */
-	function fulfillAvailableAdvancedOrders(
-        AdvancedOrder[] memory advancedOrders,
-        CriteriaResolver[] memory criteriaResolvers,
+    function fulfillAvailableAdvancedOrders(
+        AdvancedOrder[] calldata advancedOrders,
+        CriteriaResolver[] calldata criteriaResolvers,
+        FulfillmentComponent[][] calldata offerFulfillments,
+        FulfillmentComponent[][] calldata considerationFulfillments,
         bool useFulfillerProxy
-    ) external payable returns (bool[] memory statuses);
+    ) external payable returns (
+        FulfillmentDetail[] memory fulfillmentDetails,
+        Execution[] memory standardExecutions,
+        BatchExecution[] memory batchExecutions
+    );
 
     /**
      * @dev Revert when called or delegatecalled via any method other than a

--- a/contracts/interfaces/ConsiderationEventsAndErrors.sol
+++ b/contracts/interfaces/ConsiderationEventsAndErrors.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.12;
 
+import { Side } from "../lib/ConsiderationEnums.sol";
+
 import {
     SpentItem,
     ReceivedItem
@@ -102,6 +104,13 @@ interface ConsiderationEventsAndErrors {
      *      a consideration array that is shorter than the original array.
      */
     error MissingOriginalConsiderationItems();
+
+    /**
+     * @dev Revert with an error when a fulfillment is provided as part of an
+     *      call to fulfill available orders that does not declare at least one
+     *      component.
+     */
+    error MissingFulfillmentComponentOnAggregation(Side side);
 
     /**
      * @dev Revert with an error when a fulfillment is provided that does not
@@ -375,4 +384,10 @@ interface ConsiderationEventsAndErrors {
      *      calldata not produced by default ABI encoding.
      */
     error InvalidBasicOrderParameterEncoding();
+
+    /**
+     * @dev Revert with an error when attempting to fulfill any number of
+     *      available orders when none are fulfillable.
+     */
+    error NoSpecifiedOrdersAvailable();
 }

--- a/contracts/interfaces/ConsiderationInterface.sol
+++ b/contracts/interfaces/ConsiderationInterface.sol
@@ -5,12 +5,14 @@ import {
     BasicOrderParameters,
     OrderComponents,
     Fulfillment,
+    FulfillmentComponent,
     Execution,
     BatchExecution,
     Order,
     AdvancedOrder,
     OrderStatus,
-    CriteriaResolver
+    CriteriaResolver,
+    FulfillmentDetail
 } from "../lib/ConsiderationStructs.sol";
 
 /**
@@ -198,49 +200,74 @@ interface ConsiderationInterface {
      * @notice Attempt to fill a group of orders, fully or partially, with an
      *         arbitrary number of items for offer and consideration per order
      *         alongside criteria resolvers containing specific token
-     *         identifiers and associated proofs. Any order that has already
-     *         been fully filled or cancelled, or where an offer item cannot be
-     *         successfully transferred to the fulfiller, will be skipped. If an
-     *         order is skipped, all state changes for that order (including any
-     *         previously transferred offer items for that order) will be rolled
-     *         back and any unapplied criteria resolvers referencing that order
-     *         will be ignored. The fulfiller must then transfer each
-     *         consideration item on the remaining orders to the intended
-     *         recipient — note that a failing transfer of a consideration item
-     *         from the fulfiller will cause the entire transaction to revert.
+     *         identifiers and associated proofs. Any order that is not
+     *         currently active, has already been fully filled, or has been
+     *         cancelled will be omitted. Remaining offer and consideration
+     *         items will then be aggregated where possible as indicated by the
+     *         supplied offer and consideration component arrays and aggregated
+     *         items will be transferred to the fulfiller or to each intended
+     *         recipient, respectively. Note that a failing item transfer or an
+     *         issue with order formatting will cause the entire batch to fail.
      *
-     * @param advancedOrders    The orders to fulfill along with the fraction of
-     *                          those orders to attempt to fill. Note that both
-     *                          the offerer and the fulfiller must first approve
-     *                          this contract (or their proxy if indicated by
-     *                          the order) to transfer any relevant tokens on
-     *                          their behalf and that contracts must implement
-     *                          `onERC1155Received` in order to receive ERC1155
-     *                          tokens as consideration. Also note that all
-     *                          offer and consideration components must have no
-     *                          remainder after multiplication of the respective
-     *                          amount with the supplied fraction for an order's
-     *                          partial fill amount to be considered valid.
-     * @param criteriaResolvers An array where each element contains a reference
-     *                          to a specific offer or consideration, a token
-     *                          identifier, and a proof that the supplied token
-     *                          identifier is contained in the merkle root held
-     *                          by the item in question's criteria element. Note
-     *                          that an empty criteria indicates that any
-     *                          (transferrable) token identifier on the token in
-     *                          question is valid and that no associated proof
-     *                          needs to be supplied.
-     * @param useFulfillerProxy A flag indicating whether to source approvals
-     *                          for fulfilled tokens from an associated proxy.
+     * @param advancedOrders            The orders to fulfill along with the
+     *                                  fraction of those orders to attempt to
+     *                                  fill. Note that both the offerer and the
+     *                                  fulfiller must first approve this
+     *                                  contract (or their proxy if indicated by
+     *                                  the order) to transfer any relevant
+     *                                  tokens on their behalf and that
+     *                                  contracts must implement
+     *                                  `onERC1155Received` in order to receive
+     *                                  ERC1155 tokens as consideration. Also
+     *                                  note that all offer and consideration
+     *                                  components must have no remainder after
+     *                                  multiplication of the respective amount
+     *                                  with the supplied fraction for an
+     *                                  order's partial fill amount to be
+     *                                  considered valid.
+     * @param criteriaResolvers         An array where each element contains a
+     *                                  reference to a specific offer or
+     *                                  consideration, a token identifier, and a
+     *                                  proof that the supplied token identifier
+     *                                  is contained in the merkle root held by
+     *                                  the item in question's criteria element.
+     *                                  Note that an empty criteria indicates
+     *                                  that any (transferrable) token
+     *                                  identifier on the token in question is
+     *                                  valid and that no associated proof needs
+     *                                  to be supplied.
+     * @param offerFulfillments         An array of FulfillmentComponent arrays
+     *                                  indicating which offer items to attempt
+     *                                  to aggregate when preparing executions.
+     * @param considerationFulfillments An array of FulfillmentComponent arrays
+     *                                  indicating which consideration items to
+     *                                  attempt to aggregate when preparing
+     *                                  executions.
+     * @param useFulfillerProxy         A flag indicating whether to source
+     *                                  approvals for fulfilled tokens from an
+     *                                  associated proxy.
      *
-     * @return statuses An array of booleans indicating whether each order has
-     *                  been fulfilled.
+     * @return fulfillmentDetails A array of FulfillmentDetail structs, each
+     *                            indicating whether the associated order has
+     *                            been fulfilled and whether a proxy was used.
+     * @return standardExecutions An array of elements indicating the sequence
+     *                            of non-batch transfers performed as part of
+     *                            matching the given orders.
+     * @return batchExecutions    An array of elements indicating the sequence
+     *                            of batch transfers performed as part of
+     *                            matching the given orders.
      */
     function fulfillAvailableAdvancedOrders(
-        AdvancedOrder[] memory advancedOrders,
-        CriteriaResolver[] memory criteriaResolvers,
+        AdvancedOrder[] calldata advancedOrders,
+        CriteriaResolver[] calldata criteriaResolvers,
+        FulfillmentComponent[][] calldata offerFulfillments,
+        FulfillmentComponent[][] calldata considerationFulfillments,
         bool useFulfillerProxy
-    ) external payable returns (bool[] memory statuses);
+    ) external payable returns (
+        FulfillmentDetail[] memory fulfillmentDetails,
+        Execution[] memory standardExecutions,
+        BatchExecution[] memory batchExecutions
+    );
 
     /**
      * @notice Match an arbitrary number of orders, each with an arbitrary

--- a/contracts/lib/ConsiderationBase.sol
+++ b/contracts/lib/ConsiderationBase.sol
@@ -120,7 +120,7 @@ contract ConsiderationBase is ConsiderationEventsAndErrors {
             )
         );
         _CHAIN_ID = block.chainid;
-        _DOMAIN_SEPARATOR = _deriveDomainSeparator();
+        _DOMAIN_SEPARATOR = _deriveInitialDomainSeparator();
 
         // TODO: validate each of these based on expected codehash
         _LEGACY_PROXY_REGISTRY = ProxyRegistryInterface(legacyProxyRegistry);
@@ -131,11 +131,23 @@ contract ConsiderationBase is ConsiderationEventsAndErrors {
     }
 
     /**
+     * @dev Internal view function to derive the initial EIP-712 domain
+     *      separator.
+     *
+     * @return The derived domain separator.
+     */
+    function _deriveInitialDomainSeparator() internal view virtual returns (
+        bytes32
+    ) {
+        return _deriveDomainSeparator();
+    }
+
+    /**
      * @dev Internal view function to derive the EIP-712 domain separator.
      *
      * @return The derived domain separator.
      */
-    function _deriveDomainSeparator() internal view returns (bytes32) {
+    function _deriveDomainSeparator() internal view virtual returns (bytes32) {
         return keccak256(
             abi.encode(
                 _EIP_712_DOMAIN_TYPEHASH,

--- a/contracts/lib/ConsiderationDelegated.sol
+++ b/contracts/lib/ConsiderationDelegated.sol
@@ -2,12 +2,20 @@
 pragma solidity 0.8.12;
 
 import {
-	ConsiderationDelegatedInterface
+    ConsiderationInterface
+} from "../interfaces/ConsiderationInterface.sol";
+
+import {
+    ConsiderationDelegatedInterface
 } from "../interfaces/ConsiderationDelegatedInterface.sol";
 
 import {
     AdvancedOrder,
-    CriteriaResolver
+    CriteriaResolver,
+    FulfillmentComponent,
+    FulfillmentDetail,
+    Execution,
+    BatchExecution
 } from "./ConsiderationStructs.sol";
 
 import { ConsiderationInternal } from "./ConsiderationInternal.sol";
@@ -20,8 +28,8 @@ import { ConsiderationInternal } from "./ConsiderationInternal.sol";
  *         restraints introduced by EIP-170.
  */
 contract ConsiderationDelegated is
-	ConsiderationDelegatedInterface,
-	ConsiderationInternal {
+    ConsiderationDelegatedInterface,
+    ConsiderationInternal {
     // Only delegator may call this contract (stricter than using a library).
     address internal immutable _DELEGATOR;
 
@@ -39,62 +47,138 @@ contract ConsiderationDelegated is
      *         or partially, with an arbitrary number of items for offer and
      *         consideration per order alongside criteria resolvers containing
      *         specific token identifiers and associated proofs. Any order that
-     *         has already been fully filled or cancelled, or where an offer
-     *         item cannot be successfully transferred to the fulfiller, will be
-     *         skipped. If an order is skipped, all state changes for that order
-     *         (including any previously transferred offer items for that order)
-     *         will be rolled back and any unapplied criteria resolvers
-     *         referencing that order will be ignored. The fulfiller must then
-     *         transfer each consideration item on the remaining orders to the
-     *         intended recipient — note that a failing transfer of a
-     *         consideration item from the fulfiller will cause the entire
-     *         transaction to revert.
+     *         is not currently active, has already been fully filled, or has
+     *         been cancelled will be omitted. Remaining offer and consideration
+     *         items will then be aggregated where possible as indicated by the
+     *         supplied offer and consideration component arrays and aggregated
+     *         items will be transferred to the fulfiller or to each intended
+     *         recipient, respectively. Note that a failing item transfer or an
+     *         issue with order formatting will cause the entire batch to fail.
      *
-     * @param advancedOrders    The orders to fulfill along with the fraction of
-     *                          those orders to attempt to fill. Note that both
-     *                          the offerer and the fulfiller must first approve
-     *                          this contract (or their proxy if indicated by
-     *                          the order) to transfer any relevant tokens on
-     *                          their behalf and that contracts must implement
-     *                          `onERC1155Received` in order to receive ERC1155
-     *                          tokens as consideration. Also note that all
-     *                          offer and consideration components must have no
-     *                          remainder after multiplication of the respective
-     *                          amount with the supplied fraction for an order's
-     *                          partial fill amount to be considered valid.
-     * @param criteriaResolvers An array where each element contains a reference
-     *                          to a specific offer or consideration, a token
-     *                          identifier, and a proof that the supplied token
-     *                          identifier is contained in the merkle root held
-     *                          by the item in question's criteria element. Note
-     *                          that an empty criteria indicates that any
-     *                          (transferrable) token identifier on the token in
-     *                          question is valid and that no associated proof
-     *                          needs to be supplied.
-     * @param useFulfillerProxy A flag indicating whether to source approvals
-     *                          for fulfilled tokens from an associated proxy.
+     * @param advancedOrders            The orders to fulfill along with the
+     *                                  fraction of those orders to attempt to
+     *                                  fill. Note that both the offerer and the
+     *                                  fulfiller must first approve this
+     *                                  contract (or their proxy if indicated by
+     *                                  the order) to transfer any relevant
+     *                                  tokens on their behalf and that
+     *                                  contracts must implement
+     *                                  `onERC1155Received` in order to receive
+     *                                  ERC1155 tokens as consideration. Also
+     *                                  note that all offer and consideration
+     *                                  components must have no remainder after
+     *                                  multiplication of the respective amount
+     *                                  with the supplied fraction for an
+     *                                  order's partial fill amount to be
+     *                                  considered valid.
+     * @param criteriaResolvers         An array where each element contains a
+     *                                  reference to a specific offer or
+     *                                  consideration, a token identifier, and a
+     *                                  proof that the supplied token identifier
+     *                                  is contained in the merkle root held by
+     *                                  the item in question's criteria element.
+     *                                  Note that an empty criteria indicates
+     *                                  that any (transferrable) token
+     *                                  identifier on the token in question is
+     *                                  valid and that no associated proof needs
+     *                                  to be supplied.
+     * @param offerFulfillments         An array of FulfillmentComponent arrays
+     *                                  indicating which offer items to attempt
+     *                                  to aggregate when preparing executions.
+     * @param considerationFulfillments An array of FulfillmentComponent arrays
+     *                                  indicating which consideration items to
+     *                                  attempt to aggregate when preparing
+     *                                  executions.
+     * @param useFulfillerProxy         A flag indicating whether to source
+     *                                  approvals for fulfilled tokens from an
+     *                                  associated proxy.
      *
-     * @return statuses An array of booleans indicating whether each order has
-     *                  been fulfilled.
+     * @return fulfillmentDetails A array of FulfillmentDetail structs, each
+     *                            indicating whether the associated order has
+     *                            been fulfilled and whether a proxy was used.
+     * @return standardExecutions An array of elements indicating the sequence
+     *                            of non-batch transfers performed as part of
+     *                            matching the given orders.
+     * @return batchExecutions    An array of elements indicating the sequence
+     *                            of batch transfers performed as part of
+     *                            matching the given orders.
      */
-	function fulfillAvailableAdvancedOrders(
+    function fulfillAvailableAdvancedOrders(
         AdvancedOrder[] memory advancedOrders,
         CriteriaResolver[] memory criteriaResolvers,
+        FulfillmentComponent[][] memory offerFulfillments,
+        FulfillmentComponent[][] memory considerationFulfillments,
         bool useFulfillerProxy
-    ) external payable override returns (bool[] memory statuses) {
-    	// Ensure that only delegatecalls from Consideration are allowed.
-		if (address(this) != _DELEGATOR) {
-			revert OnlyDelegatecallFromConsideration();
-		}
+    ) external payable override returns (
+        FulfillmentDetail[] memory fulfillmentDetails,
+        Execution[] memory standardExecutions,
+        BatchExecution[] memory batchExecutions
+    ) {
+        // Ensure that only delegatecalls from Consideration are allowed.
+        if (address(this) != _DELEGATOR) {
+            revert OnlyDelegatecallFromConsideration();
+        }
 
-		// Allocate array of booleans for tracking statuses for each order.
-    	statuses = new bool[](advancedOrders.length);
+        // Validate orders, apply amounts, & determine if they utilize proxies.
+        fulfillmentDetails = _validateOrdersAndPrepareToFulfill(
+            advancedOrders,
+            criteriaResolvers,
+            false // Signifies that invalid orders should NOT revert.
+        );
 
-    	// Declare unused variables — this function is not yet implemented.
-    	criteriaResolvers;
-    	useFulfillerProxy;
+        // Apply criteria resolvers to orders regardless of fulfillment details.
+        _applyCriteriaResolvers(advancedOrders, criteriaResolvers);
 
-    	// Return order fulfillment statuses.
-    	return statuses;
+        // Aggregate used offer and consideration items and execute transfers.
+        (standardExecutions, batchExecutions) = _fulfillAvailableOrders(
+            advancedOrders,
+            offerFulfillments,
+            considerationFulfillments,
+            fulfillmentDetails,
+            useFulfillerProxy
+        );
+
+        // Return order fulfillment details and executions.
+        return (fulfillmentDetails, standardExecutions, batchExecutions);
+    }
+
+    /**
+     * @dev Override the view function to get the EIP-712 domain separator so
+     *      that it uses the address of the original Consideration contract as
+     *      the verifying address.
+     *
+     * @return The domain separator on the Consideration contract.
+     */
+    function _deriveInitialDomainSeparator() internal view override returns (
+        bytes32
+    ) {
+        return keccak256(
+            abi.encode(
+                _EIP_712_DOMAIN_TYPEHASH,
+                _NAME_HASH,
+                _VERSION_HASH,
+                block.chainid,
+                msg.sender
+            )
+        );
+    }
+
+    /**
+     * @dev Override the view function to get the EIP-712 domain separator so
+     *      that it uses the address of the original Consideration contract as
+     *      the verifying address.
+     *
+     * @return The domain separator on the Consideration contract.
+     */
+    function _deriveDomainSeparator() internal view override returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                _EIP_712_DOMAIN_TYPEHASH,
+                _NAME_HASH,
+                _VERSION_HASH,
+                block.chainid,
+                _DELEGATOR
+            )
+        );
     }
 }

--- a/contracts/lib/ConsiderationStructs.sol
+++ b/contracts/lib/ConsiderationStructs.sol
@@ -246,3 +246,14 @@ struct Batch {
     bytes32 hash;
     uint256[] executionIndices;
 }
+
+/**
+ * @dev An fulfillment detail will be returned for each supplied order when
+ *      attempting to fulfill any available orders from a given group, and
+ *      indicates whether the order in question was fulfilled as well as whether
+ *      a proxy was utilized when fulfilling the order.
+ */
+struct FulfillmentDetail {
+    bool fulfillOrder;
+    bool useOffererProxy;
+}

--- a/contracts/test/DelegatedDomainSeparatorTester.sol
+++ b/contracts/test/DelegatedDomainSeparatorTester.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.12;
+
+import { ConsiderationDelegated } from "../lib/ConsiderationDelegated.sol";
+
+contract DelegatedDomainSeparatorTester is ConsiderationDelegated {
+    address _DEPLOYER;
+
+    constructor(
+        address legacyProxyRegistry,
+        address requiredProxyImplementation
+    ) ConsiderationDelegated(
+        legacyProxyRegistry,
+        requiredProxyImplementation
+    ) {
+        _DEPLOYER = msg.sender;
+    }
+
+    function deriveDomainSeparatorAndCompare() external view {
+        bytes32 derived = _deriveDomainSeparator();
+        bytes32 expected = keccak256(
+            abi.encode(
+                _EIP_712_DOMAIN_TYPEHASH,
+                _NAME_HASH,
+                _VERSION_HASH,
+                block.chainid,
+                _DEPLOYER
+            )
+        );
+
+        if (derived != expected) {
+            revert("Incorrectly derived domain separator.");
+        }
+    }
+}


### PR DESCRIPTION
This draft PR sets up the initial scaffolding and interface for a `fulfillAvailableOrders` function, implemented on an independent "delegated" contract (required to work around the contract size limit). This is part of the "Feature Wishlist" and would enable bulk purchasing with tolerance for individual order fulfillment failures without failing the entire batch while still supporting fulfillment aggregation (as is currently the case with `matchOrders`). It also provides a framework for further additions to the core Consideration contracts where required, though we should consider doing away with the delegated contract if possible once more optimizations have been applied as it does increase overhead for executing the delegated logic.