### PR TITLE
Remove `gt` for `gcd` loop boolean condition

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,3 +19,4 @@ Chomtana                       | `chomtana.eth`
 Saw-mon and Natalie            | `sawmonandnatalie.eth`
 0x4non                         | `punkdev.eth`
 Laurence E. Day                | `norsefire.eth`
+vectorized.eth                 | `vectorized.eth`

--- a/contracts/lib/OrderValidator.sol
+++ b/contracts/lib/OrderValidator.sol
@@ -236,7 +236,7 @@ contract OrderValidator is Executor, ZoneInteraction {
                     function gcd(_a, _b) -> out {
                         for {
 
-                        } gt(_b, 0) {
+                        } _b {
 
                         } {
                             let _c := _b


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Ain't much but it's honest work.

We don't need a `gt(_b, 0)` check for `gcd`, since all values are uint256.  

The zeroness of `_b` will suffice as the boolean condition for the loop.

I tried on Remix, the compiler doesn't optimize that one out. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

Remove the `gt` check.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
