### PR TITLE
Enforce style prefix increment and postfix increment

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@ Contributor                    | ENS
 d1ll0n                         | `d1ll0n.eth`
 transmissions11                | `t11s.eth`
 Kartik                         | `slokh.eth`
+0x4non                         | `punkdev.eth`

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -233,7 +233,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 orderHashes[i] = orderHash;
 
                 // Decrement the number of fulfilled orders.
-                maximumFulfilled--;
+                --maximumFulfilled;
 
                 // Place the start time for the order on the stack.
                 uint256 startTime = advancedOrder.parameters.startTime;
@@ -489,7 +489,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 // If offerer and recipient on the execution are the same...
                 if (execution.item.recipient == execution.offerer) {
                     // increment total filtered executions.
-                    totalFilteredExecutions += 1;
+                    ++totalFilteredExecutions;
                 } else {
                     // Otherwise, assign the execution to the executions array.
                     executions[i - totalFilteredExecutions] = execution;
@@ -515,7 +515,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 // If offerer and recipient on the execution are the same...
                 if (execution.item.recipient == execution.offerer) {
                     // increment total filtered executions.
-                    totalFilteredExecutions += 1;
+                    ++totalFilteredExecutions ;
                 } else {
                     // Otherwise, assign the execution to the executions array.
                     executions[
@@ -769,7 +769,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 // If offerer and recipient on the execution are the same...
                 if (execution.item.recipient == execution.offerer) {
                     // increment total filtered executions.
-                    totalFilteredExecutions += 1;
+                    ++totalFilteredExecutions;
                 } else {
                     // Otherwise, assign the execution to the executions array.
                     executions[i - totalFilteredExecutions] = execution;

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -515,7 +515,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 // If offerer and recipient on the execution are the same...
                 if (execution.item.recipient == execution.offerer) {
                     // increment total filtered executions.
-                    ++totalFilteredExecutions ;
+                    ++totalFilteredExecutions;
                 } else {
                     // Otherwise, assign the execution to the executions array.
                     executions[

--- a/reference/lib/ReferenceOrderCombiner.sol
+++ b/reference/lib/ReferenceOrderCombiner.sol
@@ -239,7 +239,7 @@ contract ReferenceOrderCombiner is
             orderHashes[i] = orderHash;
 
             // Decrement the number of fulfilled orders.
-            maximumFulfilled--;
+            --maximumFulfilled;
 
             // Place the start time for the order on the stack.
             uint256 startTime = advancedOrder.parameters.startTime;
@@ -482,7 +482,7 @@ contract ReferenceOrderCombiner is
             // If offerer and recipient on the execution are the same...
             if (execution.item.recipient == execution.offerer) {
                 // increment total filtered executions.
-                totalFilteredExecutions += 1;
+                ++totalFilteredExecutions;
             } else {
                 // Otherwise, assign the execution to the executions array.
                 executions[i - totalFilteredExecutions] = execution;
@@ -508,7 +508,7 @@ contract ReferenceOrderCombiner is
             // If offerer and recipient on the execution are the same...
             if (execution.item.recipient == execution.offerer) {
                 // increment total filtered executions.
-                totalFilteredExecutions += 1;
+                ++totalFilteredExecutions;
             } else {
                 // Otherwise, assign the execution to the executions array.
                 executions[
@@ -765,7 +765,7 @@ contract ReferenceOrderCombiner is
             // If offerer and recipient on the execution are the same...
             if (execution.item.recipient == execution.offerer) {
                 // increment total filtered executions.
-                totalFilteredExecutions += 1;
+                ++totalFilteredExecutions;
             } else {
                 // Otherwise, assign the execution to the executions array.
                 executions[i - totalFilteredExecutions] = execution;


### PR DESCRIPTION
## Motivation


The difference between the prefix increment and postfix increment expression lies in the return value of the expression.

The prefix increment expression (`++i`) returns the updated value after it's incremented. The postfix increment expression (`i++`) returns the original value.

The prefix increment expression is cheaper in terms of gas.

Consider using the prefix increment expression whenever the return value is not needed.

Note to be careful using this optimization whenever the expression's return value is used afterwards, e.g. `uint a = i++` and `uint a = ++i` result in different values for `a`.
