### PR TITLE
index `NewConduit` event parameter `conduit`

### DIFF
--- a/contracts/interfaces/ConduitControllerInterface.sol
+++ b/contracts/interfaces/ConduitControllerInterface.sol
@@ -26,7 +26,7 @@ interface ConduitControllerInterface {
      * @param conduit    The newly created conduit.
      * @param conduitKey The conduit key used to create the new conduit.
      */
-    event NewConduit(address conduit, bytes32 conduitKey);
+    event NewConduit(address indexed conduit, bytes32 conduitKey);
 
     /**
      * @dev Emit an event whenever conduit ownership is transferred.


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

Indexed event parameters are stored in the topics part of the log instead of the data part, which allows for faster indexing/querying because of the use of bloom filters for topics. Up to three parameters in every event can be indexed. Indexed event parameters allow for faster and more efficient/effective event lookups.

Most events already have indexed parameters, therefore it's a good idea to also index the remaining events.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add `indexed` keyword to index event `address` parameter
