### PR TITLE
Use calldata ptr constant

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,3 +18,4 @@ Diego Estevez                  | `antidiego.eth`
 Chomtana                       | `chomtana.eth`
 Saw-mon and Natalie            | `sawmonandnatalie.eth`
 0x4non                         | `punkdev.eth`
+Laurence E. Day                | `norsefire.eth`

--- a/contracts/lib/TokenTransferrer.sol
+++ b/contracts/lib/TokenTransferrer.sol
@@ -566,7 +566,7 @@ contract TokenTransferrer is TokenTransferrerErrors {
 
                 // Determine the total calldata size for the call to transfer.
                 let transferDataSize := add(
-                    BatchTransfer1155Params_data_length_basePtr,
+                    BatchTransfer1155Params_calldata_baseSize,
                     idsAndAmountsSize
                 )
 

--- a/contracts/lib/TokenTransferrerConstants.sol
+++ b/contracts/lib/TokenTransferrerConstants.sol
@@ -140,6 +140,7 @@ uint256 constant BatchTransfer1155Params_ids_head_ptr = 0x64;
 uint256 constant BatchTransfer1155Params_amounts_head_ptr = 0x84;
 uint256 constant BatchTransfer1155Params_data_head_ptr = 0xa4;
 uint256 constant BatchTransfer1155Params_data_length_basePtr = 0xc4;
+uint256 constant BatchTransfer1155Params_calldata_baseSize = 0xc4;
 
 uint256 constant BatchTransfer1155Params_ids_length_ptr = 0xc4;
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

The `transferDataSize` parameter in `__performERC1155BatchTransfers` of `contracts/lib/TokenTransferrer.sol` was reusing a constant `BatchTransfer1155Params_data_length_basePtr` to determine the calldata size for the call to transfer.

## Solution

Simple: introduce a new constant in `TokenTransferrerConstants.sol` called `BatchTransfer1155Params_calldata_baseSize` and use that.
