### PR TITLE
EIP1271 verification for non standard signature with 64 or 65 length

### DIFF
--- a/contracts/test/EIP1271WalletSpecial.sol
+++ b/contracts/test/EIP1271WalletSpecial.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.7;
+
+interface ERC20ApprovalInterface {
+    function approve(address, uint256) external returns (bool);
+}
+
+interface NFTApprovalInterface {
+    function setApprovalForAll(address, bool) external;
+}
+
+contract EIP1271WalletSpecial {
+    bytes4 private constant _EIP_1271_MAGIC_VALUE = 0x1626ba7e;
+
+    address public immutable owner;
+
+    bool public showRevertMessage;
+
+    mapping(bytes32 => bool) public digestApproved;
+
+    bool public isValid;
+
+    constructor(address _owner) {
+        owner = _owner;
+        showRevertMessage = true;
+        isValid = true;
+    }
+
+    function setValid(bool valid) external {
+        isValid = valid;
+    }
+
+    function revertWithMessage(bool showMessage) external {
+        showRevertMessage = showMessage;
+    }
+
+    function registerDigest(bytes32 digest, bool approved) external {
+        digestApproved[digest] = approved;
+    }
+
+    function approveERC20(
+        ERC20ApprovalInterface token,
+        address operator,
+        uint256 amount
+    ) external {
+        if (msg.sender != owner) {
+            revert("Only owner");
+        }
+
+        token.approve(operator, amount);
+    }
+
+    function approveNFT(NFTApprovalInterface token, address operator) external {
+        if (msg.sender != owner) {
+            revert("Only owner");
+        }
+
+        token.setApprovalForAll(operator, true);
+    }
+
+    function isValidSignature(bytes32 digest, bytes memory signature)
+        external
+        view
+        returns (bytes4)
+    {
+        if (digestApproved[digest]) {
+            return _EIP_1271_MAGIC_VALUE;
+        }
+
+        if (signature.length != 65) {
+            revert();
+        }
+
+        bytes32 a;
+        bytes32 b;
+        uint8 c;
+
+        assembly {
+            a := mload(add(signature, 0x20))
+            b := mload(add(signature, 0x40))
+            c := byte(0, mload(add(signature, 0x60)))
+        }
+
+        require(a == 0x00000000000000000000000000000000 && b == bytes32(uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)) && c == 7, "Invalid signature");
+
+        return isValid ? _EIP_1271_MAGIC_VALUE : bytes4(0xffffffff);
+    }
+}


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

EIP-1271 Signature may contains 64 or 65 bytes but isn't EIP-2098 signature. But it may be reverted if it isn't EIP-2098 signature.

EIP-1271 Signature that contains 64 or 65 bytes may be custom kind of signature for example it may be keccak256 of some value or merkle tree root.

In the case that 64 or 65 bytes EIP-1271 Signature is not EIP-2098 signature. It will be reverted with `InvalidSignature()` or `BadSignatureV(v)` because it is checked with EIP-2098 verification algorithm first and recoveredSigner may be address(0)

Assume current signature is a valid EIP-1271 signature (calling `isValidSignature` on signer return correct magicValue).
(Using EIP1271WalletSpecial that I have hardcoded an invalid EIP-2098 signature as a valid one)

```
      if (signature.length == 64) {
          // Declare temporary vs that will be decomposed into s and v.
          bytes32 vs;

          (r, vs) = abi.decode(signature, (bytes32, bytes32));

          s = vs & EIP2098_allButHighestBitMask;

          v = uint8(uint256(vs >> 255)) + 27;
      }
```

This code block will be passed. But ecrecover may return 0

If ecrecover return 0

```
      if (recoveredSigner == address(0)) {
          revert InvalidSignature();
          // Should a signer be recovered, but it doesn't match the signer...
      }
```

It will be reverted with `InvalidSignature()`.

But in fact it should be valid due to assumption above. ( must perform `_assertValidEIP1271Signature(signer, digest, signature);` )

If ecrecover return non-zero address

```
      } else if (recoveredSigner != signer) {
          // Attempt EIP-1271 static call to signer in case it's a contract.
          _assertValidEIP1271Signature(signer, digest, signature);
      }
```

This case is valid as it is calling `_assertValidEIP1271Signature(signer, digest, signature);` as expected

### Case signature length 65

```
      } else if (signature.length == 65) {
          (r, s) = abi.decode(signature, (bytes32, bytes32));
          v = uint8(signature[64]);

          // Ensure v value is properly formatted.
          if (v != 27 && v != 28) {
              revert BadSignatureV(v);
          }
      }
```

In this case, It may be reverted with revert `BadSignatureV(v);` if length is 65 but uint8(signature[64]) is not 27 or 28.

But in fact it should be valid due to assumption above. ( must perform `_assertValidEIP1271Signature(signer, digest, signature);` )

### Other length

Signature of other length is verified directly into signer contract by calling `_assertValidEIP1271Signature(signer, digest, signature);`, so it will be passed.

```
      } else {
          // For all other signature lengths, try verification via EIP-1271.
          // Attempt EIP-1271 static call to signer in case it's a contract.
          _assertValidEIP1271Signature(signer, digest, signature);

          // Return early if the ERC-1271 signature check succeeded.
          return;
      }
```

## Solution

Check isContract on signer first, if it is contract only verify EIP-1271 as contract never sign EIP-2098 under his address.

If signer is an EOA, only check for EIP-2098 as EOA never use EIP-1271.

If signer is an EOA but signature is malformed or recovered to different signer, revert.
