### PR TITLE
Fix ConsiderationConstants:AlmostOneWord to be 0x1f

### DIFF
--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -95,7 +95,7 @@ uint256 constant Fulfillment_itemIndex_offset = 0x20;
 
 uint256 constant AdvancedOrder_numerator_offset = 0x20;
 
-uint256 constant AlmostOneWord = 0x19;
+uint256 constant AlmostOneWord = 0x1f;
 uint256 constant OneWord = 0x20;
 uint256 constant TwoWords = 0x40;
 uint256 constant ThreeWords = 0x60;


### PR DESCRIPTION
Fixing the bug introduced in #322.

Similar to #388, which only fixed one occurrence.