### PR TITLE
Skip execution with amount 0 in _applyFulfillment in FulfillmentApplier

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@ Contributor                    | ENS
 d1ll0n                         | `d1ll0n.eth`
 transmissions11                | `t11s.eth`
 Kartik                         | `slokh.eth`
+Chomtana                       |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,4 +6,4 @@ Contributor                    | ENS
 d1ll0n                         | `d1ll0n.eth`
 transmissions11                | `t11s.eth`
 Kartik                         | `slokh.eth`
-Chomtana                       |
+Chomtana                       | `chomtana.eth`

--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -118,6 +118,13 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
         execution.item.amount = considerationItem.amount;
         execution.item.recipient = considerationItem.recipient;
 
+        // Set the offerer and receipient to null address if execution
+        // amount is zero. This will cause the execution item to be skipped.
+        if (execution.item.amount == 0) {
+            execution.offerer = address(0);
+            execution.item.recipient = payable(0);
+        }
+
         // Return the final execution that will be triggered for relevant items.
         return execution; // Execution(considerationItem, offerer, conduitKey);
     }


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

_applyFulfillment in FulfillmentApplier can set execution.item.recipient = payable(execution.offerer); if execution.item.amount == 0 to reduce gas on processing zero amount execution

I have submitted this as a Gas Optimization. But it may help solve a major issue

https://twitter.com/z0age/status/1532876361123045378

```
One more key finding relates to fulfillment aggregation — triggering two errors (aggregation amount overflow followed by aggregating a zero-amount item) bypasses both checks in a "two wrongs make a *very* wrong" situation. The fix involves a small modification to the error check.
```

It not only reduce gas but also cause the execution item that has zero amount to be skipped. As a result, it may solve aggregating a zero-amount item case which may cause following revert.

```
    /**
     * @dev Internal pure function to ensure that a given item amount is not
     *      zero.
     *
     * @param amount The amount to check.
     */
    function _assertNonZeroAmount(uint256 amount) internal pure {
        // Revert if the supplied amont is equal to zero.
        if (amount == 0) {
            revert MissingItemAmount();
        }
    }
```

Fixing this case may not require any modification to the error check but you need to ensure that amount = 0 never get passed to the Executor at first.

If this help fix a serious issue, it would be pleasure if you increase severity of this submission of mine (Chom#1652).

## Solution

We can add

```
        // Set the offerer and receipient to null address if execution
        // amount is zero. This will cause the execution item to be skipped.
        if (execution.item.amount == 0) {
            execution.offerer = address(0);
            execution.item.recipient = payable(0);
        }
```

Before returning into

```
      // Reuse execution struct with consideration amount and recipient.
      execution.item.amount = considerationItem.amount;
      execution.item.recipient = considerationItem.recipient;

      // Return the final execution that will be triggered for relevant items.
      return execution; // Execution(considerationItem, offerer, conduitKey);
```

which result in

```
      // Reuse execution struct with consideration amount and recipient.
      execution.item.amount = considerationItem.amount;
      execution.item.recipient = considerationItem.recipient;

        // Set the offerer and receipient to null address if execution
        // amount is zero. This will cause the execution item to be skipped.
        if (execution.item.amount == 0) {
            execution.offerer = address(0);
            execution.item.recipient = payable(0);
        }

      // Return the final execution that will be triggered for relevant items.
      return execution; // Execution(considerationItem, offerer, conduitKey);
```

To let execution with zero amount being skipped in _executeAvailableFulfillments function in OrderCombiner

https://github.com/code-423n4/2022-05-opensea-seaport/blob/4140473b1f85d0df602548ad260b1739ddd734a5/contracts/lib/OrderCombiner.sol#L479-L494

https://github.com/code-423n4/2022-05-opensea-seaport/blob/4140473b1f85d0df602548ad260b1739ddd734a5/contracts/lib/OrderCombiner.sol#L504-L521

```
              // Derive aggregated execution corresponding with fulfillment.
              Execution memory execution = _aggregateAvailable(
                  advancedOrders,
                  Side.OFFER,
                  components,
                  fulfillerConduitKey
              );

              // If offerer and recipient on the execution are the same...
              if (execution.item.recipient == execution.offerer) {
                  // increment total filtered executions.
                  totalFilteredExecutions += 1;
              } else {
                  // Otherwise, assign the execution to the executions array.
                  executions[i - totalFilteredExecutions] = execution;
              }
```

Which lead to following optimization path:
1. execution.item.amount == 0
2. execution.item.recipient == execution.offerer
3. totalFilteredExecutions += 1 (skipping) instead of inserting into executions list
4. Execution skipped
5. Save a lot of gas on any function that used to execute that execution
6. amount = 0 not being passed to Executor causing revert to be not triggered. Thus, fixing a serious aggregating a zero-amount item problem.
