### PR TITLE
Optimize order status storage ptr

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -53,3 +53,4 @@ zaz                            | `1zaz1.eth`
 berndartmueller                | `berndartmueller.eth`
 dmfxyz                         | `dmfxyz.eth`
 0xf4ce                         | `0xf4ce.eth`
+phaze                          | `phaze.eth`

--- a/contracts/conduit/ConduitController.sol
+++ b/contracts/conduit/ConduitController.sol
@@ -95,11 +95,14 @@ contract ConduitController is ConduitControllerInterface {
         // Deploy the conduit via CREATE2 using the conduit key as the salt.
         new Conduit{ salt: conduitKey }();
 
+        // Initialize storage variable referencing conduit properties.
+        ConduitProperties storage conduitProperties = _conduits[conduit];
+
         // Set the supplied initial owner as the owner of the conduit.
-        _conduits[conduit].owner = initialOwner;
+        conduitProperties.owner = initialOwner;
 
         // Set conduit key used to deploy the conduit to enable reverse lookup.
-        _conduits[conduit].key = conduitKey;
+        conduitProperties.key = conduitKey;
 
         // Emit an event indicating that the conduit has been deployed.
         emit NewConduit(conduit, conduitKey);

--- a/contracts/lib/OrderValidator.sol
+++ b/contracts/lib/OrderValidator.sol
@@ -53,7 +53,7 @@ contract OrderValidator is Executor, ZoneInteraction {
         bytes memory signature
     ) internal {
         // Retrieve the order status for the given order hash.
-        OrderStatus memory orderStatus = _orderStatus[orderHash];
+        OrderStatus storage orderStatus = _orderStatus[orderHash];
 
         // Ensure order is fillable and is not cancelled.
         _verifyOrderStatus(
@@ -69,10 +69,10 @@ contract OrderValidator is Executor, ZoneInteraction {
         }
 
         // Update order status as fully filled, packing struct values.
-        _orderStatus[orderHash].isValidated = true;
-        _orderStatus[orderHash].isCancelled = false;
-        _orderStatus[orderHash].numerator = 1;
-        _orderStatus[orderHash].denominator = 1;
+        orderStatus.isValidated = true;
+        orderStatus.isCancelled = false;
+        orderStatus.numerator = 1;
+        orderStatus.denominator = 1;
     }
 
     /**
@@ -165,7 +165,7 @@ contract OrderValidator is Executor, ZoneInteraction {
         );
 
         // Retrieve the order status using the derived order hash.
-        OrderStatus memory orderStatus = _orderStatus[orderHash];
+        OrderStatus storage orderStatus = _orderStatus[orderHash];
 
         // Ensure order is fillable and is not cancelled.
         if (
@@ -276,17 +276,17 @@ contract OrderValidator is Executor, ZoneInteraction {
             // Skip overflow check: checked above unless numerator is reduced.
             unchecked {
                 // Update order status and fill amount, packing struct values.
-                _orderStatus[orderHash].isValidated = true;
-                _orderStatus[orderHash].isCancelled = false;
-                _orderStatus[orderHash].numerator = uint120(filledNumerator);
-                _orderStatus[orderHash].denominator = uint120(denominator);
+                orderStatus.isValidated = true;
+                orderStatus.isCancelled = false;
+                orderStatus.numerator = uint120(filledNumerator);
+                orderStatus.denominator = uint120(denominator);
             }
         } else {
             // Update order status and fill amount, packing struct values.
-            _orderStatus[orderHash].isValidated = true;
-            _orderStatus[orderHash].isCancelled = false;
-            _orderStatus[orderHash].numerator = uint120(numerator);
-            _orderStatus[orderHash].denominator = uint120(denominator);
+            orderStatus.isValidated = true;
+            orderStatus.isCancelled = false;
+            orderStatus.numerator = uint120(numerator);
+            orderStatus.denominator = uint120(denominator);
         }
 
         // Return order hash, a modified numerator, and a modified denominator.
@@ -311,6 +311,8 @@ contract OrderValidator is Executor, ZoneInteraction {
         // Ensure that the reentrancy guard is not currently set.
         _assertNonReentrant();
 
+        // Declare variables outside of the loop.
+        OrderStatus storage orderStatus;
         address offerer;
         address zone;
 
@@ -350,9 +352,12 @@ contract OrderValidator is Executor, ZoneInteraction {
                     order.counter
                 );
 
+                // Retrieve the order status using the derived order hash.
+                orderStatus = _orderStatus[orderHash];
+
                 // Update the order status as not valid and cancelled.
-                _orderStatus[orderHash].isValidated = false;
-                _orderStatus[orderHash].isCancelled = true;
+                orderStatus.isValidated = false;
+                orderStatus.isCancelled = true;
 
                 // Emit an event signifying that the order has been cancelled.
                 emit OrderCancelled(orderHash, offerer, zone);
@@ -389,6 +394,7 @@ contract OrderValidator is Executor, ZoneInteraction {
         _assertNonReentrant();
 
         // Declare variables outside of the loop.
+        OrderStatus storage orderStatus;
         bytes32 orderHash;
         address offerer;
 
@@ -414,7 +420,7 @@ contract OrderValidator is Executor, ZoneInteraction {
                 );
 
                 // Retrieve the order status using the derived order hash.
-                OrderStatus memory orderStatus = _orderStatus[orderHash];
+                orderStatus = _orderStatus[orderHash];
 
                 // Ensure order is fillable and retrieve the filled amount.
                 _verifyOrderStatus(
@@ -430,7 +436,7 @@ contract OrderValidator is Executor, ZoneInteraction {
                     _verifySignature(offerer, orderHash, order.signature);
 
                     // Update order status to mark the order as valid.
-                    _orderStatus[orderHash].isValidated = true;
+                    orderStatus.isValidated = true;
 
                     // Emit an event signifying the order has been validated.
                     emit OrderValidated(
@@ -477,7 +483,7 @@ contract OrderValidator is Executor, ZoneInteraction {
         )
     {
         // Retrieve the order status using the order hash.
-        OrderStatus memory orderStatus = _orderStatus[orderHash];
+        OrderStatus storage orderStatus = _orderStatus[orderHash];
 
         // Return the fields on the order status.
         return (

--- a/contracts/lib/Verifiers.sol
+++ b/contracts/lib/Verifiers.sol
@@ -85,7 +85,7 @@ contract Verifiers is Assertions, SignatureVerification {
     }
 
     /**
-     * @dev Internal pure function to validate that a given order is fillable
+     * @dev Internal view function to validate that a given order is fillable
      *      and not cancelled based on the order status.
      *
      * @param orderHash       The order hash.
@@ -101,10 +101,10 @@ contract Verifiers is Assertions, SignatureVerification {
      */
     function _verifyOrderStatus(
         bytes32 orderHash,
-        OrderStatus memory orderStatus,
+        OrderStatus storage orderStatus,
         bool onlyAllowUnused,
         bool revertOnInvalid
-    ) internal pure returns (bool valid) {
+    ) internal view returns (bool valid) {
         // Ensure that the order has not been cancelled.
         if (orderStatus.isCancelled) {
             // Only revert if revertOnInvalid has been supplied as true.
@@ -116,14 +116,17 @@ contract Verifiers is Assertions, SignatureVerification {
             return false;
         }
 
+        // Read order status numerator from storage and place on stack.
+        uint256 orderStatusNumerator = orderStatus.numerator;
+
         // If the order is not entirely unused...
-        if (orderStatus.numerator != 0) {
+        if (orderStatusNumerator != 0) {
             // ensure the order has not been partially filled when not allowed.
             if (onlyAllowUnused) {
                 // Always revert on partial fills when onlyAllowUnused is true.
                 revert OrderPartiallyFilled(orderHash);
                 // Otherwise, ensure that order has not been entirely filled.
-            } else if (orderStatus.numerator >= orderStatus.denominator) {
+            } else if (orderStatusNumerator >= orderStatus.denominator) {
                 // Only revert if revertOnInvalid has been supplied as true.
                 if (revertOnInvalid) {
                     revert OrderAlreadyFilled(orderHash);

--- a/reference/conduit/ReferenceConduitController.sol
+++ b/reference/conduit/ReferenceConduitController.sol
@@ -97,11 +97,14 @@ contract ReferenceConduitController is ConduitControllerInterface {
         // Deploy the conduit via CREATE2 using the conduit key as the salt.
         new ReferenceConduit{ salt: conduitKey }();
 
+        // Initialize storage variable referencing conduit properties.
+        ConduitProperties storage conduitProperties = _conduits[conduit];
+
         // Set the supplied initial owner as the owner of the conduit.
-        _conduits[conduit].owner = initialOwner;
+        conduitProperties.owner = initialOwner;
 
         // Set conduit key used to deploy the conduit to enable reverse lookup.
-        _conduits[conduit].key = conduitKey;
+        conduitProperties.key = conduitKey;
 
         // Emit an event indicating that the conduit has been deployed.
         emit NewConduit(conduit, conduitKey);

--- a/reference/lib/ReferenceOrderValidator.sol
+++ b/reference/lib/ReferenceOrderValidator.sol
@@ -56,7 +56,7 @@ contract ReferenceOrderValidator is
         bytes memory signature
     ) internal {
         // Retrieve the order status for the given order hash.
-        OrderStatus memory orderStatus = _orderStatus[orderHash];
+        OrderStatus storage orderStatus = _orderStatus[orderHash];
 
         // Ensure order is fillable and is not cancelled.
         _verifyOrderStatus(
@@ -72,10 +72,10 @@ contract ReferenceOrderValidator is
         }
 
         // Update order status as fully filled, packing struct values.
-        _orderStatus[orderHash].isValidated = true;
-        _orderStatus[orderHash].isCancelled = false;
-        _orderStatus[orderHash].numerator = 1;
-        _orderStatus[orderHash].denominator = 1;
+        orderStatus.isValidated = true;
+        orderStatus.isCancelled = false;
+        orderStatus.numerator = 1;
+        orderStatus.denominator = 1;
     }
 
     /**
@@ -168,7 +168,7 @@ contract ReferenceOrderValidator is
         );
 
         // Retrieve the order status using the derived order hash.
-        OrderStatus memory orderStatus = _orderStatus[orderHash];
+        OrderStatus storage orderStatus = _orderStatus[orderHash];
 
         // Ensure order is fillable and is not cancelled.
         if (
@@ -248,16 +248,16 @@ contract ReferenceOrderValidator is
             }
 
             // Update order status and fill amount, packing struct values.
-            _orderStatus[orderHash].isValidated = true;
-            _orderStatus[orderHash].isCancelled = false;
-            _orderStatus[orderHash].numerator = uint120(filledNumerator);
-            _orderStatus[orderHash].denominator = uint120(denominator);
+            orderStatus.isValidated = true;
+            orderStatus.isCancelled = false;
+            orderStatus.numerator = uint120(filledNumerator);
+            orderStatus.denominator = uint120(denominator);
         } else {
             // Update order status and fill amount, packing struct values.
-            _orderStatus[orderHash].isValidated = true;
-            _orderStatus[orderHash].isCancelled = false;
-            _orderStatus[orderHash].numerator = uint120(numerator);
-            _orderStatus[orderHash].denominator = uint120(denominator);
+            orderStatus.isValidated = true;
+            orderStatus.isCancelled = false;
+            orderStatus.numerator = uint120(numerator);
+            orderStatus.denominator = uint120(denominator);
         }
 
         // Return order hash, new numerator and denominator.
@@ -301,6 +301,8 @@ contract ReferenceOrderValidator is
         notEntered
         returns (bool)
     {
+        // Declare variables outside of the loop.
+        OrderStatus storage orderStatus;
         address offerer;
         address zone;
 
@@ -338,9 +340,12 @@ contract ReferenceOrderValidator is
                 order.counter
             );
 
+            // Retrieve the order status using the derived order hash.
+            orderStatus = _orderStatus[orderHash];
+
             // Update the order status as not valid and cancelled.
-            _orderStatus[orderHash].isValidated = false;
-            _orderStatus[orderHash].isCancelled = true;
+            orderStatus.isValidated = false;
+            orderStatus.isCancelled = true;
 
             // Emit an event signifying that the order has been cancelled.
             emit OrderCancelled(orderHash, offerer, zone);
@@ -365,6 +370,7 @@ contract ReferenceOrderValidator is
         returns (bool)
     {
         // Declare variables outside of the loop.
+        OrderStatus storage orderStatus;
         bytes32 orderHash;
         address offerer;
 
@@ -388,7 +394,7 @@ contract ReferenceOrderValidator is
             );
 
             // Retrieve the order status using the derived order hash.
-            OrderStatus memory orderStatus = _orderStatus[orderHash];
+            orderStatus = _orderStatus[orderHash];
 
             // Ensure order is fillable and retrieve the filled amount.
             _verifyOrderStatus(
@@ -404,7 +410,7 @@ contract ReferenceOrderValidator is
                 _verifySignature(offerer, orderHash, order.signature);
 
                 // Update order status to mark the order as valid.
-                _orderStatus[orderHash].isValidated = true;
+                orderStatus.isValidated = true;
 
                 // Emit an event signifying the order has been validated.
                 emit OrderValidated(orderHash, offerer, orderParameters.zone);
@@ -442,7 +448,7 @@ contract ReferenceOrderValidator is
         )
     {
         // Retrieve the order status using the order hash.
-        OrderStatus memory orderStatus = _orderStatus[orderHash];
+        OrderStatus storage orderStatus = _orderStatus[orderHash];
 
         // Return the fields on the order status.
         return (

--- a/reference/lib/ReferenceVerifiers.sol
+++ b/reference/lib/ReferenceVerifiers.sol
@@ -90,7 +90,7 @@ contract ReferenceVerifiers is
     }
 
     /**
-     * @dev Internal pure function to validate that a given order is fillable
+     * @dev Internal view function to validate that a given order is fillable
      *      and not cancelled based on the order status.
      *
      * @param orderHash       The order hash.
@@ -106,10 +106,10 @@ contract ReferenceVerifiers is
      */
     function _verifyOrderStatus(
         bytes32 orderHash,
-        OrderStatus memory orderStatus,
+        OrderStatus storage orderStatus,
         bool onlyAllowUnused,
         bool revertOnInvalid
-    ) internal pure returns (bool valid) {
+    ) internal view returns (bool valid) {
         // Ensure that the order has not been cancelled.
         if (orderStatus.isCancelled) {
             // Only revert if revertOnInvalid has been supplied as true.
@@ -120,6 +120,9 @@ contract ReferenceVerifiers is
             // Return false as the order status is invalid.
             return false;
         }
+
+        // Read order status numerator from storage and place on stack.
+        uint256 orderStatusNumerator = orderStatus.numerator;
 
         // If the order is not entirely unused...
         if (orderStatus.numerator != 0) {


### PR DESCRIPTION
Ran `yarn profile` on this (#395) and main. Here's relevant section of main:
```
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  fulfillAdvancedOrder            ·     101335  ·     210427  ·      161497  ·          126  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  fulfillAvailableAdvancedOrders  ·     138952  ·     229437  ·      194772  ·           19  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  fulfillAvailableOrders          ·     172835  ·     229108  ·      206747  ·           13  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  fulfillBasicOrder               ·      93691  ·    1629762  ·      667123  ·          160  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  fulfillOrder                    ·     102924  ·     213918  ·      174928  ·          105  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  incrementCounter                ·          -  ·          -  ·       47029  ·            6  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  matchAdvancedOrders             ·     206287  ·     273293  ·      255451  ·           67  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  matchOrders                     ·     166715  ·     366203  ·      267990  ·          105  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  validate                        ·      58085  ·      69476  ·       66906  ·           25  ·          -  │
······························|··································|·············|·············|··············|···············|··············
```

and this one by @0xPhaze:
```
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  fulfillAdvancedOrder            ·     100495  ·     209364  ·      160456  ·          126  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  fulfillAvailableAdvancedOrders  ·     137882  ·     227329  ·      193387  ·           19  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  fulfillAvailableOrders          ·     171775  ·     226974  ·      205233  ·           13  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  fulfillBasicOrder               ·      92295  ·    1628366  ·      665731  ·          160  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  fulfillOrder                    ·     101849  ·     212854  ·      173852  ·          105  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  incrementCounter                ·          -  ·          -  ·       47029  ·            6  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  matchAdvancedOrders             ·     204322  ·     271122  ·      252918  ·           67  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  matchOrders                     ·     164585  ·     364061  ·      265848  ·          105  ·          -  │
······························|··································|·············|·············|··············|···············|··············
|  Seaport                    ·  validate                        ·      57801  ·      69256  ·       66679  ·           25  ·          -  │
······························|··································|·············|·············|··············|···············|··············
```

Looks materially cheaper across the board, over 200 gas cheaper in the base case and quite a bit more than that in complex cases.