### PR TITLE
standardize array length caching

### DIFF
--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -250,8 +250,11 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 // Retrieve array of offer items for the order in question.
                 OfferItem[] memory offer = advancedOrder.parameters.offer;
 
+                // Read length of offer array and place on the stack.
+                uint256 totalOffers = offer.length;
+
                 // Iterate over each offer item on the order.
-                for (uint256 j = 0; j < offer.length; ++j) {
+                for (uint256 j = 0; j < totalOffers; ++j) {
                     // Retrieve the offer item.
                     OfferItem memory offerItem = offer[j];
 
@@ -294,8 +297,11 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                     advancedOrder.parameters.consideration
                 );
 
+                // Read length of consideration array and place on the stack.
+                uint256 totalConsiderations = consideration.length;
+
                 // Iterate over each consideration item on the order.
-                for (uint256 j = 0; j < consideration.length; ++j) {
+                for (uint256 j = 0; j < totalConsiderations; ++j) {
                     // Retrieve the consideration item.
                     ConsiderationItem memory considerationItem = (
                         consideration[j]
@@ -571,6 +577,9 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
         // Retrieve the length of the advanced orders array and place on stack.
         uint256 totalOrders = advancedOrders.length;
 
+        // Retrieve the length of the executions array and place on stack.
+        uint256 totalExecutions = executions.length;
+
         // Initialize array for tracking available orders.
         availableOrders = new bool[](totalOrders);
 
@@ -597,8 +606,11 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                     advancedOrder.parameters.consideration
                 );
 
+                // Read length of consideration array and place on the stack.
+                uint256 totalConsiderations = consideration.length;
+
                 // Iterate over each consideration item to ensure it is met.
-                for (uint256 j = 0; j < consideration.length; ++j) {
+                for (uint256 j = 0; j < totalConsiderations; ++j) {
                     // Retrieve remaining amount on the consideration item.
                     uint256 unmetAmount = consideration[j].startAmount;
 
@@ -621,7 +633,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
         bytes memory accumulator = new bytes(AccumulatorDisarmed);
 
         // Iterate over each execution.
-        for (uint256 i = 0; i < executions.length; ) {
+        for (uint256 i = 0; i < totalExecutions; ) {
             // Retrieve the execution and the associated received item.
             Execution memory execution = executions[i];
             ReceivedItem memory item = execution.item;

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -577,9 +577,6 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
         // Retrieve the length of the advanced orders array and place on stack.
         uint256 totalOrders = advancedOrders.length;
 
-        // Retrieve the length of the executions array and place on stack.
-        uint256 totalExecutions = executions.length;
-
         // Initialize array for tracking available orders.
         availableOrders = new bool[](totalOrders);
 
@@ -624,6 +621,9 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
 
         // Put ether value supplied by the caller on the stack.
         uint256 etherRemaining = msg.value;
+
+        // Retrieve the length of the executions array and place on stack.
+        uint256 totalExecutions = executions.length;
 
         // Initialize an accumulator array. From this point forward, no new
         // memory regions can be safely allocated until the accumulator is no

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -622,15 +622,15 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
         // Put ether value supplied by the caller on the stack.
         uint256 etherRemaining = msg.value;
 
-        // Retrieve the length of the executions array and place on stack.
-        uint256 totalExecutions = executions.length;
-
         // Initialize an accumulator array. From this point forward, no new
         // memory regions can be safely allocated until the accumulator is no
         // longer being utilized, as the accumulator operates in an open-ended
         // fashion from this memory pointer; existing memory may still be
         // accessed and modified, however.
         bytes memory accumulator = new bytes(AccumulatorDisarmed);
+
+        // Retrieve the length of the executions array and place on stack.
+        uint256 totalExecutions = executions.length;
 
         // Iterate over each execution.
         for (uint256 i = 0; i < totalExecutions; ) {

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -251,10 +251,10 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 OfferItem[] memory offer = advancedOrder.parameters.offer;
 
                 // Read length of offer array and place on the stack.
-                uint256 totalOffers = offer.length;
+                uint256 totalOfferItems = offer.length;
 
                 // Iterate over each offer item on the order.
-                for (uint256 j = 0; j < totalOffers; ++j) {
+                for (uint256 j = 0; j < totalOfferItems; ++j) {
                     // Retrieve the offer item.
                     OfferItem memory offerItem = offer[j];
 
@@ -298,10 +298,10 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 );
 
                 // Read length of consideration array and place on the stack.
-                uint256 totalConsiderations = consideration.length;
+                uint256 totalConsiderationItems = consideration.length;
 
                 // Iterate over each consideration item on the order.
-                for (uint256 j = 0; j < totalConsiderations; ++j) {
+                for (uint256 j = 0; j < totalConsiderationItems; ++j) {
                     // Retrieve the consideration item.
                     ConsiderationItem memory considerationItem = (
                         consideration[j]
@@ -607,10 +607,10 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 );
 
                 // Read length of consideration array and place on the stack.
-                uint256 totalConsiderations = consideration.length;
+                uint256 totalConsiderationItems = consideration.length;
 
                 // Iterate over each consideration item to ensure it is met.
-                for (uint256 j = 0; j < totalConsiderations; ++j) {
+                for (uint256 j = 0; j < totalConsiderationItems; ++j) {
                     // Retrieve remaining amount on the consideration item.
                     uint256 unmetAmount = consideration[j].startAmount;
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
I noticed there were a few inconsistencies in the way seaport caches array length.  If this PR is accepted I will update other areas where array length is not being cached before a for loop.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
Read the length of an array and place the length on the stack before looping the array.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Thanks!