### PR TITLE
Fix non-matching aggregation bug in reference contracts

### DIFF
--- a/reference/lib/ReferenceFulfillmentApplier.sol
+++ b/reference/lib/ReferenceFulfillmentApplier.sol
@@ -350,6 +350,10 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                             offer,
                             execution
                         );
+                        // Break if invalid
+                        if (invalidFulfillment) {
+                            break;
+                        }
                     }
                 }
             }
@@ -532,6 +536,10 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                             consideration,
                             receivedItem
                         );
+                        // Break if invalid
+                        if (potentialCandidate.invalidFulfillment) {
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Motivation

In the reference contracts, one can aggregate items that do not match. The [`_checkMatchingConsideration`](https://github.com/code-423n4/2022-05-opensea-seaport/blob/4140473b1f85d0df602548ad260b1739ddd734a5/reference/lib/ReferenceFulfillmentApplier.sol#L523) function does not revert on `false`, instead the result is assigned to the `potentialCandidate.invalidFulfillment` field.
But this field is overwritten in the [next loop iteration](https://github.com/code-423n4/2022-05-opensea-seaport/blob/4140473b1f85d0df602548ad260b1739ddd734a5/reference/lib/ReferenceFulfillmentApplier.sol#L491).
This allows trading the offerer's items for useless items by falsely matching high-value consideration items.
Their amount is set to zero and one does not have to transfer these consideration items.

The bug is not present in the YUL version where the `_checkMatchingConsideration` [always reverts on `false`](https://github.com/code-423n4/2022-05-opensea-seaport/blob/4140473b1f85d0df602548ad260b1739ddd734a5/contracts/lib/FulfillmentApplier.sol#L739).

## Solution
I followed the current code style of `break`ing out of the `for` loop and going to the `invalidFulfillment` check at the end of the function to throw an error.