### PR TITLE
Fix additional recipients off by one error in ReferenceBasicOrderFulfiller

### DIFF
--- a/reference/lib/ReferenceBasicOrderFulfiller.sol
+++ b/reference/lib/ReferenceBasicOrderFulfiller.sol
@@ -563,7 +563,7 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
 
         // Ensure supplied consideration array length is not less than original.
         _assertConsiderationLengthIsNotLessThanOriginalConsiderationLength(
-            parameters.additionalRecipients.length + 1,
+            parameters.additionalRecipients.length,
             parameters.totalOriginalAdditionalRecipients
         );
 

--- a/test/findings/AdditionalRecipientsOffByOne.spec.ts
+++ b/test/findings/AdditionalRecipientsOffByOne.spec.ts
@@ -37,9 +37,6 @@ describe("Additional recipients off by one error allows skipping second consider
   });
 
   before(async function () {
-    if (process.env.REFERENCE) {
-      this.skip();
-    }
     alice = await getWalletWithEther();
     bob = await getWalletWithEther();
     carol = await getWalletWithEther();


### PR DESCRIPTION
I neglected to add this change to the reference contract in #317. Also enabled the test for reference contracts.