### PR TITLE
Switch to importing ConsiderationInterface in Forge tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -28,6 +28,7 @@ out = 'optimized-out'
 [test]
 solc = '0.8.13'
 via_ir = false
+src = 'test/foundry'
 
 [lite]
 out = 'optimized-out'

--- a/test/foundry/FulfillAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAdvancedOrder.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";
-import { Consideration } from "../../contracts/Consideration.sol";
+import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
 import { AdvancedOrder, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters, CriteriaResolver } from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
@@ -30,7 +30,7 @@ contract FulfillAdvancedOrder is BaseOrderTest {
     }
 
     struct Context {
-        Consideration consideration;
+        ConsiderationInterface consideration;
         FuzzInputs args;
     }
 

--- a/test/foundry/FulfillAvailableAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAvailableAdvancedOrder.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";
-import { Consideration } from "../../contracts/Consideration.sol";
+import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
 import { AdvancedOrder, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters, FulfillmentComponent, CriteriaResolver } from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
@@ -24,7 +24,7 @@ contract FulfillAvailableAdvancedOrder is BaseOrderTest {
     }
 
     struct Context {
-        Consideration consideration;
+        ConsiderationInterface consideration;
         FuzzInputs args;
     }
 

--- a/test/foundry/FulfillBasicOrderTest.sol
+++ b/test/foundry/FulfillBasicOrderTest.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";
-import { Consideration } from "../../contracts/Consideration.sol";
+import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
 import { OfferItem, ConsiderationItem, OrderComponents, BasicOrderParameters } from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 
@@ -27,7 +27,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         uint256 salt;
     }
     struct Context {
-        Consideration consideration;
+        ConsiderationInterface consideration;
         FuzzInputsCommon args;
         uint128 tokenAmount;
     }

--- a/test/foundry/FulfillOrderTest.sol
+++ b/test/foundry/FulfillOrderTest.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";
-import { Consideration } from "../../contracts/Consideration.sol";
+import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
 import { Order, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters } from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
@@ -24,7 +24,7 @@ contract FulfillOrderTest is BaseOrderTest {
     }
 
     struct Context {
-        Consideration consideration;
+        ConsiderationInterface consideration;
         FuzzInputsCommon args;
         uint256 erc1155amt;
         uint128 tipAmt;

--- a/test/foundry/FullfillAvailableOrder.t.sol
+++ b/test/foundry/FullfillAvailableOrder.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";
-import { Consideration } from "../../contracts/Consideration.sol";
+import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
 import { Order, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
@@ -24,7 +24,7 @@ contract FulfillAvailableOrder is BaseOrderTest {
     }
 
     struct Context {
-        Consideration consideration;
+        ConsiderationInterface consideration;
         FuzzInputs args;
     }
 

--- a/test/foundry/MatchAdvancedOrder.t.sol
+++ b/test/foundry/MatchAdvancedOrder.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { Order, Fulfillment } from "../../contracts/lib/ConsiderationStructs.sol";
-import { Consideration } from "../../contracts/Consideration.sol";
+import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
 import { AdvancedOrder, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters, CriteriaResolver, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
@@ -24,7 +24,7 @@ contract MatchAdvancedOrder is BaseOrderTest {
     }
 
     struct Context {
-        Consideration consideration;
+        ConsiderationInterface consideration;
         FuzzInputs args;
     }
 

--- a/test/foundry/MatchOrders.t.sol
+++ b/test/foundry/MatchOrders.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { Order, Fulfillment } from "../../contracts/lib/ConsiderationStructs.sol";
-import { Consideration } from "../../contracts/Consideration.sol";
+import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
 import { AdvancedOrder, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters, CriteriaResolver, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
@@ -24,7 +24,7 @@ contract MatchOrders is BaseOrderTest {
     }
 
     struct Context {
-        Consideration consideration;
+        ConsiderationInterface consideration;
         FuzzInputsCommon args;
     }
 

--- a/test/foundry/NonReentrant.t.sol
+++ b/test/foundry/NonReentrant.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";
-import { Consideration } from "../../contracts/Consideration.sol";
+import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
 import { AdditionalRecipient, Fulfillment, OfferItem, ConsiderationItem, FulfillmentComponent, OrderComponents, AdvancedOrder, BasicOrderParameters, Order } from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { EntryPoint, ReentryPoint } from "./utils/reentrancy/ReentrantEnums.sol";
@@ -18,7 +18,7 @@ contract NonReentrantTest is BaseOrderTest {
     Order order;
     Order[] orders;
     ReentryPoint reentryPoint;
-    Consideration currentConsideration;
+    ConsiderationInterface currentConsideration;
 
     /**
      * @dev Foundry fuzzes enums as uints, so we need to manually fuzz on uints and use vm.assume
@@ -38,7 +38,7 @@ contract NonReentrantTest is BaseOrderTest {
     }
 
     struct Context {
-        Consideration consideration;
+        ConsiderationInterface consideration;
         NonReentrantInputs args;
     }
 

--- a/test/foundry/utils/BaseConsiderationTest.sol
+++ b/test/foundry/utils/BaseConsiderationTest.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.13;
 
 import { ConduitController } from "../../../contracts/conduit/ConduitController.sol";
-import { Consideration } from "../../../contracts/Consideration.sol";
+import { ConsiderationInterface } from "../../../contracts/interfaces/ConsiderationInterface.sol";
 import { OrderType, BasicOrderType, ItemType, Side } from "../../../contracts/lib/ConsiderationEnums.sol";
 import { OfferItem, ConsiderationItem, OrderComponents, BasicOrderParameters } from "../../../contracts/lib/ConsiderationStructs.sol";
 import { Test } from "forge-std/Test.sol";
@@ -15,8 +15,8 @@ import { Conduit } from "../../../contracts/conduit/Conduit.sol";
 contract BaseConsiderationTest is Test {
     using stdStorage for StdStorage;
 
-    Consideration consideration;
-    Consideration referenceConsideration;
+    ConsiderationInterface consideration;
+    ConsiderationInterface referenceConsideration;
     bytes32 conduitKeyOne;
     ConduitController conduitController;
     ConduitController referenceConduitController;
@@ -59,7 +59,7 @@ contract BaseConsiderationTest is Test {
         referenceConduitController = ConduitController(
             address(new ReferenceConduitController())
         );
-        referenceConsideration = Consideration(
+        referenceConsideration = ConsiderationInterface(
             address(
                 new ReferenceConsideration(address(referenceConduitController))
             )
@@ -77,19 +77,6 @@ contract BaseConsiderationTest is Test {
         );
     }
 
-    function _deployAndConfigureConsideration() public {
-        conduitController = new ConduitController();
-        consideration = new Consideration(address(conduitController));
-        conduit = Conduit(
-            conduitController.createConduit(conduitKeyOne, address(this))
-        );
-        conduitController.updateChannel(
-            address(conduit),
-            address(consideration),
-            true
-        );
-    }
-
     ///@dev deploy optimized consideration contracts from pre-compiled source (solc-0.8.13, IR pipeline enabled)
     function _deployAndConfigurePrecompiledOptimizedConsideration() public {
         conduitController = ConduitController(
@@ -97,7 +84,7 @@ contract BaseConsiderationTest is Test {
                 "optimized-out/ConduitController.sol/ConduitController.json"
             )
         );
-        consideration = Consideration(
+        consideration = ConsiderationInterface(
             deployCode(
                 "optimized-out/Consideration.sol/Consideration.json",
                 abi.encode(address(conduitController))
@@ -122,7 +109,7 @@ contract BaseConsiderationTest is Test {
                 "reference-out/ReferenceConduitController.sol/ReferenceConduitController.json"
             )
         );
-        referenceConsideration = Consideration(
+        referenceConsideration = ConsiderationInterface(
             deployCode(
                 "reference-out/ReferenceConsideration.sol/ReferenceConsideration.json",
                 abi.encode(address(referenceConduitController))
@@ -180,7 +167,7 @@ contract BaseConsiderationTest is Test {
     }
 
     function signOrder(
-        Consideration _consideration,
+        ConsiderationInterface _consideration,
         uint256 _pkOfSigner,
         bytes32 _orderHash
     ) internal returns (bytes memory) {


### PR DESCRIPTION
Avoid any compilation discrepancies between via_ir=true and via_ir=false