### PR TITLE
Fix AlmostOneWord from 0x19 to 0x1f = 31

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,3 +32,4 @@ cygaar                         | `cygaar.eth`
 Meta0xNull                     | `meta0xnull.eth`
 sach1r0                        |
 Matt Solomon                   | `msolomon.eth`
+leonardoalt                    | `leoalt.eth`

--- a/contracts/lib/TokenTransferrerConstants.sol
+++ b/contracts/lib/TokenTransferrerConstants.sol
@@ -33,7 +33,7 @@ pragma solidity >=0.8.7;
  *      codebase but have been left in for readability.
  */
 
-uint256 constant AlmostOneWord = 0x19;
+uint256 constant AlmostOneWord = 0x1f;
 uint256 constant OneWord = 0x20;
 uint256 constant TwoWords = 0x40;
 uint256 constant ThreeWords = 0x60;


### PR DESCRIPTION
Assuming that the comment under https://github.com/ProjectOpenSea/seaport/pull/311/files#diff-39e723c7a1e430233f5f7956e4e0f6d23f77fb7e3f1a11e145f53e215f3610fdR36 is correct, this fixes it.
It should be 31 because the changes in that PR were made to make sure that data rounds up in number of words, which is computed by `(Size + 31) / 32`.