### PR TITLE
✖️CI: Update `checkout` and `setup-node` versions & concurrency handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,6 @@
 name: Consideration Test CI
 
-on:
-  push:
-    branches: [ $default-branch ]
-  pull_request:
-    branches: 
-      - "**"
+on: [push, pull_request]
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches: [ $default-branch ]
   pull_request:
     branches: 
-    - "**"
+      - "**"
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Consideration Test CI
 
-on: [push]
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: 
+    - "**"
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Consideration Test CI
 
 on: [push]
 
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build Artifacts
@@ -12,9 +16,9 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
@@ -29,9 +33,9 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
@@ -46,9 +50,9 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
@@ -66,9 +70,9 @@ jobs:
       REFERENCE: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
@@ -78,7 +82,7 @@ jobs:
     name: Run "Lite" Forge Tests (via_ir = false; fuzz_runs = 1000)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -100,7 +104,7 @@ jobs:
     name: Run Forge Tests (via_ir = true; fuzz_runs = 5000)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -130,9 +134,9 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
@@ -154,9 +158,9 @@ jobs:
       REFERENCE: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install


### PR DESCRIPTION
This PR updates the `actions/checkout` & `actions/setup-node` to the latest version `v3` as well as includes concurrency handling for the GitHub CI. Eventually, should also fix https://github.com/ProjectOpenSea/seaport/pull/278#issuecomment-1133359532 regarding external PRs.