### PR TITLE
Move scratch space reading closer in _callConduitUsingOffsets

### DIFF
--- a/contracts/lib/Executor.sol
+++ b/contracts/lib/Executor.sol
@@ -504,6 +504,7 @@ contract Executor is Verifiers, TokenTransferrer {
         address conduit = _deriveConduit(conduitKey);
 
         bool success;
+        bytes4 result;
 
         // call the conduit.
         assembly {
@@ -520,6 +521,9 @@ contract Executor is Verifiers, TokenTransferrer {
                 0,
                 OneWord
             )
+
+            // Take value from scratch space and place it on the stack.
+            result := mload(0)
         }
 
         // If the call failed...
@@ -529,13 +533,6 @@ contract Executor is Verifiers, TokenTransferrer {
 
             // Otherwise, revert with a generic error.
             revert InvalidCallToConduit(conduit);
-        }
-
-        // Ensure that the conduit returned the correct magic value.
-        bytes4 result;
-        assembly {
-            // Take value from scratch space and place it on the stack.
-            result := mload(0)
         }
 
         // Ensure result was extracted and matches EIP-1271 magic value.


### PR DESCRIPTION
This is to avoid the scratch space to become dirty between assembly blocks

Gas wise this prefers the success case, as opposed to the failure case.