### PR TITLE
80 is the way

### DIFF
--- a/reference/ReferenceConsideration.sol
+++ b/reference/ReferenceConsideration.sol
@@ -515,8 +515,8 @@ contract ReferenceConsideration is
 
     /**
      * @notice Cancel all orders from a given offerer with a given zone in bulk
-     *         by incrementing a counter. Note that only the offerer may increment
-     *         the counter.
+     *         by incrementing a counter. Note that only the offerer may 
+     *         increment the counter.
      *
      * @return newCounter The new counter.
      */
@@ -543,7 +543,8 @@ contract ReferenceConsideration is
         override
         returns (bytes32 orderHash)
     {
-        // Derive order hash by supplying order parameters along with the counter.
+        // Derive order hash by supplying order parameters along with the 
+        // counter.
         // prettier-ignore
         orderHash = _deriveOrderHash(
             OrderParameters(

--- a/reference/ReferenceConsideration.sol
+++ b/reference/ReferenceConsideration.sol
@@ -515,7 +515,7 @@ contract ReferenceConsideration is
 
     /**
      * @notice Cancel all orders from a given offerer with a given zone in bulk
-     *         by incrementing a counter. Note that only the offerer may 
+     *         by incrementing a counter. Note that only the offerer may
      *         increment the counter.
      *
      * @return newCounter The new counter.
@@ -543,7 +543,7 @@ contract ReferenceConsideration is
         override
         returns (bytes32 orderHash)
     {
-        // Derive order hash by supplying order parameters along with the 
+        // Derive order hash by supplying order parameters along with the
         // counter.
         // prettier-ignore
         orderHash = _deriveOrderHash(

--- a/reference/lib/ReferenceAssertions.sol
+++ b/reference/lib/ReferenceAssertions.sol
@@ -38,7 +38,7 @@ contract ReferenceAssertions is
      * @dev Internal view function to to ensure that the supplied consideration
      *      array length on a given set of order parameters is not less than the
      *      original consideration array length for that order and to retrieve
-     *      the current counter for a given order's offerer and zone and use it 
+     *      the current counter for a given order's offerer and zone and use it
      *      to  derive the order hash.
      *
      * @param orderParameters The parameters of the order to hash.

--- a/reference/lib/ReferenceAssertions.sol
+++ b/reference/lib/ReferenceAssertions.sol
@@ -38,8 +38,8 @@ contract ReferenceAssertions is
      * @dev Internal view function to to ensure that the supplied consideration
      *      array length on a given set of order parameters is not less than the
      *      original consideration array length for that order and to retrieve
-     *      the current counter for a given order's offerer and zone and use it to
-     *      derive the order hash.
+     *      the current counter for a given order's offerer and zone and use it 
+     *      to  derive the order hash.
      *
      * @param orderParameters The parameters of the order to hash.
      *

--- a/reference/lib/ReferenceBasicOrderFulfiller.sol
+++ b/reference/lib/ReferenceBasicOrderFulfiller.sol
@@ -57,8 +57,8 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
     }
 
     /**
-     * @dev Creates a mapping of BasicOrderType Enums to BasicOrderRouteType Enums
-     *      and BasicOrderType Enums to OrderType Enums
+     * @dev Creates a mapping of BasicOrderType Enums to BasicOrderRouteType
+     * Enums and BasicOrderType Enums to OrderType Enums
      */
     function createMappings() internal {
         // BasicOrderType to BasicOrderRouteType
@@ -572,7 +572,8 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
         // Memory to store hashes.
         BasicFulfillmentHashes memory hashes;
 
-        // Store ItemType/Token parameters in a struct in memory to avoid stack issues.
+        // Store ItemType/Token parameters in a struct in memory to avoid stack 
+        // issues.
         FulfillmentItemTypes memory fulfillmentItemTypes = FulfillmentItemTypes(
             orderType,
             receivedItemType,
@@ -620,7 +621,8 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
                 )
             );
 
-            // Declare memory for additionalReceivedItem, additionalRecipientItem.
+            // Declare memory for additionalReceivedItem and
+            // additionalRecipientItem.
             ReceivedItem memory additionalReceivedItem;
             ConsiderationItem memory additionalRecipientItem;
 
@@ -671,7 +673,8 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
                     continue;
                 }
 
-                // Create a new consideration item for each additional recipient.
+                // Create a new consideration item for each additional 
+                // recipient.
                 additionalRecipientItem = ConsiderationItem(
                     fulfillmentItemTypes.additionalRecipientsItemType,
                     fulfillmentItemTypes.additionalRecipientsToken,
@@ -762,7 +765,8 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
                         offerItem.token,
                         offerItem.identifier,
                         offerItem.amount,
-                        offerItem.amount // Assembly uses OfferItem instead of SpentItem.
+                        // Assembly uses OfferItem instead of SpentItem.
+                        offerItem.amount 
                     )
                 )
             ];
@@ -880,9 +884,10 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
      * @param erc20Token            The ERC20 token to transfer.
      * @param amount                The amount of ERC20 tokens to transfer.
      * @param parameters            The parameters of the order.
-     * @param fromOfferer           Whether to decrement amount from the offered amount.
-     * @param accumulatorStruct     A struct containing conduit transfer data and its
-     *                              corresponding conduitKey.
+     * @param fromOfferer           Whether to decrement amount from the 
+     *                              offered amount.
+     * @param accumulatorStruct     A struct containing conduit transfer data 
+     *                              and its corresponding conduitKey.
      */
     function _transferERC20AndFinalize(
         address from,

--- a/reference/lib/ReferenceBasicOrderFulfiller.sol
+++ b/reference/lib/ReferenceBasicOrderFulfiller.sol
@@ -572,7 +572,7 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
         // Memory to store hashes.
         BasicFulfillmentHashes memory hashes;
 
-        // Store ItemType/Token parameters in a struct in memory to avoid stack 
+        // Store ItemType/Token parameters in a struct in memory to avoid stack
         // issues.
         FulfillmentItemTypes memory fulfillmentItemTypes = FulfillmentItemTypes(
             orderType,
@@ -673,7 +673,7 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
                     continue;
                 }
 
-                // Create a new consideration item for each additional 
+                // Create a new consideration item for each additional
                 // recipient.
                 additionalRecipientItem = ConsiderationItem(
                     fulfillmentItemTypes.additionalRecipientsItemType,
@@ -766,7 +766,7 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
                         offerItem.identifier,
                         offerItem.amount,
                         // Assembly uses OfferItem instead of SpentItem.
-                        offerItem.amount 
+                        offerItem.amount
                     )
                 )
             ];
@@ -884,9 +884,9 @@ contract ReferenceBasicOrderFulfiller is ReferenceOrderValidator {
      * @param erc20Token            The ERC20 token to transfer.
      * @param amount                The amount of ERC20 tokens to transfer.
      * @param parameters            The parameters of the order.
-     * @param fromOfferer           Whether to decrement amount from the 
+     * @param fromOfferer           Whether to decrement amount from the
      *                              offered amount.
-     * @param accumulatorStruct     A struct containing conduit transfer data 
+     * @param accumulatorStruct     A struct containing conduit transfer data
      *                              and its corresponding conduitKey.
      */
     function _transferERC20AndFinalize(

--- a/reference/lib/ReferenceExecutor.sol
+++ b/reference/lib/ReferenceExecutor.sol
@@ -48,14 +48,15 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
     /**
      * @dev Internal function to transfer a given item.
      *
-     * @param item                  The item to transfer including an amount and recipient.
-     * @param offerer               The account offering the item, i.e. the from address.
-     * @param conduitKey            A bytes32 value indicating what corresponding conduit,
-     *                              if any, to source token approvals from. The zero hash
-     *                              signifies that no conduit should be used (and direct
-     *                              approvals set on Consideration)
-     * @param accumulatorStruct     A struct containing conduit transfer data and its
-     *                              corresponding conduitKey.
+     * @param item       The item to transfer including an amount and recipient.
+     * @param offerer    The account offering the item, i.e. the from address.
+     * @param conduitKey A bytes32 value indicating what corresponding
+     *                   conduit, if any, to source token approvals 
+     *                   from. The zero hash signifies that no conduit
+     *                   should be used (and direct approvals set on
+     *                   Consideration)
+     * @param accumulatorStruct     A struct containing conduit transfer data
+     *                              and its corresponding conduitKey.
      */
     function _transfer(
         ReceivedItem memory item,
@@ -128,16 +129,16 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      to a given recipient using a given conduit if applicable. Sufficient
      *      approvals must be set on this contract, the conduit.
      *
-     * @param token                 The ERC20 token to transfer.
-     * @param from                  The originator of the transfer.
-     * @param to                    The recipient of the transfer.
-     * @param amount                The amount to transfer.
-     * @param conduitKey            A bytes32 value indicating what corresponding conduit,
-     *                              if any, to source token approvals from. The zero hash
-     *                              signifies that no conduit should be used (and direct
-     *                              approvals set on Consideration).
-     * @param accumulatorStruct     A struct containing conduit transfer data and its
-     *                              corresponding conduitKey.
+     * @param token         The ERC20 token to transfer.
+     * @param from          The originator of the transfer.
+     * @param to            The recipient of the transfer.
+     * @param amount        The amount to transfer.
+     * @param conduitKey    A bytes32 value indicating what corresponding 
+     *                      conduit, if any, to source token approvals from.
+     *                      The zero hash signifies that no conduit should
+     *                      be used (and direct approvals set on Consideration).
+     * @param accumulatorStruct     A struct containing conduit transfer data 
+     *                              and its corresponding conduitKey.
      */
     function _transferERC20(
         address token,
@@ -177,17 +178,17 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      originator to a given recipient. Sufficient approvals must be set,
      *      either on the respective conduit or on this contract itself.
      *
-     * @param token                 The ERC721 token to transfer.
-     * @param from                  The originator of the transfer.
-     * @param to                    The recipient of the transfer.
-     * @param identifier            The tokenId to transfer.
-     * @param amount                The "amount" (this value must be equal to one).
-     * @param conduitKey            A bytes32 value indicating what corresponding conduit,
-     *                              if any, to source token approvals from. The zero hash
-     *                              signifies that no conduit should be used (and direct
-     *                              approvals set on Consideration).
-     * @param accumulatorStruct     A struct containing conduit transfer data and its
-     *                              corresponding conduitKey.
+     * @param token         The ERC721 token to transfer.
+     * @param from          The originator of the transfer.
+     * @param to            The recipient of the transfer.
+     * @param identifier    The tokenId to transfer.
+     * @param amount        The "amount" (this value must be equal to one).
+     * @param conduitKey    A bytes32 value indicating what corresponding 
+     *                      conduit, if any, to source token approvals from.
+     *                      The zero hash signifies that no conduit should 
+     *                      be used (and direct approvals set on Consideration).
+     * @param accumulatorStruct     A struct containing conduit transfer data 
+     *                              and its corresponding conduitKey.
      */
     function _transferERC721(
         address token,
@@ -230,17 +231,17 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      to a given recipient. Sufficient approvals must be set, either on
      *      the respective conduit or on this contract itself.
      *
-     * @param token                 The ERC1155 token to transfer.
-     * @param from                  The originator of the transfer.
-     * @param to                    The recipient of the transfer.
-     * @param identifier            The tokenId to transfer.
-     * @param amount                The amount to transfer.
-     * @param conduitKey            A bytes32 value indicating what corresponding conduit,
-     *                              if any, to source token approvals from. The zero hash
-     *                              signifies that no conduit should be used (and direct
-     *                              approvals set on Consideration).
-     * @param accumulatorStruct     A struct containing conduit transfer data and its
-     *                              corresponding conduitKey.
+     * @param token         The ERC1155 token to transfer.
+     * @param from          The originator of the transfer.
+     * @param to            The recipient of the transfer.
+     * @param identifier    The tokenId to transfer.
+     * @param amount        The amount to transfer.
+     * @param conduitKey    A bytes32 value indicating what corresponding 
+     *                      conduit, if any, to source token approvals from.
+     *                      The zero hash signifies that no conduit should 
+     *                      be used (and direct approvals set on Consideration).
+     * @param accumulatorStruct     A struct containing conduit transfer data 
+     *                              and its corresponding conduitKey.
      */
     function _transferERC1155(
         address token,
@@ -282,12 +283,12 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      is "armed") and the supplied conduit key does not match the key held
      *      by the accumulator.
      *
-     * @param accumulatorStruct A struct containing conduit transfer data and its
-     *                          corresponding conduitKey.
-     * @param conduitKey        A bytes32 value indicating what corresponding conduit,
-     *                          if any, to source token approvals from. The zero hash
-     *                          signifies that no conduit should be used, with direct
-     *                          approvals set on this contract.
+     * @param accumulatorStruct A struct containing conduit transfer data 
+     *                          and its corresponding conduitKey.
+     * @param conduitKey    A bytes32 value indicating what corresponding 
+     *                      conduit, if any, to source token approvals from.
+     *                      The zero hash signifies that no conduit should 
+     *                      be used (and direct approvals set on Consideration).
      */
     function _triggerIfArmedAndNotAccumulatable(
         AccumulatorStruct memory accumulatorStruct,
@@ -304,8 +305,8 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      the accumulator if the accumulator contains item transfers (i.e. it
      *      is "armed").
      *
-     * @param accumulatorStruct A struct containing conduit transfer data and its
-     *                          corresponding conduitKey.
+     * @param accumulatorStruct A struct containing conduit transfer data 
+     *                          and its corresponding conduitKey.
      */
     function _triggerIfArmed(AccumulatorStruct memory accumulatorStruct)
         internal
@@ -324,8 +325,8 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      a given conduit key, supplying all accumulated item transfers. The
      *      accumulator will be "disarmed" and reset in the process.
      *
-     * @param accumulatorStruct A struct containing conduit transfer data and its
-     *                          corresponding conduitKey.
+     * @param accumulatorStruct A struct containing conduit transfer data 
+     *                          and its corresponding conduitKey.
      */
     function _trigger(AccumulatorStruct memory accumulatorStruct) internal {
         // Call the conduit with all the accumulated transfers.
@@ -342,12 +343,12 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      that collects a series of transfers to execute against a given
      *      conduit in a single call.
      *
-     * @param conduitKey        A bytes32 value indicating what corresponding conduit,
-     *                          if any, to source token approvals from. The zero hash
-     *                          signifies that no conduit should be used, with direct
-     *                          approvals set on this contract.
-     * @param accumulatorStruct A struct containing conduit transfer data and its
-     *                          corresponding conduitKey.
+     * @param conduitKey    A bytes32 value indicating what corresponding 
+     *                      conduit, if any, to source token approvals from.
+     *                      The zero hash signifies that no conduit should 
+     *                      be used (and direct approvals set on Consideration).
+     * @param accumulatorStruct A struct containing conduit transfer data 
+     *                          and its corresponding conduitKey.
      * @param itemType          The type of the item to transfer.
      * @param token             The token to transfer.
      * @param from              The originator of the transfer.

--- a/reference/lib/ReferenceExecutor.sol
+++ b/reference/lib/ReferenceExecutor.sol
@@ -51,7 +51,7 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      * @param item       The item to transfer including an amount and recipient.
      * @param offerer    The account offering the item, i.e. the from address.
      * @param conduitKey A bytes32 value indicating what corresponding
-     *                   conduit, if any, to source token approvals 
+     *                   conduit, if any, to source token approvals
      *                   from. The zero hash signifies that no conduit
      *                   should be used (and direct approvals set on
      *                   Consideration)
@@ -133,11 +133,11 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      * @param from          The originator of the transfer.
      * @param to            The recipient of the transfer.
      * @param amount        The amount to transfer.
-     * @param conduitKey    A bytes32 value indicating what corresponding 
+     * @param conduitKey    A bytes32 value indicating what corresponding
      *                      conduit, if any, to source token approvals from.
      *                      The zero hash signifies that no conduit should
      *                      be used (and direct approvals set on Consideration).
-     * @param accumulatorStruct     A struct containing conduit transfer data 
+     * @param accumulatorStruct     A struct containing conduit transfer data
      *                              and its corresponding conduitKey.
      */
     function _transferERC20(
@@ -183,11 +183,11 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      * @param to            The recipient of the transfer.
      * @param identifier    The tokenId to transfer.
      * @param amount        The "amount" (this value must be equal to one).
-     * @param conduitKey    A bytes32 value indicating what corresponding 
+     * @param conduitKey    A bytes32 value indicating what corresponding
      *                      conduit, if any, to source token approvals from.
-     *                      The zero hash signifies that no conduit should 
+     *                      The zero hash signifies that no conduit should
      *                      be used (and direct approvals set on Consideration).
-     * @param accumulatorStruct     A struct containing conduit transfer data 
+     * @param accumulatorStruct     A struct containing conduit transfer data
      *                              and its corresponding conduitKey.
      */
     function _transferERC721(
@@ -236,11 +236,11 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      * @param to            The recipient of the transfer.
      * @param identifier    The tokenId to transfer.
      * @param amount        The amount to transfer.
-     * @param conduitKey    A bytes32 value indicating what corresponding 
+     * @param conduitKey    A bytes32 value indicating what corresponding
      *                      conduit, if any, to source token approvals from.
-     *                      The zero hash signifies that no conduit should 
+     *                      The zero hash signifies that no conduit should
      *                      be used (and direct approvals set on Consideration).
-     * @param accumulatorStruct     A struct containing conduit transfer data 
+     * @param accumulatorStruct     A struct containing conduit transfer data
      *                              and its corresponding conduitKey.
      */
     function _transferERC1155(
@@ -283,11 +283,11 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      is "armed") and the supplied conduit key does not match the key held
      *      by the accumulator.
      *
-     * @param accumulatorStruct A struct containing conduit transfer data 
+     * @param accumulatorStruct A struct containing conduit transfer data
      *                          and its corresponding conduitKey.
-     * @param conduitKey    A bytes32 value indicating what corresponding 
+     * @param conduitKey    A bytes32 value indicating what corresponding
      *                      conduit, if any, to source token approvals from.
-     *                      The zero hash signifies that no conduit should 
+     *                      The zero hash signifies that no conduit should
      *                      be used (and direct approvals set on Consideration).
      */
     function _triggerIfArmedAndNotAccumulatable(
@@ -305,7 +305,7 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      the accumulator if the accumulator contains item transfers (i.e. it
      *      is "armed").
      *
-     * @param accumulatorStruct A struct containing conduit transfer data 
+     * @param accumulatorStruct A struct containing conduit transfer data
      *                          and its corresponding conduitKey.
      */
     function _triggerIfArmed(AccumulatorStruct memory accumulatorStruct)
@@ -325,7 +325,7 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      a given conduit key, supplying all accumulated item transfers. The
      *      accumulator will be "disarmed" and reset in the process.
      *
-     * @param accumulatorStruct A struct containing conduit transfer data 
+     * @param accumulatorStruct A struct containing conduit transfer data
      *                          and its corresponding conduitKey.
      */
     function _trigger(AccumulatorStruct memory accumulatorStruct) internal {
@@ -343,11 +343,11 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      that collects a series of transfers to execute against a given
      *      conduit in a single call.
      *
-     * @param conduitKey    A bytes32 value indicating what corresponding 
+     * @param conduitKey    A bytes32 value indicating what corresponding
      *                      conduit, if any, to source token approvals from.
-     *                      The zero hash signifies that no conduit should 
+     *                      The zero hash signifies that no conduit should
      *                      be used (and direct approvals set on Consideration).
-     * @param accumulatorStruct A struct containing conduit transfer data 
+     * @param accumulatorStruct A struct containing conduit transfer data
      *                          and its corresponding conduitKey.
      * @param itemType          The type of the item to transfer.
      * @param token             The token to transfer.

--- a/reference/lib/ReferenceExecutor.sol
+++ b/reference/lib/ReferenceExecutor.sol
@@ -48,13 +48,15 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
     /**
      * @dev Internal function to transfer a given item.
      *
-     * @param item       The item to transfer including an amount and recipient.
-     * @param offerer    The account offering the item, i.e. the from address.
-     * @param conduitKey A bytes32 value indicating what corresponding
-     *                   conduit, if any, to source token approvals
-     *                   from. The zero hash signifies that no conduit
-     *                   should be used (and direct approvals set on
-     *                   Consideration)
+     * @param item                  The item to transfer including an amount
+     *                              and recipient.
+     * @param offerer               The account offering the item, i.e. the
+     *                              from address.
+     * @param conduitKey            A bytes32 value indicating what
+     *                              corresponding conduit, if any, to source
+     *                              token approvals from. The zero hash
+     *                              signifies that no conduit should be used
+     *                              (and direct approvals set on Consideration)
      * @param accumulatorStruct     A struct containing conduit transfer data
      *                              and its corresponding conduitKey.
      */
@@ -129,14 +131,15 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      to a given recipient using a given conduit if applicable. Sufficient
      *      approvals must be set on this contract, the conduit.
      *
-     * @param token         The ERC20 token to transfer.
-     * @param from          The originator of the transfer.
-     * @param to            The recipient of the transfer.
-     * @param amount        The amount to transfer.
-     * @param conduitKey    A bytes32 value indicating what corresponding
-     *                      conduit, if any, to source token approvals from.
-     *                      The zero hash signifies that no conduit should
-     *                      be used (and direct approvals set on Consideration).
+     * @param token                 The ERC20 token to transfer.
+     * @param from                  The originator of the transfer.
+     * @param to                    The recipient of the transfer.
+     * @param amount                The amount to transfer.
+     * @param conduitKey            A bytes32 value indicating what
+     *                              corresponding conduit, if any, to source
+     *                              token approvals from. The zero hash
+     *                              signifies that no conduit should be used
+     *                              (and direct approvals set on Consideration)
      * @param accumulatorStruct     A struct containing conduit transfer data
      *                              and its corresponding conduitKey.
      */
@@ -178,15 +181,17 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      originator to a given recipient. Sufficient approvals must be set,
      *      either on the respective conduit or on this contract itself.
      *
-     * @param token         The ERC721 token to transfer.
-     * @param from          The originator of the transfer.
-     * @param to            The recipient of the transfer.
-     * @param identifier    The tokenId to transfer.
-     * @param amount        The "amount" (this value must be equal to one).
-     * @param conduitKey    A bytes32 value indicating what corresponding
-     *                      conduit, if any, to source token approvals from.
-     *                      The zero hash signifies that no conduit should
-     *                      be used (and direct approvals set on Consideration).
+     * @param token                 The ERC721 token to transfer.
+     * @param from                  The originator of the transfer.
+     * @param to                    The recipient of the transfer.
+     * @param identifier            The tokenId to transfer.
+     * @param amount                The "amount" (this value must be equal
+     *                              to one).
+     * @param conduitKey            A bytes32 value indicating what
+     *                              corresponding conduit, if any, to source
+     *                              token approvals from. The zero hash
+     *                              signifies that no conduit should be used
+     *                              (and direct approvals set on Consideration)
      * @param accumulatorStruct     A struct containing conduit transfer data
      *                              and its corresponding conduitKey.
      */
@@ -231,15 +236,16 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      to a given recipient. Sufficient approvals must be set, either on
      *      the respective conduit or on this contract itself.
      *
-     * @param token         The ERC1155 token to transfer.
-     * @param from          The originator of the transfer.
-     * @param to            The recipient of the transfer.
-     * @param identifier    The tokenId to transfer.
-     * @param amount        The amount to transfer.
-     * @param conduitKey    A bytes32 value indicating what corresponding
-     *                      conduit, if any, to source token approvals from.
-     *                      The zero hash signifies that no conduit should
-     *                      be used (and direct approvals set on Consideration).
+     * @param token                 The ERC1155 token to transfer.
+     * @param from                  The originator of the transfer.
+     * @param to                    The recipient of the transfer.
+     * @param identifier            The tokenId to transfer.
+     * @param amount                The amount to transfer.
+     * @param conduitKey            A bytes32 value indicating what
+     *                              corresponding conduit, if any, to source
+     *                              token approvals from. The zero hash
+     *                              signifies that no conduit should be used
+     *                              (and direct approvals set on Consideration)
      * @param accumulatorStruct     A struct containing conduit transfer data
      *                              and its corresponding conduitKey.
      */
@@ -285,10 +291,11 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *
      * @param accumulatorStruct A struct containing conduit transfer data
      *                          and its corresponding conduitKey.
-     * @param conduitKey    A bytes32 value indicating what corresponding
-     *                      conduit, if any, to source token approvals from.
-     *                      The zero hash signifies that no conduit should
-     *                      be used (and direct approvals set on Consideration).
+     * @param conduitKey        A bytes32 value indicating what corresponding
+     *                          conduit, if any, to source token approvals
+     *                          from. The zero hash signifies that no conduit
+     *                          should be used (and direct approvals set on
+     *                          Consideration)
      */
     function _triggerIfArmedAndNotAccumulatable(
         AccumulatorStruct memory accumulatorStruct,
@@ -343,10 +350,11 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *      that collects a series of transfers to execute against a given
      *      conduit in a single call.
      *
-     * @param conduitKey    A bytes32 value indicating what corresponding
-     *                      conduit, if any, to source token approvals from.
-     *                      The zero hash signifies that no conduit should
-     *                      be used (and direct approvals set on Consideration).
+     * @param conduitKey        A bytes32 value indicating what
+     *                          corresponding conduit, if any, to source
+     *                          token approvals from. The zero hash
+     *                          signifies that no conduit should be used
+     *                          (and direct approvals set on Consideration)
      * @param accumulatorStruct A struct containing conduit transfer data
      *                          and its corresponding conduitKey.
      * @param itemType          The type of the item to transfer.
@@ -421,8 +429,8 @@ contract ReferenceExecutor is ReferenceVerifiers, ReferenceTokenTransferrer {
      *                   the "salt" parameter supplied by the deployer (i.e. the
      *                   conduit controller) when deploying the given conduit.
      *
-     * @return conduit The address of the conduit associated with the given
-     *                 conduit key.
+     * @return conduit   The address of the conduit associated with the given
+     *                   conduit key.
      */
     function _getConduit(bytes32 conduitKey)
         internal

--- a/reference/lib/ReferenceFulfillmentApplier.sol
+++ b/reference/lib/ReferenceFulfillmentApplier.sol
@@ -234,14 +234,14 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
     }
 
     /**
-     * @dev Internal pure function to check the indicated offer item 
+     * @dev Internal pure function to check the indicated offer item
      *      matches original item.
      *
      * @param orderToExecute  The order to compare.
      * @param offer The offer to compare
      * @param execution  The aggregated offer item
      *
-     * @return invalidFulfillment A boolean indicating whether the 
+     * @return invalidFulfillment A boolean indicating whether the
      *                            fulfillment is invalid.
      */
     function _checkMatchingOffer(
@@ -318,7 +318,7 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                     i < offerComponents.length;
                     ++i
                 ) {
-                    // Get the order index and item index of the offer 
+                    // Get the order index and item index of the offer
                     // component.
                     orderIndex = offerComponents[i].orderIndex;
                     itemIndex = offerComponents[i].itemIndex;
@@ -339,17 +339,17 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                         if (invalidFulfillment) {
                             break;
                         }
-                        // Get the spent item based on the offer components 
+                        // Get the spent item based on the offer components
                         // item index.
                         offer = orderToExecute.spentItems[itemIndex];
                         // Update the Received Item Amount.
                         execution.item.amount =
                             execution.item.amount +
                             offer.amount;
-                        // Zero out amount on original offerItem to indicate 
+                        // Zero out amount on original offerItem to indicate
                         // it is spent,
                         offer.amount = 0;
-                        // Ensure the indicated offer item matches original 
+                        // Ensure the indicated offer item matches original
                         // item.
                         invalidFulfillment = _checkMatchingOffer(
                             orderToExecute,
@@ -415,7 +415,7 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
     }
 
     /**
-     * @dev Internal pure function to check the indicated consideration item 
+     * @dev Internal pure function to check the indicated consideration item
      *      matches original item.
      *
      * @param consideration  The consideration to compare
@@ -501,7 +501,7 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                     i < considerationComponents.length;
                     ++i
                 ) {
-                    // Get the order index and item index of the consideration 
+                    // Get the order index and item index of the consideration
                     // component.
                     potentialCandidate.orderIndex = considerationComponents[i]
                         .orderIndex;
@@ -515,7 +515,7 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                     if (potentialCandidate.invalidFulfillment) {
                         break;
                     }
-                    // Get the order based on consideration components order 
+                    // Get the order based on consideration components order
                     // index.
                     orderToExecute = ordersToExecute[
                         potentialCandidate.orderIndex
@@ -538,7 +538,7 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                         receivedItem.amount =
                             receivedItem.amount +
                             consideration.amount;
-                        // Zero out amount on original consideration item to 
+                        // Zero out amount on original consideration item to
                         // indicate it is spent
                         consideration.amount = 0;
                         // Ensure the indicated consideration item matches

--- a/reference/lib/ReferenceFulfillmentApplier.sol
+++ b/reference/lib/ReferenceFulfillmentApplier.sol
@@ -234,13 +234,15 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
     }
 
     /**
-     * @dev Internal pure function to check the indicated offer item matches original item.
+     * @dev Internal pure function to check the indicated offer item 
+     *      matches original item.
      *
      * @param orderToExecute  The order to compare.
      * @param offer The offer to compare
      * @param execution  The aggregated offer item
      *
-     * @return invalidFulfillment A boolean indicating whether the fulfillment is invalid.
+     * @return invalidFulfillment A boolean indicating whether the 
+     *                            fulfillment is invalid.
      */
     function _checkMatchingOffer(
         OrderToExecute memory orderToExecute,
@@ -316,7 +318,8 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                     i < offerComponents.length;
                     ++i
                 ) {
-                    // Get the order index and item index of the offer component.
+                    // Get the order index and item index of the offer 
+                    // component.
                     orderIndex = offerComponents[i].orderIndex;
                     itemIndex = offerComponents[i].itemIndex;
 
@@ -336,15 +339,18 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                         if (invalidFulfillment) {
                             break;
                         }
-                        // Get the spent item based on the offer components item index.
+                        // Get the spent item based on the offer components 
+                        // item index.
                         offer = orderToExecute.spentItems[itemIndex];
                         // Update the Received Item Amount.
                         execution.item.amount =
                             execution.item.amount +
                             offer.amount;
-                        // Zero out amount on original offerItem to indicate it is spent,
+                        // Zero out amount on original offerItem to indicate 
+                        // it is spent,
                         offer.amount = 0;
-                        // Ensure the indicated offer item matches original item.
+                        // Ensure the indicated offer item matches original 
+                        // item.
                         invalidFulfillment = _checkMatchingOffer(
                             orderToExecute,
                             offer,
@@ -409,12 +415,14 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
     }
 
     /**
-     * @dev Internal pure function to check the indicated consideration item matches original item.
+     * @dev Internal pure function to check the indicated consideration item 
+     *      matches original item.
      *
      * @param consideration  The consideration to compare
      * @param receivedItem  The aggregated received item
      *
-     * @return invalidFulfillment A boolean indicating whether the fulfillment is invalid.
+     * @return invalidFulfillment A boolean indicating whether the fulfillment
+     *                            is invalid.
      */
     function _checkMatchingConsideration(
         ReceivedItem memory consideration,
@@ -493,7 +501,8 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                     i < considerationComponents.length;
                     ++i
                 ) {
-                    // Get the order index and item index of the consideration component.
+                    // Get the order index and item index of the consideration 
+                    // component.
                     potentialCandidate.orderIndex = considerationComponents[i]
                         .orderIndex;
                     potentialCandidate.itemIndex = considerationComponents[i]
@@ -506,7 +515,8 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                     if (potentialCandidate.invalidFulfillment) {
                         break;
                     }
-                    // Get the order based on consideration components order index.
+                    // Get the order based on consideration components order 
+                    // index.
                     orderToExecute = ordersToExecute[
                         potentialCandidate.orderIndex
                     ];
@@ -528,9 +538,11 @@ contract ReferenceFulfillmentApplier is FulfillmentApplicationErrors {
                         receivedItem.amount =
                             receivedItem.amount +
                             consideration.amount;
-                        // Zero out amount on original consideration item to indicate it is spent
+                        // Zero out amount on original consideration item to 
+                        // indicate it is spent
                         consideration.amount = 0;
-                        // Ensure the indicated consideration item matches original item.
+                        // Ensure the indicated consideration item matches
+                        // original item.
                         potentialCandidate
                             .invalidFulfillment = _checkMatchingConsideration(
                             consideration,

--- a/reference/lib/ReferenceGettersAndDerivers.sol
+++ b/reference/lib/ReferenceGettersAndDerivers.sol
@@ -52,7 +52,7 @@ contract ReferenceGettersAndDerivers is ReferenceConsiderationBase {
     }
 
     /**
-     * @dev Internal view function to derive the EIP-712 hash for a 
+     * @dev Internal view function to derive the EIP-712 hash for a
      *      consideration item.
      *
      * @param considerationItem The consideration item to hash.

--- a/reference/lib/ReferenceGettersAndDerivers.sol
+++ b/reference/lib/ReferenceGettersAndDerivers.sol
@@ -52,7 +52,8 @@ contract ReferenceGettersAndDerivers is ReferenceConsiderationBase {
     }
 
     /**
-     * @dev Internal view function to derive the EIP-712 hash for a consideration item.
+     * @dev Internal view function to derive the EIP-712 hash for a 
+     *      consideration item.
      *
      * @param considerationItem The consideration item to hash.
      *

--- a/reference/lib/ReferenceOrderCombiner.sol
+++ b/reference/lib/ReferenceOrderCombiner.sol
@@ -81,10 +81,10 @@ contract ReferenceOrderCombiner is
      *                                  considered valid.
      *
      * @param ordersToExecute           The orders to execute.  This is an
-     *                                  explicit version of advancedOrders 
-     *                                  without memory optimization, that 
-     *                                  provides an array of spentItems and 
-     *                                  receivedItems for fulfillment and 
+     *                                  explicit version of advancedOrders
+     *                                  without memory optimization, that
+     *                                  provides an array of spentItems and
+     *                                  receivedItems for fulfillment and
      *                                  event emission.
      *
      * @param criteriaResolvers         An array where each element contains a
@@ -114,11 +114,11 @@ contract ReferenceOrderCombiner is
      *                                  items.
      * @param maximumFulfilled          The maximum number of orders to fulfill.
      *
-     * @return availableOrders          An array of booleans indicating if each 
+     * @return availableOrders          An array of booleans indicating if each
      *                                  order with an index corresponding to the
-     *                                  index of the returned boolean was 
+     *                                  index of the returned boolean was
      *                                  fulfillable or not.
-     * @return executions               An array of elements indicating the 
+     * @return executions               An array of elements indicating the
      *                                  sequence of transfers performed as part
      *                                  of matching the given orders.
      */
@@ -374,7 +374,7 @@ contract ReferenceOrderCombiner is
             // Get the array of spentItems from the orderToExecute struct.
             SpentItem[] memory spentItems = ordersToExecute[i].spentItems;
 
-            // Get the array of spent receivedItems from the 
+            // Get the array of spent receivedItems from the
             // orderToExecute struct.
             ReceivedItem[] memory receivedItems = ordersToExecute[i]
                 .receivedItems;
@@ -404,10 +404,10 @@ contract ReferenceOrderCombiner is
      *      order formatting will cause the entire batch to fail.
      *
      * @param ordersToExecute           The orders to execute.  This is an
-     *                                  explicit version of advancedOrders 
-     *                                  without memory optimization, that 
-     *                                  provides an array of spentItems and 
-     *                                  receivedItems for fulfillment and 
+     *                                  explicit version of advancedOrders
+     *                                  without memory optimization, that
+     *                                  provides an array of spentItems and
+     *                                  receivedItems for fulfillment and
      *                                  event emission.
      *                                  Note that both the offerer and the
      *                                  fulfiller must first approve this
@@ -440,9 +440,9 @@ contract ReferenceOrderCombiner is
      *
      * @return availableOrders          An array of booleans indicating if each
      *                                  order with an index corresponding to the
-     *                                  index of the returned boolean was 
+     *                                  index of the returned boolean was
      *                                  fulfillable or not.
-     * @return executions               An array of elements indicating the 
+     * @return executions               An array of elements indicating the
      *                                  sequence of transfers performed as part
      *                                  of matching the given orders.
      */
@@ -705,7 +705,7 @@ contract ReferenceOrderCombiner is
      *                          order for the match operation to be valid.
      *
      * @return executions       An array of elements indicating the sequence of
-     *                          transfers performed as part of matching the 
+     *                          transfers performed as part of matching the
      *                          given orders.
      */
     function _matchAdvancedOrders(

--- a/reference/lib/ReferenceOrderCombiner.sol
+++ b/reference/lib/ReferenceOrderCombiner.sol
@@ -81,10 +81,11 @@ contract ReferenceOrderCombiner is
      *                                  considered valid.
      *
      * @param ordersToExecute           The orders to execute.  This is an
-     *                                  explicit version of advancedOrders without
-     *                                  memory optimization, that provides
-     *                                  an array of spentItems and receivedItems
-     *                                  for fulfillment and event emission.
+     *                                  explicit version of advancedOrders 
+     *                                  without memory optimization, that 
+     *                                  provides an array of spentItems and 
+     *                                  receivedItems for fulfillment and 
+     *                                  event emission.
      *
      * @param criteriaResolvers         An array where each element contains a
      *                                  reference to a specific offer or
@@ -113,12 +114,13 @@ contract ReferenceOrderCombiner is
      *                                  items.
      * @param maximumFulfilled          The maximum number of orders to fulfill.
      *
-     * @return availableOrders          An array of booleans indicating if each order
-     *                                  with an index corresponding to the index of the
-     *                                  returned boolean was fulfillable or not.
-     * @return executions               An array of elements indicating the sequence of
-     *                                  transfers performed as part of matching the given
-     *                                  orders.
+     * @return availableOrders          An array of booleans indicating if each 
+     *                                  order with an index corresponding to the
+     *                                  index of the returned boolean was 
+     *                                  fulfillable or not.
+     * @return executions               An array of elements indicating the 
+     *                                  sequence of transfers performed as part
+     *                                  of matching the given orders.
      */
     function _fulfillAvailableAdvancedOrders(
         AdvancedOrder[] memory advancedOrders,
@@ -372,7 +374,8 @@ contract ReferenceOrderCombiner is
             // Get the array of spentItems from the orderToExecute struct.
             SpentItem[] memory spentItems = ordersToExecute[i].spentItems;
 
-            // Get the array of spent receivedItems from the orderToExecute struct.
+            // Get the array of spent receivedItems from the 
+            // orderToExecute struct.
             ReceivedItem[] memory receivedItems = ordersToExecute[i]
                 .receivedItems;
 
@@ -401,14 +404,15 @@ contract ReferenceOrderCombiner is
      *      order formatting will cause the entire batch to fail.
      *
      * @param ordersToExecute           The orders to execute.  This is an
-     *                                  explicit version of advancedOrders without
-     *                                  memory optimization, that provides
-     *                                  an array of spentItems and receivedItems
-     *                                  for fulfillment and event emission.
+     *                                  explicit version of advancedOrders 
+     *                                  without memory optimization, that 
+     *                                  provides an array of spentItems and 
+     *                                  receivedItems for fulfillment and 
+     *                                  event emission.
      *                                  Note that both the offerer and the
      *                                  fulfiller must first approve this
-     *                                  contract (or the conduit if indicated by
-     *                                  the order) to transfer any relevant
+     *                                  contract (or the conduit if indicated
+     *                                  by the order) to transfer any relevant
      *                                  tokens on their behalf and that
      *                                  contracts must implement
      *                                  `onERC1155Received` in order to receive
@@ -434,12 +438,13 @@ contract ReferenceOrderCombiner is
      * @param recipient                 The intended recipient for all received
      *                                  items.
      *
-     * @return availableOrders        An array of booleans indicating if each order
-     *                                  with an index corresponding to the index of the
-     *                                  returned boolean was fulfillable or not.
-     * @return executions               An array of elements indicating the sequence of
-     *                                  transfers performed as part of matching the given
-     *                                  orders.
+     * @return availableOrders          An array of booleans indicating if each
+     *                                  order with an index corresponding to the
+     *                                  index of the returned boolean was 
+     *                                  fulfillable or not.
+     * @return executions               An array of elements indicating the 
+     *                                  sequence of transfers performed as part
+     *                                  of matching the given orders.
      */
     function _executeAvailableFulfillments(
         OrderToExecute[] memory ordersToExecute,
@@ -700,8 +705,8 @@ contract ReferenceOrderCombiner is
      *                          order for the match operation to be valid.
      *
      * @return executions       An array of elements indicating the sequence of
-     *                          transfers performed as part of matching the given
-     *                          orders.
+     *                          transfers performed as part of matching the 
+     *                          given orders.
      */
     function _matchAdvancedOrders(
         AdvancedOrder[] memory advancedOrders,

--- a/reference/lib/ReferenceOrderFulfiller.sol
+++ b/reference/lib/ReferenceOrderFulfiller.sol
@@ -142,8 +142,9 @@ contract ReferenceOrderFulfiller is
      *                            should be used (and direct approvals set on
      *                            Consideration).
      * @param recipient           The intended recipient for all received items.
-     * @return orderToExecute     Returns the order of items that are being transferred.
-     *                            This will be used for the OrderFulfilled Event.
+     * @return orderToExecute     Returns the order of items that are being 
+     *                            transferred. This will be used for the 
+     *                            OrderFulfilled Event.
      */
     function _applyFractionsAndTransferEach(
         OrderParameters memory orderParameters,
@@ -346,8 +347,8 @@ contract ReferenceOrderFulfiller is
     }
 
     /**
-     * @dev Internal pure function to convert an advanced order to an order to execute with
-     *      numerator of 1.
+     * @dev Internal pure function to convert an advanced order to an order 
+     *      to execute with numerator of 1.
      *
      * @param advancedOrder The advanced order to convert.
      *
@@ -422,8 +423,8 @@ contract ReferenceOrderFulfiller is
     }
 
     /**
-     * @dev Internal pure function to convert an array of advanced orders to an array of
-     *      orders to execute.
+     * @dev Internal pure function to convert an array of advanced orders to 
+     *      an array of orders to execute.
      *
      * @param advancedOrders The advanced orders to convert.
      *

--- a/reference/lib/ReferenceOrderFulfiller.sol
+++ b/reference/lib/ReferenceOrderFulfiller.sol
@@ -142,8 +142,8 @@ contract ReferenceOrderFulfiller is
      *                            should be used (and direct approvals set on
      *                            Consideration).
      * @param recipient           The intended recipient for all received items.
-     * @return orderToExecute     Returns the order of items that are being 
-     *                            transferred. This will be used for the 
+     * @return orderToExecute     Returns the order of items that are being
+     *                            transferred. This will be used for the
      *                            OrderFulfilled Event.
      */
     function _applyFractionsAndTransferEach(
@@ -347,7 +347,7 @@ contract ReferenceOrderFulfiller is
     }
 
     /**
-     * @dev Internal pure function to convert an advanced order to an order 
+     * @dev Internal pure function to convert an advanced order to an order
      *      to execute with numerator of 1.
      *
      * @param advancedOrder The advanced order to convert.
@@ -423,7 +423,7 @@ contract ReferenceOrderFulfiller is
     }
 
     /**
-     * @dev Internal pure function to convert an array of advanced orders to 
+     * @dev Internal pure function to convert an array of advanced orders to
      *      an array of orders to execute.
      *
      * @param advancedOrders The advanced orders to convert.

--- a/reference/lib/ReferenceOrderValidator.sol
+++ b/reference/lib/ReferenceOrderValidator.sol
@@ -152,7 +152,7 @@ contract ReferenceOrderValidator is
             revert PartialFillsNotEnabledForOrder();
         }
 
-        // Retrieve current counter and use it w/ parameters to derive 
+        // Retrieve current counter and use it w/ parameters to derive
         // order hash.
         orderHash = _assertConsiderationLengthAndGetCounterdOrderHash(
             orderParameters

--- a/reference/lib/ReferenceOrderValidator.sol
+++ b/reference/lib/ReferenceOrderValidator.sol
@@ -152,7 +152,8 @@ contract ReferenceOrderValidator is
             revert PartialFillsNotEnabledForOrder();
         }
 
-        // Retrieve current counter and use it w/ parameters to derive order hash.
+        // Retrieve current counter and use it w/ parameters to derive 
+        // order hash.
         orderHash = _assertConsiderationLengthAndGetCounterdOrderHash(
             orderParameters
         );


### PR DESCRIPTION
Adhere to 80-character line limit in comments.  Imports and L#75 in `ReferenceConsiderationBase.sol` still violate this rule.