### PR TITLE
Use correct offset variable to reference objects in assembly

### DIFF
--- a/contracts/lib/GettersAndDerivers.sol
+++ b/contracts/lib/GettersAndDerivers.sol
@@ -65,7 +65,7 @@ contract GettersAndDerivers is ConsiderationBase {
             let hashArrPtr := mload(FreeMemoryPointerSlot)
 
             // Get the pointer to the offers array.
-            let offerArrPtr := mload(add(orderParameters, TwoWords))
+            let offerArrPtr := mload(add(orderParameters, OrderParameters_offer_head_offset))
 
             // Load the length.
             let offerLength := mload(offerArrPtr)


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->
Use of generic offset variables such as `TwoWords` may be confusing in assembly code(and may also change in the future). To improve readability use specific offset variables to reference objects in assembly code.

## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Replace generic offset variable such as `TwoWords` with specific one eg. `OrderParameters_offer_head_offset` wherever possible
