### PR TITLE
First ecrecover is tried and if that fails ERC-1271 is tried

### DIFF
--- a/contracts/interfaces/SignatureVerificationErrors.sol
+++ b/contracts/interfaces/SignatureVerificationErrors.sol
@@ -8,13 +8,6 @@ pragma solidity >=0.8.7;
  *         verification.
  */
 interface SignatureVerificationErrors {
-    /**
-     * @dev Revert with an error when a signature that does not contain a v
-     *      value of 27 or 28 has been supplied.
-     *
-     * @param v The invalid v value.
-     */
-    error BadSignatureV(uint8 v);
 
     /**
      * @dev Revert with an error when the signer recovered by the supplied

--- a/contracts/interfaces/SignatureVerificationErrors.sol
+++ b/contracts/interfaces/SignatureVerificationErrors.sol
@@ -8,7 +8,6 @@ pragma solidity >=0.8.7;
  *         verification.
  */
 interface SignatureVerificationErrors {
-
     /**
      * @dev Revert with an error when the signer recovered by the supplied
      *      signature does not match the offerer or an allowed EIP-1271 signer

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -33,6 +33,10 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
         bytes32 digest,
         bytes memory signature
     ) internal view {
+        if (signer == 0) {
+           // Make sure to never allow the ecrecover "error" case
+           revert InvalidSigner();
+        }
         address recoveredSigner = _tryEcRecoverSignature(digest, signature);
         // Found a match: recovered address matches the signer
         if (recoveredSigner == signer) return;

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -33,7 +33,7 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
         bytes32 digest,
         bytes memory signature
     ) internal view {
-        if (signer == 0) {
+        if (signer == address(0)) {
            // Make sure to never allow the ecrecover "error" case
            revert InvalidSigner();
         }

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -104,7 +104,7 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
                     byte(v, ECDSA_twentySeventhAndTwentyEighthBytesSet)
                 )
             }
-            // Ensure v value is properly formatted. Return invalid value if not
+            // Early abort if v value is out of range to save the cost of ecrecover.
             if (vIsInvalid) {
                 return (address(0));
             }

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -34,8 +34,8 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
         bytes memory signature
     ) internal view {
         if (signer == address(0)) {
-           // Make sure to never allow the ecrecover "error" case
-           revert InvalidSigner();
+            // Make sure to never allow the ecrecover "error" case
+            revert InvalidSigner();
         }
         address recoveredSigner = _tryEcRecoverSignature(digest, signature);
         // Found a match: recovered address matches the signer
@@ -108,7 +108,7 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
                     byte(v, ECDSA_twentySeventhAndTwentyEighthBytesSet)
                 )
             }
-            // Early abort if v value is out of range to save the cost of ecrecover.
+            // Ensure v value is properly formatted. Return invalid value if not
             if (vIsInvalid) {
                 return (address(0));
             }

--- a/reference/lib/ReferenceSignatureVerification.sol
+++ b/reference/lib/ReferenceSignatureVerification.sol
@@ -17,12 +17,9 @@ import "contracts/lib/ConsiderationConstants.sol";
  */
 contract ReferenceSignatureVerification is SignatureVerificationErrors {
     /**
-     * @dev Internal view function to verify the signature of an order. An
-     *      ERC-1271 fallback will be attempted if either the signature length
-     *      is not 32 or 33 bytes or if the recovered signer does not match the
-     *      supplied signer. Note that in cases where a 32 or 33 byte signature
-     *      is supplied, only standard ECDSA signatures that recover to a
-     *      non-zero address are supported.
+     * @dev Internal view function to verify the signature of an order.
+     *      First ecrecover is tried and if that fails ERC-1271 is tried
+     *      Note: This order keeps the gas costs limited
      *
      * @param signer    The signer for the order.
      * @param digest    The digest to verify the signature against.
@@ -34,6 +31,35 @@ contract ReferenceSignatureVerification is SignatureVerificationErrors {
         bytes32 digest,
         bytes memory signature
     ) internal view {
+        if (signer == address(0)) {
+            // Make sure to never allow the ecrecover "error" case
+            revert InvalidSigner();
+        }
+        address recoveredSigner = _tryEcRecoverSignature(digest, signature);
+        // Found a match: recovered address matches the signer
+        if (recoveredSigner == signer) return;
+
+        // Attempt EIP-1271 static call to signer in case it's a contract.
+        // reverts when not successful
+        _assertValidEIP1271Signature(signer, digest, signature);
+    }
+
+    /**
+     * @dev Internal view function to verify the signature of an order. An
+     *      EcRecover will be attempted if either the signature length
+     *      is 64 or 65. Note only standard ECDSA signatures that recover to a
+     *      non-zero address are supported.
+     *
+     * @param digest    The digest to verify the signature against.
+     * @param signature A signature from the signer indicating that the order
+     *                  has been approved.
+     */
+
+    function _tryEcRecoverSignature(bytes32 digest, bytes memory signature)
+        internal
+        view
+        returns (address)
+    {
         // Declare r, s, and v signature parameters.
         bytes32 r;
         bytes32 s;
@@ -55,28 +81,13 @@ contract ReferenceSignatureVerification is SignatureVerificationErrors {
 
             // Ensure v value is properly formatted.
             if (v != 27 && v != 28) {
-                revert BadSignatureV(v);
+                return (address(0));
             }
         } else {
-            // For all other signature lengths, try verification via EIP-1271.
-            // Attempt EIP-1271 static call to signer in case it's a contract.
-            _assertValidEIP1271Signature(signer, digest, signature);
-
-            // Return early if the ERC-1271 signature check succeeded.
-            return;
+            return (address(0));
         }
 
-        // Attempt to recover signer using the digest and signature parameters.
-        address recoveredSigner = ecrecover(digest, v, r, s);
-
-        // Disallow invalid signers.
-        if (recoveredSigner == address(0)) {
-            revert InvalidSignature();
-            // Should a signer be recovered, but it doesn't match the signer...
-        } else if (recoveredSigner != signer) {
-            // Attempt EIP-1271 static call to signer in case it's a contract.
-            _assertValidEIP1271Signature(signer, digest, signature);
-        }
+        return ecrecover(digest, v, r, s);
     }
 
     /**

--- a/test/index.js
+++ b/test/index.js
@@ -10548,7 +10548,7 @@ describe(`Consideration (version: ${VERSION}) — initial test suite`, function 
             .fulfillBasicOrder(basicOrderParameters, {
               value,
             })
-        ).to.be.revertedWith("BadSignatureV(1)");
+        ).to.be.revertedWith("InvalidSigner"); // was BadSignatureV(1)");
 
         // construct an invalid signature
         basicOrderParameters.signature = "0x".padEnd(130, "f") + "1c";
@@ -10559,7 +10559,7 @@ describe(`Consideration (version: ${VERSION}) — initial test suite`, function 
             .fulfillBasicOrder(basicOrderParameters, {
               value,
             })
-        ).to.be.revertedWith("InvalidSignature");
+        ).to.be.revertedWith("InvalidSigner"); // was InvalidSignature");
 
         basicOrderParameters.signature = originalSignature;
 


### PR DESCRIPTION
This is an alternative solution to https://github.com/ProjectOpenSea/seaport/pull/441

## Motivation
The current solution fails with Gnosis safe.
Verifying a the signer is a contract wallet is relative expensive, so this solution tries ecrecover first. 

## Solution
First ecrecover is tried and if that fails ERC-1271 is tried
