### PR TITLE
Replace generic constant by OrderParameters_offer_head_offset

### DIFF
--- a/contracts/lib/GettersAndDerivers.sol
+++ b/contracts/lib/GettersAndDerivers.sol
@@ -65,7 +65,9 @@ contract GettersAndDerivers is ConsiderationBase {
             let hashArrPtr := mload(FreeMemoryPointerSlot)
 
             // Get the pointer to the offers array.
-            let offerArrPtr := mload(add(orderParameters, TwoWords))
+            let offerArrPtr := mload(
+                add(orderParameters, OrderParameters_offer_head_offset)
+            )
 
             // Load the length.
             let offerLength := mload(offerArrPtr)


### PR DESCRIPTION
TwoWords (0x40) is a generic constant. There is a more appropriate constant
`OrderParameters_offer_head_offset` with the same value here. This constant is already being used in line 181.

For verification:
1. `TwoWords`: https://github.com/ProjectOpenSea/seaport/blob/c084b88f55753cff187efe403c3e2d0117f8286d/contracts/lib/ConsiderationConstants.sol#L100
2. `OrderParameters_offer_head_offset`: https://github.com/ProjectOpenSea/seaport/blob/c084b88f55753cff187efe403c3e2d0117f8286d/contracts/lib/ConsiderationConstants.sol#L89