### PR TITLE
Add support for vyper to hardhat

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,6 +1,7 @@
 import * as dotenv from "dotenv";
 
 import { HardhatUserConfig, subtask } from "hardhat/config";
+import "@nomiclabs/hardhat-vyper";
 import "@nomiclabs/hardhat-waffle";
 import "@typechain/hardhat";
 import "hardhat-gas-reporter";

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.4",
+    "@nomiclabs/hardhat-vyper": "^3.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@rari-capital/solmate": "^6.2.0",
     "@typechain/ethers-v5": "^10.0.0",


### PR DESCRIPTION
Added support for vyper to hardhat with the goal of running the tests in `test/index.js` with vyper contracts.