### PR TITLE
Added unchecked to OrderFulfiller

### DIFF
--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -157,10 +157,13 @@ contract OrderFulfiller is
         bytes32 fulfillerConduitKey,
         address recipient
     ) internal {
-        // Derive order duration, time elapsed, and time remaining.
-        uint256 duration = orderParameters.endTime - orderParameters.startTime;
-        uint256 elapsed = block.timestamp - orderParameters.startTime;
-        uint256 remaining = duration - elapsed;
+        // Skip underflow checks as we know orderParameters.startTime <= block.timestamp < orderParameters.endTime
+        unchecked {
+            // Derive order duration, time elapsed, and time remaining.
+            uint256 duration = orderParameters.endTime - orderParameters.startTime;
+            uint256 elapsed = block.timestamp - orderParameters.startTime;
+            uint256 remaining = duration - elapsed;
+        }
 
         // Put ether value supplied by the caller on the stack.
         uint256 etherRemaining = msg.value;


### PR DESCRIPTION
## Motivation
Unchecked can be used in some places where we know for sure that the calculations won't overflow or underflow, and there are some places where it can be used to save the gas spent on these checks.

## Solution
Added unchecked where the calculations can't overflow or underflow.