### PR TITLE
Add tests for fulfill basic order with invalid length for additional recipients

### DIFF
--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -123,15 +123,12 @@ contract FulfillBasicOrderTest is BaseOrderTest, LowLevelHelpers {
     }
 
     function testFulfillBasicOrderRevertInvalidAdditionalRecipientsLength(
-        uint256 amountToSubtractFromTotalRecipients,
-        AdditionalRecipient[] memory additionalRecipients
+        uint256 fuzzTotalRecipients,
+        uint256 fuzzAmountToSubtractFromTotalRecipients
     ) public {
-        vm.assume(additionalRecipients.length <= 200);
-        vm.assume(
-            amountToSubtractFromTotalRecipients <= additionalRecipients.length
-        );
-        bool overwriteTotalRecipientsLength = amountToSubtractFromTotalRecipients >
-                0;
+        uint256 totalRecipients = fuzzTotalRecipients % 200;
+        uint256 amountToSubtractFromTotalRecipients = fuzzAmountToSubtractFromTotalRecipients % totalRecipients;
+        bool overwriteTotalRecipientsLength = amountToSubtractFromTotalRecipients > 0; 
 
         // Create basic order
         (
@@ -140,7 +137,7 @@ contract FulfillBasicOrderTest is BaseOrderTest, LowLevelHelpers {
         ) = prepareBasicOrderAndOrderParameters(1);
 
         // Add additional recipients
-        _basicOrderParameters.additionalRecipients = additionalRecipients;
+        _basicOrderParameters.additionalRecipients = new AdditionalRecipient[](totalRecipients);
         for (
             uint256 i = 0;
             i < _basicOrderParameters.additionalRecipients.length;

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -3,11 +3,14 @@
 
 pragma solidity >=0.8.13;
 
+import { OneWord } from "../../contracts/lib/ConsiderationConstants.sol";
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
-import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";
+import { AdditionalRecipient, Order } from "../../contracts/lib/ConsiderationStructs.sol";
 import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
 import { OfferItem, ConsiderationItem, OrderComponents, BasicOrderParameters } from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
+
+import { LowLevelHelpers } from "../../contracts/lib/LowLevelHelpers.sol";
 
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
 
@@ -16,7 +19,9 @@ import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
 import { TestERC20 } from "../../contracts/test/TestERC20.sol";
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
 
-contract FulfillBasicOrderTest is BaseOrderTest {
+import { OrderParameters } from "./utils/reentrancy/ReentrantStructs.sol";
+
+contract FulfillBasicOrderTest is BaseOrderTest, LowLevelHelpers {
     using ArithmeticUtil for uint128;
 
     BasicOrderParameters basicOrderParameters;
@@ -114,6 +119,143 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         test(
             this.basicErc20To1155,
             Context(referenceConsideration, inputs, tokenAmount)
+        );
+    }
+
+    function testFulfillBasicOrderRevertInvalidAdditionalRecipientsLength(
+        uint256 amountToSubtractFromTotalRecipients,
+        AdditionalRecipient[] memory additionalRecipients
+    ) public {
+        vm.assume(additionalRecipients.length <= 200);
+        vm.assume(
+            amountToSubtractFromTotalRecipients <= additionalRecipients.length
+        );
+        bool overwriteTotalRecipientsLength = amountToSubtractFromTotalRecipients >
+                0;
+
+        // Create basic order
+        (
+            Order memory myOrder,
+            BasicOrderParameters memory _basicOrderParameters
+        ) = prepareBasicOrderAndOrderParameters(1);
+
+        // Add additional recipients
+        _basicOrderParameters.additionalRecipients = additionalRecipients;
+        for (
+            uint256 i = 0;
+            i < _basicOrderParameters.additionalRecipients.length;
+            i++
+        ) {
+            _basicOrderParameters.additionalRecipients[i].amount = 1;
+        }
+
+        // Validate the order.
+        Order[] memory myOrders = new Order[](1);
+        myOrders[0] = myOrder;
+        consideration.validate(myOrders);
+
+        // Get the calldata that will be passed into fulfillBasicOrder.
+        bytes4 fulfillBasicOrderSignature = consideration
+            .fulfillBasicOrder
+            .selector;
+        bytes memory fulfillBasicOrderCalldata = abi.encodeWithSelector(
+            fulfillBasicOrderSignature,
+            _basicOrderParameters
+        );
+
+        if (overwriteTotalRecipientsLength) {
+            // Get the additional recipients length from the calldata and
+            // store the length - amountToSubtractFromTotalRecipients in the calldata
+            // so that the length value does _not_ accurately represent the actual
+            // total recipients length.
+            assembly {
+                let additionalRecipientsLengthOffset := add(
+                    fulfillBasicOrderCalldata,
+                    0x264
+                )
+                let additionalRecipientsLength := mload(
+                    additionalRecipientsLengthOffset
+                )
+                mstore(
+                    additionalRecipientsLengthOffset,
+                    sub(
+                        additionalRecipientsLength,
+                        amountToSubtractFromTotalRecipients
+                    )
+                )
+            }
+        }
+
+        address considerationAddress = address(consideration);
+        uint256 calldataLength = fulfillBasicOrderCalldata.length;
+        bool success;
+
+        assembly {
+            // Call fulfillBasicOrders
+            success := call(
+                gas(),
+                considerationAddress,
+                0,
+                // The fn signature and calldata starts after the
+                // first OneWord bytes, as those initial bytes just
+                // contain the length of fulfillBasicOrderCalldata
+                add(fulfillBasicOrderCalldata, OneWord),
+                calldataLength,
+                // Store output at empty storage location,
+                // identified using "free memory pointer".
+                mload(0x40),
+                OneWord
+            )
+        }
+
+        // If overwriteTotalRecipientsLength is True, the call should
+        // have failed (success should be False) and if overwriteTotalRecipientsLength is False,
+        // the call should have succeeded (success should be True).
+        assertEq(!overwriteTotalRecipientsLength, success);
+
+        if (overwriteTotalRecipientsLength) {
+            // Expect a revert if the additional recipients length is too small (e.g. 1 was subtracted).
+            vm.expectRevert();
+        }
+
+        if (!success) {
+            // Revert and pass the revert reason along if one was returned.
+            _revertWithReasonIfOneIsReturned();
+
+            // Otherwise, revert with a generic error message.
+            revert();
+        }
+    }
+
+    function prepareBasicOrderAndOrderParameters(uint256 tokenId)
+        internal
+        returns (
+            Order memory _order,
+            BasicOrderParameters memory _basicOrderParameters
+        )
+    {
+        test1155_1.mint(address(this), tokenId, 10);
+
+        _configureERC1155OfferItem(tokenId, 10);
+        _configureErc20ConsiderationItem(alice, 10);
+        uint256 nonce = consideration.getCounter(address(this));
+
+        OrderParameters memory _orderParameters = getOrderParameters(
+            payable(this),
+            OrderType.FULL_OPEN
+        );
+        OrderComponents memory _orderComponents = toOrderComponents(
+            _orderParameters,
+            nonce
+        );
+
+        bytes32 orderHash = consideration.getOrderHash(_orderComponents);
+
+        bytes memory _signature = signOrder(consideration, alicePk, orderHash);
+        _order = Order(_orderParameters, _signature);
+        _basicOrderParameters = toBasicOrderParameters(
+            _order,
+            BasicOrderType.ERC20_TO_ERC1155_FULL_OPEN
         );
     }
 

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -127,8 +127,13 @@ contract FulfillBasicOrderTest is BaseOrderTest, LowLevelHelpers {
         uint256 fuzzAmountToSubtractFromTotalRecipients
     ) public {
         uint256 totalRecipients = fuzzTotalRecipients % 200;
-        uint256 amountToSubtractFromTotalRecipients = fuzzAmountToSubtractFromTotalRecipients % totalRecipients;
-        bool overwriteTotalRecipientsLength = amountToSubtractFromTotalRecipients > 0; 
+        // Set amount to subtract from total recipients
+        // to be at most totalRecipients.
+        uint256 amountToSubtractFromTotalRecipients = totalRecipients > 0
+            ? fuzzAmountToSubtractFromTotalRecipients % totalRecipients
+            : 0;
+        bool overwriteTotalRecipientsLength = amountToSubtractFromTotalRecipients >
+                0;
 
         // Create basic order
         (
@@ -137,13 +142,17 @@ contract FulfillBasicOrderTest is BaseOrderTest, LowLevelHelpers {
         ) = prepareBasicOrderAndOrderParameters(1);
 
         // Add additional recipients
-        _basicOrderParameters.additionalRecipients = new AdditionalRecipient[](totalRecipients);
+        _basicOrderParameters.additionalRecipients = new AdditionalRecipient[](
+            totalRecipients
+        );
         for (
             uint256 i = 0;
             i < _basicOrderParameters.additionalRecipients.length;
             i++
         ) {
-            _basicOrderParameters.additionalRecipients[i] = AdditionalRecipient({recipient:alice, amount: 1});
+            _basicOrderParameters.additionalRecipients[
+                i
+            ] = AdditionalRecipient({ recipient: alice, amount: 1 });
         }
 
         // Validate the order.

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -143,7 +143,7 @@ contract FulfillBasicOrderTest is BaseOrderTest, LowLevelHelpers {
             i < _basicOrderParameters.additionalRecipients.length;
             i++
         ) {
-            _basicOrderParameters.additionalRecipients[i].amount = 1;
+            _basicOrderParameters.additionalRecipients[i] = AdditionalRecipient({recipient:alice, amount: 1});
         }
 
         // Validate the order.

--- a/test/foundry/utils/BaseOrderTest.sol
+++ b/test/foundry/utils/BaseOrderTest.sol
@@ -10,9 +10,9 @@ import { ERC721Recipient } from "./ERC721Recipient.sol";
 import { ERC1155Recipient } from "./ERC1155Recipient.sol";
 import { ProxyRegistry } from "../interfaces/ProxyRegistry.sol";
 import { OwnableDelegateProxy } from "../interfaces/OwnableDelegateProxy.sol";
-import { OrderType } from "../../../contracts/lib/ConsiderationEnums.sol";
+import { BasicOrderType, OrderType } from "../../../contracts/lib/ConsiderationEnums.sol";
 import { StructCopier } from "./StructCopier.sol";
-import { ConsiderationItem, AdditionalRecipient, OfferItem, Fulfillment, FulfillmentComponent, ItemType, OrderComponents, OrderParameters } from "../../../contracts/lib/ConsiderationStructs.sol";
+import { BasicOrderParameters, ConsiderationItem, AdditionalRecipient, OfferItem, Fulfillment, FulfillmentComponent, ItemType, Order, OrderComponents, OrderParameters } from "../../../contracts/lib/ConsiderationStructs.sol";
 import { ArithmeticUtil } from "./ArithmeticUtil.sol";
 import { AmountDeriver } from "../../../contracts/lib/AmountDeriver.sol";
 
@@ -88,6 +88,7 @@ contract BaseOrderTest is
     AdditionalRecipient[] additionalRecipients;
 
     uint256 internal globalTokenId;
+    uint256 internal globalSalt;
 
     event Transfer(address indexed from, address indexed to, uint256 value);
 
@@ -515,6 +516,102 @@ contract BaseOrderTest is
                 parameters.salt,
                 parameters.conduitKey,
                 counter
+            );
+    }
+
+    function getOrderParameters(address payable offerer, OrderType orderType)
+        internal
+        returns (OrderParameters memory)
+    {
+        return
+            OrderParameters(
+                offerer,
+                address(0),
+                offerItems,
+                considerationItems,
+                orderType,
+                block.timestamp,
+                block.timestamp + 1,
+                bytes32(0),
+                globalSalt++,
+                bytes32(0),
+                considerationItems.length
+            );
+    }
+
+    function toOrderComponents(OrderParameters memory _params, uint256 nonce)
+        internal
+        pure
+        returns (OrderComponents memory)
+    {
+        return
+            OrderComponents(
+                _params.offerer,
+                _params.zone,
+                _params.offer,
+                _params.consideration,
+                _params.orderType,
+                _params.startTime,
+                _params.endTime,
+                _params.zoneHash,
+                _params.salt,
+                _params.conduitKey,
+                nonce
+            );
+    }
+
+    function toBasicOrderParameters(
+        Order memory _order,
+        BasicOrderType basicOrderType
+    ) internal pure returns (BasicOrderParameters memory) {
+        return
+            BasicOrderParameters(
+                _order.parameters.consideration[0].token,
+                _order.parameters.consideration[0].identifierOrCriteria,
+                _order.parameters.consideration[0].endAmount,
+                payable(_order.parameters.offerer),
+                _order.parameters.zone,
+                _order.parameters.offer[0].token,
+                _order.parameters.offer[0].identifierOrCriteria,
+                _order.parameters.offer[0].endAmount,
+                basicOrderType,
+                _order.parameters.startTime,
+                _order.parameters.endTime,
+                _order.parameters.zoneHash,
+                _order.parameters.salt,
+                _order.parameters.conduitKey,
+                _order.parameters.conduitKey,
+                0,
+                new AdditionalRecipient[](0),
+                _order.signature
+            );
+    }
+
+    function toBasicOrderParameters(
+        OrderComponents memory _order,
+        BasicOrderType basicOrderType,
+        bytes memory signature
+    ) internal pure returns (BasicOrderParameters memory) {
+        return
+            BasicOrderParameters(
+                _order.consideration[0].token,
+                _order.consideration[0].identifierOrCriteria,
+                _order.consideration[0].endAmount,
+                payable(_order.offerer),
+                _order.zone,
+                _order.offer[0].token,
+                _order.offer[0].identifierOrCriteria,
+                _order.offer[0].endAmount,
+                basicOrderType,
+                _order.startTime,
+                _order.endTime,
+                _order.zoneHash,
+                _order.salt,
+                _order.conduitKey,
+                _order.conduitKey,
+                0,
+                new AdditionalRecipient[](0),
+                signature
             );
     }
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->
We have no tests for invalid length of additional recipients in the calldata for `FulfillBasicOrder`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add fuzz tests for invalid length of additional recipients in the calldata for `FulfillBasicOrder`, where the tests check both
1. `fulfillBasicOrder` does not revert when additional recipients length is not modified
2. `fulfillBasicOrder` does revert when additional recipients length is modified (made smaller than the actual additional recipients length)

## Testing
`forge test --match-contract FulfillBasicOrderTest` all tests pass
`forge test --match-contract NonReentrantTest` all tests pass