### PR TITLE
lint: remove extra whitespace

### DIFF
--- a/reference/conduit/ReferenceConduit.sol
+++ b/reference/conduit/ReferenceConduit.sol
@@ -128,7 +128,7 @@ contract ReferenceConduit is ConduitInterface, ReferenceTokenTransferrer {
     /**
      * @dev Internal function to transfer a given item.
      *
-     * @param item     The item to transfer, including an amount and recipient.
+     * @param item The item to transfer, including an amount and recipient.
      */
     function _transfer(ConduitTransfer calldata item) internal {
         // If the item type indicates Ether or a native token...


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Removes extra white spaces after the param `item` and its corresponding description. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

This makes the natspec styling consistent with `_batchTransferERC1155`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
