### PR TITLE
Use ++i to match code style in reference code

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,3 +25,4 @@ karmacoma                      | `karmacoma.eth`
 horsefacts                     | `horsefacts.eth`
 UncarvedBlock                  | `uncarvedblock.eth`
 Zoraiz Mahmood                 | `zorz.eth`
+cygaar                         | `cygaar.eth`

--- a/reference/conduit/ReferenceConduit.sol
+++ b/reference/conduit/ReferenceConduit.sol
@@ -45,7 +45,7 @@ contract ReferenceConduit is ConduitInterface, ReferenceTokenTransferrer {
         uint256 totalStandardTransfers = transfers.length;
 
         // Iterate over each standard execution.
-        for (uint256 i = 0; i < totalStandardTransfers; i++) {
+        for (uint256 i = 0; i < totalStandardTransfers; ++i) {
             // Retrieve the transfer in question.
             ConduitTransfer calldata standardTransfer = transfers[i];
 
@@ -66,7 +66,7 @@ contract ReferenceConduit is ConduitInterface, ReferenceTokenTransferrer {
         uint256 totalBatchTransfers = batchTransfers.length;
 
         // Iterate over each batch transfer.
-        for (uint256 i = 0; i < totalBatchTransfers; i++) {
+        for (uint256 i = 0; i < totalBatchTransfers; ++i) {
             // Retrieve the batch transfer in question.
             ConduitBatch1155Transfer calldata batchTransfer = batchTransfers[i];
 
@@ -88,7 +88,7 @@ contract ReferenceConduit is ConduitInterface, ReferenceTokenTransferrer {
         uint256 totalStandardTransfers = standardTransfers.length;
 
         // Iterate over each standard transfer.
-        for (uint256 i = 0; i < totalStandardTransfers; i++) {
+        for (uint256 i = 0; i < totalStandardTransfers; ++i) {
             // Retrieve the transfer in question.
             ConduitTransfer calldata standardTransfer = standardTransfers[i];
 
@@ -99,7 +99,7 @@ contract ReferenceConduit is ConduitInterface, ReferenceTokenTransferrer {
         uint256 totalBatchTransfers = batchTransfers.length;
 
         // Iterate over each batch transfer.
-        for (uint256 i = 0; i < totalBatchTransfers; i++) {
+        for (uint256 i = 0; i < totalBatchTransfers; ++i) {
             // Retrieve the batch transfer in question.
             ConduitBatch1155Transfer calldata batchTransfer = batchTransfers[i];
 

--- a/reference/lib/ReferenceBasicOrderFulfiller.sol
+++ b/reference/lib/ReferenceBasicOrderFulfiller.sol
@@ -641,7 +641,7 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
             for (
                 uint256 recipientCount = 0;
                 recipientCount < parameters.additionalRecipients.length;
-                recipientCount++
+                ++recipientCount
             ) {
                 // Get the next additionalRecipient.
                 AdditionalRecipient memory additionalRecipient = (
@@ -712,7 +712,7 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
                 uint256 additionalTips = parameters
                     .totalOriginalAdditionalRecipients;
                 additionalTips < parameters.additionalRecipients.length;
-                additionalTips++
+                ++additionalTips
             ) {
                 // Get the next additionalRecipient.
                 AdditionalRecipient memory additionalRecipient = (


### PR DESCRIPTION
## Motivation
We use ++i over i++ for pretty much the entire codebase, so it's worth making these reference files consistent.

Just some honest work

## Solution
Change <var>++ to ++<var>
