### PR TITLE
Minor optimization for testing `v` is valid for signature verification.

### DIFF
--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -275,6 +275,9 @@ uint256 constant BasicOrder_signature_ptr = 0x260;
 bytes32 constant EIP2098_allButHighestBitMask = (
     0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 );
+bytes32 constant ECDSA_twentySeventhAndTwentyEighthBytesSet = (
+    0x0000000000000000000000000000000000000000000000000000000101000000
+);
 
 // abi.encodeWithSignature("NoContract(address)")
 uint256 constant NoContract_error_signature = (

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -77,9 +77,9 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
                 v := byte(0, mload(add(signature, ThreeWords)))
 
                 // Whether v is 27 or 28.
-                // The magic number has the 27th and 28th bytes
+                // The magic constant has the 27th and 28th bytes
                 // counting from the most significant byte set to 1.
-                vIsValid := byte(v, 0x0101000000)
+                vIsValid := byte(v, ECDSA_twentySeventhAndTwentyEighthBytesSet)
             }
 
             // Ensure v value is properly formatted.

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -63,7 +63,7 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
         } else if (signature.length == 65) {
             // Whether v value is properly formatted.
             bool vIsValid;
-            
+
             // If signature is 65 bytes, parse as a standard signature (r+s+v).
             // Read each parameter directly from the signature's memory region.
             assembly {
@@ -75,8 +75,8 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
 
                 // Place final byte on the stack at v.
                 v := byte(0, mload(add(signature, ThreeWords)))
-                
-                // Whether v is 27 or 28. 
+
+                // Whether v is 27 or 28.
                 // The magic number has the 27th and 28th bytes
                 // counting from the most significant byte set to 1.
                 vIsValid := byte(v, 0x0101000000)

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -61,8 +61,8 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
                 v := add(shr(255, vs), 27)
             }
         } else if (signature.length == 65) {
-            // Whether v value is properly formatted.
-            bool vIsValid;
+            // Whether v value is not properly formatted.
+            bool vIsInvalid;
 
             // If signature is 65 bytes, parse as a standard signature (r+s+v).
             // Read each parameter directly from the signature's memory region.
@@ -76,14 +76,16 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
                 // Place final byte on the stack at v.
                 v := byte(0, mload(add(signature, ThreeWords)))
 
-                // Whether v is 27 or 28.
+                // Whether v is not 27 or 28.
                 // The magic constant has the 27th and 28th bytes
                 // counting from the most significant byte set to 1.
-                vIsValid := byte(v, ECDSA_twentySeventhAndTwentyEighthBytesSet)
+                vIsInvalid := iszero(
+                    byte(v, ECDSA_twentySeventhAndTwentyEighthBytesSet)
+                )
             }
 
             // Ensure v value is properly formatted.
-            if (!vIsValid) {
+            if (vIsInvalid) {
                 revert BadSignatureV(v);
             }
         } else {

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -61,6 +61,9 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
                 v := add(shr(255, vs), 27)
             }
         } else if (signature.length == 65) {
+            // Whether v value is properly formatted.
+            bool vIsValid;
+            
             // If signature is 65 bytes, parse as a standard signature (r+s+v).
             // Read each parameter directly from the signature's memory region.
             assembly {
@@ -72,10 +75,15 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
 
                 // Place final byte on the stack at v.
                 v := byte(0, mload(add(signature, ThreeWords)))
+                
+                // Whether v is 27 or 28. 
+                // The magic number has the 27th and 28th bytes
+                // counting from the most significant byte set to 1.
+                vIsValid := byte(v, 0x0101000000)
             }
 
             // Ensure v value is properly formatted.
-            if (v != 27 && v != 28) {
+            if (!vIsValid) {
                 revert BadSignatureV(v);
             }
         } else {


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Sorry, my last contribution was actually a psyops that didn't work. 

So I gotta do something that hopefully won't get optimized away by the compiler.

Copied from https://github.com/Rari-Capital/solmate/pull/247/files

Please feel free to copy more tricks from the solmate PR.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Use some assembly to test if `v` is either 27 or 28, and take the negation of the result.