### PR TITLE
gas: add unchecked for ConduitController#updateChannel

### DIFF
--- a/contracts/conduit/ConduitController.sol
+++ b/contracts/conduit/ConduitController.sol
@@ -154,8 +154,11 @@ contract ConduitController is ConduitControllerInterface {
         } else if (!isOpen && channelPreviouslyOpen) {
             // Set a previously open channel as closed via "swap & pop" method.
             // Decrement located index to get the index of the closed channel.
-            uint256 removedChannelIndex = channelIndexPlusOne - 1;
-
+            uint256 removedChannelIndex;
+            // channelPreviouslyOpen already make sure channelIndexPlusOne > 0
+            unchecked {
+                removedChannelIndex = channelIndexPlusOne - 1;
+            }
             // Use length of channels array to determine index of last channel.
             uint256 finalChannelIndex = conduitProperties.channels.length - 1;
 

--- a/contracts/conduit/ConduitController.sol
+++ b/contracts/conduit/ConduitController.sol
@@ -155,7 +155,7 @@ contract ConduitController is ConduitControllerInterface {
             // Set a previously open channel as closed via "swap & pop" method.
             // Decrement located index to get the index of the closed channel.
             uint256 removedChannelIndex;
-            // channelPreviouslyOpen already make sure channelIndexPlusOne > 0
+            // channelPreviouslyOpen already ensures channelIndexPlusOne > 0
             unchecked {
                 removedChannelIndex = channelIndexPlusOne - 1;
             }


### PR DESCRIPTION
## Motivation

For the arithmetic operations that will never over/underflow, using the unchecked directive (Solidity v0.8 has default overflow/underflow checks) can save some gas from the unnecessary internal over/underflow checks.

In `ConduitController.sol#updateChannel()`, when `channelPreviouslyOpen` is `true` means that `channelIndexPlusOne != 0`, and `channelIndexPlusOne` is `uint256`, so `channelIndexPlusOne` must >= 1, then `channelIndexPlusOne - 1` will never underflow.

## Solution

add `unchecked` for that case