### PR TITLE
Fix edge case assertion for FulfillAdvancedOrder fuzz tests

### DIFF
--- a/test/foundry/FulfillAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAdvancedOrder.t.sol
@@ -107,24 +107,24 @@ contract FulfillAdvancedOrder is BaseOrderTest {
     }
 
     function testAdvancedPartialAscendingOfferAmount1155(
-        FuzzInputs memory inputs,
+        FuzzInputs memory args,
         uint128 tokenAmount,
         uint256 warpAmount
-    ) public validateInputs(inputs) {
+    ) public validateInputs(args) {
         vm.assume(tokenAmount > 0);
 
         test(
             this.advancedPartialAscendingOfferAmount1155,
             Context(
                 referenceConsideration,
-                inputs,
+                args,
                 tokenAmount,
                 warpAmount % 1000
             )
         );
         test(
             this.advancedPartialAscendingOfferAmount1155,
-            Context(consideration, inputs, tokenAmount, warpAmount % 1000)
+            Context(consideration, args, tokenAmount, warpAmount % 1000)
         );
     }
 
@@ -374,11 +374,6 @@ contract FulfillAdvancedOrder is BaseOrderTest {
         external
         stateless
     {
-        vm.assume(
-            context.args.recipient != address(0) &&
-                context.args.recipient != address(test1155_1)
-        );
-
         bytes32 conduitKey = context.args.useConduit
             ? conduitKeyOne
             : bytes32(0);
@@ -554,8 +549,11 @@ contract FulfillAdvancedOrder is BaseOrderTest {
             assertFalse(isCancelled);
             assertEq(totalFilled, context.args.numer);
             assertEq(totalSize, context.args.denom);
+            // if recipient is alice (offerer), final balance will be number minted, ie, denom
             assertEq(
-                context.args.numer,
+                context.args.recipient == alice
+                    ? context.args.denom
+                    : context.args.numer,
                 test1155_1.balanceOf(
                     context.args.recipient,
                     context.args.tokenId


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
When `args.recipient` is `alice`, the `balanceOf` assertion will fail.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
Conditionally assert either numer or denom balance 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
