### PR TITLE
Added unchecked to FulfillmentApplier

### DIFF
--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -107,11 +107,14 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
             // Retrieve the first offer component from the fulfillment.
             FulfillmentComponent memory targetComponent = (offerComponents[0]);
 
-            // Add excess offer item amount to the original array of orders.
-            advancedOrders[targetComponent.orderIndex]
-                .parameters
-                .offer[targetComponent.itemIndex]
-                .startAmount = execution.item.amount - considerationItem.amount;
+            // Skip underflow check as considerationItem.amount <= execution.item.amount.
+            unchecked {
+                // Add excess offer item amount to the original array of orders.
+                advancedOrders[targetComponent.orderIndex]
+                    .parameters
+                    .offer[targetComponent.itemIndex]
+                    .startAmount = execution.item.amount - considerationItem.amount;
+            }
         }
 
         // Reuse execution struct with consideration amount and recipient.

--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -113,7 +113,9 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
                 advancedOrders[targetComponent.orderIndex]
                     .parameters
                     .offer[targetComponent.itemIndex]
-                    .startAmount = execution.item.amount - considerationItem.amount;
+                    .startAmount =
+                    execution.item.amount -
+                    considerationItem.amount;
             }
         }
 


### PR DESCRIPTION
## Motivation
Unchecked can be used in some places where we know for sure that the calculations won't overflow or underflow, and there are some places where it can be used to save the gas spent on these checks.

## Solution
Added unchecked where the calculations can't overflow or underflow.