### PR TITLE
Change nested scope to unchecked nested scope

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@ Contributor                    | ENS
 d1ll0n                         | `d1ll0n.eth`
 transmissions11                | `t11s.eth`
 Kartik                         | `slokh.eth`
+0x4non                         | `punkdev.eth`

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -283,7 +283,7 @@ contract OrderFulfiller is
          */
 
         // Declare a nested scope to minimize stack depth.
-        {
+        unchecked {
             // Declare virtual function pointer with ConsiderationItem argument.
             function(ConsiderationItem memory, address, bytes32, bytes memory)
                 internal _transferConsiderationItem;
@@ -301,7 +301,8 @@ contract OrderFulfiller is
             }
 
             // Iterate over each consideration item on the order.
-            for (uint256 i = 0; i < orderParameters.consideration.length; ) {
+            // Skip overflow check as for loop is indexed starting at zero.
+            for (uint256 i = 0; i < orderParameters.consideration.length; ++i) {
                 // Retrieve the consideration item.
                 ConsiderationItem memory considerationItem = (
                     orderParameters.consideration[i]
@@ -347,9 +348,7 @@ contract OrderFulfiller is
                     }
 
                     // Skip underflow check as a comparison has just been made.
-                    unchecked {
-                        etherRemaining -= amount;
-                    }
+                    etherRemaining -= amount;
                 }
 
                 // Transfer item from caller to recipient specified by the item.
@@ -360,10 +359,6 @@ contract OrderFulfiller is
                     accumulator
                 );
 
-                // Skip overflow check as for loop is indexed starting at zero.
-                unchecked {
-                    ++i;
-                }
             }
         }
 

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -263,7 +263,6 @@ contract OrderFulfiller is
                     orderParameters.conduitKey,
                     accumulator
                 );
-
             }
         }
 
@@ -358,7 +357,6 @@ contract OrderFulfiller is
                     fulfillerConduitKey,
                     accumulator
                 );
-
             }
         }
 

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -193,7 +193,7 @@ contract OrderFulfiller is
          */
 
         // Declare a nested scope to minimize stack depth.
-        {
+        unchecked {
             // Declare a virtual function pointer taking an OfferItem argument.
             function(OfferItem memory, address, bytes32, bytes memory)
                 internal _transferOfferItem;
@@ -212,7 +212,8 @@ contract OrderFulfiller is
             }
 
             // Iterate over each offer on the order.
-            for (uint256 i = 0; i < orderParameters.offer.length; ) {
+            // Skip overflow check as for loop is indexed starting at zero.
+            for (uint256 i = 0; i < orderParameters.offer.length; ++i) {
                 // Retrieve the offer item.
                 OfferItem memory offerItem = orderParameters.offer[i];
                 // Declare a nested scope to minimize stack depth.
@@ -251,9 +252,7 @@ contract OrderFulfiller is
                         }
 
                         // Skip underflow check as a comparison has just been made.
-                        unchecked {
-                            etherRemaining -= amount;
-                        }
+                        etherRemaining -= amount;
                     }
                 }
 
@@ -265,10 +264,6 @@ contract OrderFulfiller is
                     accumulator
                 );
 
-                // Skip overflow check as for loop is indexed starting at zero.
-                unchecked {
-                    ++i;
-                }
             }
         }
 

--- a/reference/lib/ReferenceFulfillmentApplier.sol
+++ b/reference/lib/ReferenceFulfillmentApplier.sol
@@ -52,7 +52,7 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
         OrderToExecute[] memory ordersToExecute,
         FulfillmentComponent[] calldata offerComponents,
         FulfillmentComponent[] calldata considerationComponents
-    ) internal view returns (Execution memory execution) {
+    ) internal pure returns (Execution memory execution) {
         // Ensure 1+ of both offer and consideration components are supplied.
         if (
             offerComponents.length == 0 || considerationComponents.length == 0


### PR DESCRIPTION
## Motivation

All the calculations inside of the block where safe, so the calculations where wrapped in an unchecked block. There for its safe to move the unchecked scope to the parent scope.
Example;
```solidity
{
  for (uint i = 0; i < length;) {
     unchecked { /* math */ }
     // code
     unchecked { ++i; }
   }
}
```

This could be;
```solidity
unchecked {
  for (uint i = 0; i < length; ++i) {
     /* math */
     // code
   }
}
```