### PR TITLE
Added unchecked to OrderCombiner

### DIFF
--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -232,8 +232,11 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 // Otherwise, track the order hash in question.
                 orderHashes[i] = orderHash;
 
-                // Decrement the number of fulfilled orders.
-                maximumFulfilled--;
+                // Skip underflow check as maximumFulfilled > 0.
+                unchecked {
+                    // Decrement the number of fulfilled orders.
+                    maximumFulfilled--;
+                }
 
                 // Place the start time for the order on the stack.
                 uint256 startTime = advancedOrder.parameters.startTime;


### PR DESCRIPTION
## Motivation
Unchecked can be used in some places where we know for sure that the calculations won't overflow or underflow, and there are some places where it can be used to save the gas spent on these checks.

## Solution
Added unchecked where the calculations can't overflow or underflow.