### PR TITLE
Nitpick: clarify a comment about `orderStatus`

### DIFF
--- a/contracts/lib/OrderValidator.sol
+++ b/contracts/lib/OrderValidator.sol
@@ -195,7 +195,8 @@ contract OrderValidator is Executor, ZoneInteraction {
         uint256 filledNumerator = orderStatus.numerator;
         uint256 filledDenominator = orderStatus.denominator;
 
-        // If order currently has a non-zero denominator it is partially filled.
+        // If order (orderStatus) currently has a non-zero denominator it is
+        // partially filled.
         if (filledDenominator != 0) {
             // If denominator of 1 supplied, fill all remaining amount on order.
             if (denominator == 1) {


### PR DESCRIPTION
There are two "orders" at this context. The `OrderStatus memory orderStatus` defined in line 170 and `advancedOrder`. For advanced order, the condition "has a non-zero denominator" is always true.
