### PR TITLE
simplify fulfillBasicOrder - reference

### DIFF
--- a/contracts/Consideration.sol
+++ b/contracts/Consideration.sol
@@ -132,14 +132,13 @@ contract Consideration is ConsiderationInterface, ConsiderationInternal {
         }
 
         // Declare more arguments that will be derived from route and calldata.
-        address additionalRecipientsToken;
         ItemType receivedItemType;
         ItemType offeredItemType;
         uint8 routeAsInt = uint8(route);
 
         // If route > 3 additionalRecipientsToken is offerToken
         // else considerationToken
-        additionalRecipientsToken = (routeAsInt > 3)
+        address additionalRecipientsToken = (routeAsInt > 3)
             ? parameters.offerToken
             : parameters.considerationToken;
 
@@ -175,10 +174,8 @@ contract Consideration is ConsiderationInterface, ConsiderationInternal {
         address payable offerer = parameters.offerer;
 
         // Declare conduit argument used by transfer functions.
-        address conduit;
-
         // use offerer conduit for routes 0-3, fulfiller conduit otherwise.
-        conduit = (routeAsInt > 3)
+        address conduit = (routeAsInt > 3)
             ? parameters.fulfillerConduit
             : parameters.offererConduit;
 


### PR DESCRIPTION
## Change Overview
Modified `fulfillBasicOrder` assembly to a simplified solidity version.  Maintaining exact functionality on original codebase.

## Testing Approach and Results
Rerun through the hardhat tests that are already implemented, to get passing status, DOES NOT verify outputs are exactly the same at this time.  This will need to be done in a future push.
