### PR TITLE
chore: remove unused config parameter

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -13,7 +13,6 @@ remappings = [
 ]
 fuzz_runs = 5000
 fuzz_max_global_rejects = 2_000_000
-fuzz_max_local_rejects = 10_000
 optimizer_runs = 15000
 
 [reference]


### PR DESCRIPTION
## Motivation

`fuzz_max_local_rejects` is actually not used by Foundry and has no effect. More info: https://github.com/foundry-rs/foundry/issues/1202

## Solution

Delete the config parameter.