### PR TITLE
Update CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@ Contributor                    | ENS
 0age                           | `0age.eth`
 d1ll0n                         | `d1ll0n.eth`
 transmissions11                | `t11s.eth`
+ori_dabush                     |

--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -95,11 +95,14 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
                 considerationComponents[0]
             );
 
-            // Add excess consideration item amount to original array of orders.
-            advancedOrders[targetComponent.orderIndex]
-                .parameters
-                .consideration[targetComponent.itemIndex]
-                .startAmount = considerationItem.amount - execution.item.amount;
+            // Skip underflow check as considerationItem.amount > execution.item.amount.
+            unchecked {
+                // Add excess consideration item amount to original array of orders.
+                advancedOrders[targetComponent.orderIndex]
+                    .parameters
+                    .consideration[targetComponent.itemIndex]
+                    .startAmount = considerationItem.amount - execution.item.amount;
+            }
 
             // Reduce total consideration amount to equal the offer amount.
             considerationItem.amount = execution.item.amount;
@@ -107,11 +110,14 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
             // Retrieve the first offer component from the fulfillment.
             FulfillmentComponent memory targetComponent = (offerComponents[0]);
 
-            // Add excess offer item amount to the original array of orders.
-            advancedOrders[targetComponent.orderIndex]
-                .parameters
-                .offer[targetComponent.itemIndex]
-                .startAmount = execution.item.amount - considerationItem.amount;
+            // Skip underflow check as considerationItem.amount <= execution.item.amount.
+            unchecked {
+                // Add excess offer item amount to the original array of orders.
+                advancedOrders[targetComponent.orderIndex]
+                    .parameters
+                    .offer[targetComponent.itemIndex]
+                    .startAmount = execution.item.amount - considerationItem.amount;
+            }
         }
 
         // Reuse execution struct with consideration amount and recipient.

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -232,8 +232,11 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 // Otherwise, track the order hash in question.
                 orderHashes[i] = orderHash;
 
-                // Decrement the number of fulfilled orders.
-                maximumFulfilled--;
+                // Skip underflow check as maximumFulfilled > 0.
+                unchecked {
+                    // Decrement the number of fulfilled orders.
+                    maximumFulfilled--;
+                }
 
                 // Place the start time for the order on the stack.
                 uint256 startTime = advancedOrder.parameters.startTime;


### PR DESCRIPTION
## Motivation
Unchecked can be used in some places where we know for sure that the calculations won't overflow or underflow, and there are some places where it can be used to save the gas spent on these checks.

## Solution
Added unchecked where the calculations can't overflow or underflow.