### PR TITLE
Simplified assembly in the rest of ConsiderationInternal

### DIFF
--- a/contracts/lib/ConsiderationInternal.sol
+++ b/contracts/lib/ConsiderationInternal.sol
@@ -1898,7 +1898,7 @@ contract ConsiderationInternal is ConsiderationInternalView {
         (bool success, bytes memory result) = token.call(
             abi.encodeCall(ERC20Interface.transferFrom, (from, to, amount))
         );
-        
+
         // Ensure that the transfer succeeded.
         _assertValidTokenTransfer(success, token, from, to, 0, amount);
 


### PR DESCRIPTION
## Change Overview
Modified `_applyFractionsAndTransferEach`, `_validateOrdersAndPrepareToFulfill`,  `_transferEth`, `_performDirectERC20Transfer`, `_transferERC721`, and `_transferERC1155` assembly to a simplified solidity version.  Maintaining exact functionality on original codebase.

Re-added helper function `_callDirectlyOrViaProxy`.

## Testing Approach and Results
Rerun through the hardhat tests that are already implemented, to get passing status, DOES NOT verify outputs are exactly the same at this time.  This will need to be done in a future push.
