### PR TITLE
Gas opt: skip `remaining` calculation when not necessary

### DIFF
--- a/contracts/lib/AmountDeriver.sol
+++ b/contracts/lib/AmountDeriver.sol
@@ -142,7 +142,7 @@ contract AmountDeriver is AmountDerivationErrors {
         uint256 numerator,
         uint256 denominator,
         uint256 elapsed,
-        uint256 remaining,
+        // uint256 remaining,
         uint256 duration,
         bool roundUp
     ) internal pure returns (uint256 amount) {
@@ -156,7 +156,8 @@ contract AmountDeriver is AmountDerivationErrors {
                 _getFraction(numerator, denominator, startAmount),
                 _getFraction(numerator, denominator, endAmount),
                 elapsed,
-                remaining,
+                // remaining,
+                duration - elapsed,
                 duration,
                 roundUp
             );

--- a/contracts/lib/AmountDeriver.sol
+++ b/contracts/lib/AmountDeriver.sol
@@ -17,15 +17,15 @@ import "./ConsiderationConstants.sol";
  */
 contract AmountDeriver is AmountDerivationErrors {
     /**
-     * @dev Internal pure function to derive the current amount of a given item
+     * @dev Internal view function to derive the current amount of a given item
      *      based on the current price, the starting price, and the ending
      *      price. If the start and end prices differ, the current price will be
      *      interpolated on a linear basis.
      *
      * @param startAmount The starting amount of the item.
      * @param endAmount   The ending amount of the item.
-     * @param startTime   The starting time of the order
-     * @param endTime     The end time of the order
+     * @param startTime   The starting time of the order.
+     * @param endTime     The end time of the order.
      * @param roundUp     A boolean indicating whether the resultant amount
      *                    should be rounded up or down.
      *
@@ -127,7 +127,7 @@ contract AmountDeriver is AmountDerivationErrors {
     }
 
     /**
-     * @dev Internal pure function to apply a fraction to a consideration
+     * @dev Internal view function to apply a fraction to a consideration
      * or offer item.
      *
      * @param startAmount     The starting amount of the item.
@@ -135,8 +135,8 @@ contract AmountDeriver is AmountDerivationErrors {
      * @param numerator       A value indicating the portion of the order that
      *                        should be filled.
      * @param denominator     A value indicating the total size of the order.
-     * @param startTime       The starting time of the order
-     * @param endTime         The end time of the order
+     * @param startTime       The starting time of the order.
+     * @param endTime         The end time of the order.
      * @param roundUp         A boolean indicating whether the resultant
      *                        amount should be rounded up or down.
      *

--- a/contracts/lib/AmountDeriver.sol
+++ b/contracts/lib/AmountDeriver.sol
@@ -21,10 +21,11 @@ contract AmountDeriver is AmountDerivationErrors {
      *      based on the current price, the starting price, and the ending
      *      price. If the start and end prices differ, the current price will be
      *      interpolated on a linear basis.
-     *      Note that this function expects that startTime is lower than the current
-     *      block timestamp and endTime is greater than the current block timestamp.
-     *      If this condition is not upheld, the duration/elapsed/remaining variables
-     *      will underflow.
+     * @notice This function expects that the startTime parameter of
+     *      orderParameters is not greater than the current block timestamp
+     *      and that the endTime parameter is greater than the current block
+     *      timestamp. If this condition is not upheld, duration / elapsed /
+     *      remaining variables will underflow.
      *
      * @param startAmount The starting amount of the item.
      * @param endAmount   The ending amount of the item.

--- a/contracts/lib/AmountDeriver.sol
+++ b/contracts/lib/AmountDeriver.sol
@@ -24,6 +24,8 @@ contract AmountDeriver is AmountDerivationErrors {
      *
      * @param startAmount The starting amount of the item.
      * @param endAmount   The ending amount of the item.
+     * @param startTime   The starting time of the order
+     * @param endTime     The end time of the order
      * @param roundUp     A boolean indicating whether the resultant amount
      *                    should be rounded up or down.
      *
@@ -129,6 +131,8 @@ contract AmountDeriver is AmountDerivationErrors {
      * @param numerator       A value indicating the portion of the order that
      *                        should be filled.
      * @param denominator     A value indicating the total size of the order.
+     * @param startTime       The starting time of the order
+     * @param endTime         The end time of the order
      * @param roundUp         A boolean indicating whether the resultant
      *                        amount should be rounded up or down.
      *

--- a/contracts/lib/AmountDeriver.sol
+++ b/contracts/lib/AmountDeriver.sol
@@ -43,9 +43,13 @@ contract AmountDeriver is AmountDerivationErrors {
             // Leave extra amount to add for rounding at zero (i.e. round down).
             uint256 extraCeiling = 0;
 
+            // Derive the duration for the order and place it on the stack.
             uint256 duration = endTime - startTime;
+
+            // Derive time elapsed since the order started & place on stack.
             uint256 elapsed = block.timestamp - startTime;
-            // Derive time remaining until order expires
+
+            // Derive time remaining until order expires and place on stack.
             uint256 remaining = duration - elapsed;
 
             // If rounding up, set rounding factor to one less than denominator.

--- a/contracts/lib/AmountDeriver.sol
+++ b/contracts/lib/AmountDeriver.sol
@@ -25,7 +25,6 @@ contract AmountDeriver is AmountDerivationErrors {
      * @param startAmount The starting amount of the item.
      * @param endAmount   The ending amount of the item.
      * @param elapsed     The time elapsed since the order's start time.
-     * @param remaining   The time left until the order's end time.
      * @param duration    The total duration of the order.
      * @param roundUp     A boolean indicating whether the resultant amount
      *                    should be rounded up or down.
@@ -36,7 +35,6 @@ contract AmountDeriver is AmountDerivationErrors {
         uint256 startAmount,
         uint256 endAmount,
         uint256 elapsed,
-        uint256 remaining,
         uint256 duration,
         bool roundUp
     ) internal pure returns (uint256) {
@@ -52,6 +50,9 @@ contract AmountDeriver is AmountDerivationErrors {
                     extraCeiling = duration - 1;
                 }
             }
+
+            // Derive time remaining until order expires
+            uint256 remaining = duration - elapsed;
 
             // Aggregate new amounts weighted by time with rounding factor.
             // prettier-ignore
@@ -129,7 +130,6 @@ contract AmountDeriver is AmountDerivationErrors {
      *                        should be filled.
      * @param denominator     A value indicating the total size of the order.
      * @param elapsed         The time elapsed since the order's start time.
-     * @param remaining       The time left until the order's end time.
      * @param duration        The total duration of the order.
      * @param roundUp         A boolean indicating whether the resultant
      *                        amount should be rounded up or down.
@@ -142,7 +142,6 @@ contract AmountDeriver is AmountDerivationErrors {
         uint256 numerator,
         uint256 denominator,
         uint256 elapsed,
-        // uint256 remaining,
         uint256 duration,
         bool roundUp
     ) internal pure returns (uint256 amount) {
@@ -156,8 +155,6 @@ contract AmountDeriver is AmountDerivationErrors {
                 _getFraction(numerator, denominator, startAmount),
                 _getFraction(numerator, denominator, endAmount),
                 elapsed,
-                // remaining,
-                duration - elapsed,
                 duration,
                 roundUp
             );

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -237,12 +237,6 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 uint256 startTime = advancedOrder.parameters.startTime;
                 uint256 endTime = advancedOrder.parameters.endTime;
 
-                // Derive the duration for the order and place it on the stack.
-                // uint256 duration = advancedOrder.parameters.endTime - startTime;
-
-                // Derive time elapsed since the order started & place on stack.
-                // uint256 elapsed = block.timestamp - startTime;
-
                 // Retrieve array of offer items for the order in question.
                 OfferItem[] memory offer = advancedOrder.parameters.offer;
 
@@ -283,8 +277,6 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                         offerItem.endAmount,
                         startTime,
                         endTime,
-                        // elapsed,
-                        // duration,
                         false // round down
                     );
                 }
@@ -337,8 +329,6 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                             considerationItem.endAmount,
                             startTime,
                             endTime,
-                            // elapsed,
-                            // duration,
                             true // round up
                         )
                     );

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -235,12 +235,13 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
 
                 // Place the start time for the order on the stack.
                 uint256 startTime = advancedOrder.parameters.startTime;
+                uint256 endTime = advancedOrder.parameters.endTime;
 
                 // Derive the duration for the order and place it on the stack.
-                uint256 duration = advancedOrder.parameters.endTime - startTime;
+                // uint256 duration = advancedOrder.parameters.endTime - startTime;
 
                 // Derive time elapsed since the order started & place on stack.
-                uint256 elapsed = block.timestamp - startTime;
+                // uint256 elapsed = block.timestamp - startTime;
 
                 // Retrieve array of offer items for the order in question.
                 OfferItem[] memory offer = advancedOrder.parameters.offer;
@@ -280,8 +281,10 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                     offerItem.startAmount = _locateCurrentAmount(
                         offerItem.startAmount,
                         offerItem.endAmount,
-                        elapsed,
-                        duration,
+                        startTime,
+                        endTime,
+                        // elapsed,
+                        // duration,
                         false // round down
                     );
                 }
@@ -332,8 +335,10 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                         _locateCurrentAmount(
                             considerationItem.startAmount,
                             considerationItem.endAmount,
-                            elapsed,
-                            duration,
+                            startTime,
+                            endTime,
+                            // elapsed,
+                            // duration,
                             true // round up
                         )
                     );

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -236,7 +236,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 // Place the start time for the order on the stack.
                 uint256 startTime = advancedOrder.parameters.startTime;
 
-                // Place the end for the order on the stack.
+                // Place the end time for the order on the stack.
                 uint256 endTime = advancedOrder.parameters.endTime;
 
                 // Retrieve array of offer items for the order in question.

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -235,6 +235,8 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
 
                 // Place the start time for the order on the stack.
                 uint256 startTime = advancedOrder.parameters.startTime;
+
+                // Place the end for the order on the stack.
                 uint256 endTime = advancedOrder.parameters.endTime;
 
                 // Retrieve array of offer items for the order in question.

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -242,9 +242,6 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 // Derive time elapsed since the order started & place on stack.
                 uint256 elapsed = block.timestamp - startTime;
 
-                // Derive time remaining until order expires and place on stack.
-                uint256 remaining = duration - elapsed;
-
                 // Retrieve array of offer items for the order in question.
                 OfferItem[] memory offer = advancedOrder.parameters.offer;
 
@@ -284,7 +281,6 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                         offerItem.startAmount,
                         offerItem.endAmount,
                         elapsed,
-                        remaining,
                         duration,
                         false // round down
                     );
@@ -337,7 +333,6 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                             considerationItem.startAmount,
                             considerationItem.endAmount,
                             elapsed,
-                            remaining,
                             duration,
                             true // round up
                         )

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -158,8 +158,8 @@ contract OrderFulfiller is
         address recipient
     ) internal {
         // Derive order duration, time elapsed, and time remaining.
-        uint256 duration = orderParameters.endTime - orderParameters.startTime;
-        uint256 elapsed = block.timestamp - orderParameters.startTime;
+        // uint256 duration = orderParameters.endTime - orderParameters.startTime;
+        // uint256 elapsed = block.timestamp - orderParameters.startTime;
 
         // Put ether value supplied by the caller on the stack.
         uint256 etherRemaining = msg.value;
@@ -223,8 +223,8 @@ contract OrderFulfiller is
                         offerItem.endAmount,
                         numerator,
                         denominator,
-                        elapsed,
-                        duration,
+                        orderParameters.startTime,
+                        orderParameters.endTime,
                         false
                     );
 
@@ -311,8 +311,8 @@ contract OrderFulfiller is
                     considerationItem.endAmount,
                     numerator,
                     denominator,
-                    elapsed,
-                    duration,
+                    orderParameters.startTime,
+                    orderParameters.endTime,
                     true
                 );
 

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -157,10 +157,6 @@ contract OrderFulfiller is
         bytes32 fulfillerConduitKey,
         address recipient
     ) internal {
-        // Derive order duration, time elapsed, and time remaining.
-        // uint256 duration = orderParameters.endTime - orderParameters.startTime;
-        // uint256 elapsed = block.timestamp - orderParameters.startTime;
-
         // Put ether value supplied by the caller on the stack.
         uint256 etherRemaining = msg.value;
 

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -157,6 +157,9 @@ contract OrderFulfiller is
         bytes32 fulfillerConduitKey,
         address recipient
     ) internal {
+        uint256 startTime = orderParameters.startTime;
+        uint256 endTime = orderParameters.endTime;
+
         // Put ether value supplied by the caller on the stack.
         uint256 etherRemaining = msg.value;
 
@@ -219,8 +222,8 @@ contract OrderFulfiller is
                         offerItem.endAmount,
                         numerator,
                         denominator,
-                        orderParameters.startTime,
-                        orderParameters.endTime,
+                        startTime,
+                        endTime,
                         false
                     );
 
@@ -307,8 +310,8 @@ contract OrderFulfiller is
                     considerationItem.endAmount,
                     numerator,
                     denominator,
-                    orderParameters.startTime,
-                    orderParameters.endTime,
+                    startTime,
+                    endTime,
                     true
                 );
 

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -160,7 +160,6 @@ contract OrderFulfiller is
         // Derive order duration, time elapsed, and time remaining.
         uint256 duration = orderParameters.endTime - orderParameters.startTime;
         uint256 elapsed = block.timestamp - orderParameters.startTime;
-        uint256 remaining = duration - elapsed;
 
         // Put ether value supplied by the caller on the stack.
         uint256 etherRemaining = msg.value;
@@ -225,7 +224,6 @@ contract OrderFulfiller is
                         numerator,
                         denominator,
                         elapsed,
-                        remaining,
                         duration,
                         false
                     );
@@ -314,7 +312,6 @@ contract OrderFulfiller is
                     numerator,
                     denominator,
                     elapsed,
-                    remaining,
                     duration,
                     true
                 );

--- a/reference/lib/ReferenceAmountDeriver.sol
+++ b/reference/lib/ReferenceAmountDeriver.sol
@@ -17,15 +17,15 @@ import { FractionData } from "./ReferenceConsiderationStructs.sol";
  */
 contract ReferenceAmountDeriver is AmountDerivationErrors {
     /**
-     * @dev Internal pure function to derive the current amount of a given item
+     * @dev Internal view function to derive the current amount of a given item
      *      based on the current price, the starting price, and the ending
      *      price. If the start and end prices differ, the current price will be
      *      interpolated on a linear basis.
      *
      * @param startAmount The starting amount of the item.
      * @param endAmount   The ending amount of the item.
-     * @param startTime   The starting time of the order
-     * @param endTime     The end time of the order
+     * @param startTime   The starting time of the order.
+     * @param endTime     The end time of the order.
      * @param roundUp     A boolean indicating whether the resultant amount
      *                    should be rounded up or down.
      *
@@ -108,7 +108,7 @@ contract ReferenceAmountDeriver is AmountDerivationErrors {
     }
 
     /**
-     * @dev Internal pure function to apply a fraction to a consideration
+     * @dev Internal view function to apply a fraction to a consideration
      * or offer item.
      *
      * @param startAmount     The starting amount of the item.

--- a/reference/lib/ReferenceAmountDeriver.sol
+++ b/reference/lib/ReferenceAmountDeriver.sol
@@ -11,7 +11,7 @@ import { FractionData } from "./ReferenceConsiderationStructs.sol";
 /**
  * @title AmountDeriver
  * @author 0age
- * @notice AmountDeriver contains pure functions related to deriving item
+ * @notice AmountDeriver contains view and pure functions related to deriving item
  *         amounts based on partial fill quantity and on linear interpolation
  *         based on current time when the start amount and end amount differ.
  */

--- a/reference/lib/ReferenceAmountDeriver.sol
+++ b/reference/lib/ReferenceAmountDeriver.sol
@@ -24,9 +24,8 @@ contract ReferenceAmountDeriver is AmountDerivationErrors {
      *
      * @param startAmount The starting amount of the item.
      * @param endAmount   The ending amount of the item.
-     * @param elapsed     The time elapsed since the order's start time.
-     * @param remaining   The time left until the order's end time.
-     * @param duration    The total duration of the order.
+     * @param startTime   The starting time of the order
+     * @param endTime     The end time of the order
      * @param roundUp     A boolean indicating whether the resultant amount
      *                    should be rounded up or down.
      *
@@ -35,15 +34,23 @@ contract ReferenceAmountDeriver is AmountDerivationErrors {
     function _locateCurrentAmount(
         uint256 startAmount,
         uint256 endAmount,
-        uint256 elapsed,
-        uint256 remaining,
-        uint256 duration,
+        uint256 startTime,
+        uint256 endTime,
         bool roundUp
-    ) internal pure returns (uint256) {
+    ) internal view returns (uint256) {
         // Only modify end amount if it doesn't already equal start amount.
         if (startAmount != endAmount) {
             // Leave extra amount to add for rounding at zero (i.e. round down).
             uint256 extraCeiling = 0;
+
+            // Derive the duration for the order and place it on the stack.
+            uint256 duration = endTime - startTime;
+
+            // Derive time elapsed since the order started & place on stack.
+            uint256 elapsed = block.timestamp - startTime;
+
+            // Derive time remaining until order expires and place on stack.
+            uint256 remaining = duration - elapsed;
 
             // If rounding up, set rounding factor to one less than denominator.
             if (roundUp) {
@@ -118,7 +125,7 @@ contract ReferenceAmountDeriver is AmountDerivationErrors {
         uint256 endAmount,
         FractionData memory fractionData,
         bool roundUp
-    ) internal pure returns (uint256 amount) {
+    ) internal view returns (uint256 amount) {
         // If start amount equals end amount, apply fraction to end amount.
         if (startAmount == endAmount) {
             amount = _getFraction(
@@ -139,9 +146,8 @@ contract ReferenceAmountDeriver is AmountDerivationErrors {
                     fractionData.denominator,
                     endAmount
                 ),
-                fractionData.elapsed,
-                fractionData.remaining,
-                fractionData.duration,
+                fractionData.startTime,
+                fractionData.endTime,
                 roundUp
             );
         }

--- a/reference/lib/ReferenceConsiderationStructs.sol
+++ b/reference/lib/ReferenceConsiderationStructs.sol
@@ -69,9 +69,8 @@ struct FractionData {
     uint256 numerator; // The portion of the order that should be filled.
     uint256 denominator; // The total size of the order
     bytes32 fulfillerConduitKey; // The fulfiller's conduit key.
-    uint256 duration; // The total duration of the order.
-    uint256 elapsed; // The time elapsed since the order's start time.
-    uint256 remaining; // The time left until the order's end time.
+    uint256 startTime; // The start time of the order.
+    uint256 endTime; // The end time of the order.
 }
 
 /**

--- a/reference/lib/ReferenceOrderCombiner.sol
+++ b/reference/lib/ReferenceOrderCombiner.sol
@@ -245,17 +245,12 @@ contract ReferenceOrderCombiner is
                 // Decrement the number of fulfilled orders.
                 maximumFulfilled--;
             }
+
             // Place the start time for the order on the stack.
             uint256 startTime = advancedOrder.parameters.startTime;
 
-            // Derive the duration for the order and place it on the stack.
-            uint256 duration = advancedOrder.parameters.endTime - startTime;
-
-            // Derive time elapsed since the order started & place on stack.
-            uint256 elapsed = block.timestamp - startTime;
-
-            // Derive time remaining until order expires and place on stack.
-            uint256 remaining = duration - elapsed;
+            // Place the end for the order on the stack.
+            uint256 endTime = advancedOrder.parameters.endTime;
 
             // Retrieve array of offer items for the order in question.
             OfferItem[] memory offer = advancedOrder.parameters.offer;
@@ -292,9 +287,8 @@ contract ReferenceOrderCombiner is
                 offerItem.startAmount = _locateCurrentAmount(
                     offerItem.startAmount,
                     offerItem.endAmount,
-                    elapsed,
-                    remaining,
-                    duration,
+                    startTime,
+                    endTime,
                     false // Round down.
                 );
 
@@ -342,9 +336,8 @@ contract ReferenceOrderCombiner is
                     _locateCurrentAmount(
                         considerationItem.startAmount,
                         considerationItem.endAmount,
-                        elapsed,
-                        remaining,
-                        duration,
+                        startTime,
+                        endTime,
                         true // Round up.
                     )
                 );

--- a/reference/lib/ReferenceOrderFulfiller.sol
+++ b/reference/lib/ReferenceOrderFulfiller.sol
@@ -159,10 +159,8 @@ contract ReferenceOrderFulfiller is
             numerator,
             denominator,
             fulfillerConduitKey,
-            (orderParameters.endTime - orderParameters.startTime),
-            (block.timestamp - orderParameters.startTime),
-            ((orderParameters.endTime - orderParameters.startTime) -
-                (block.timestamp - orderParameters.startTime))
+            orderParameters.startTime,
+            orderParameters.endTime
         );
 
         // Put ether value supplied by the caller on the stack.

--- a/test/foundry/FulfillAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAdvancedOrder.t.sol
@@ -198,15 +198,15 @@ contract FulfillAdvancedOrder is BaseOrderTest {
             ""
         );
 
+        uint256 startTime = block.timestamp;
         vm.warp(block.timestamp + context.warpAmount);
         // calculate current amount of order based on warpAmount, round down since it's an offer
         // and divide by two to fulfill half of the order
         uint256 currentAmount = _locateCurrentAmount(
             context.tokenAmount * 2,
             context.tokenAmount * 4,
-            context.warpAmount,
-            1000 - context.warpAmount,
-            1000,
+            startTime,
+            startTime + 1000,
             false
         ) / 2;
         // set transaction value to sum of eth consideration items (including endAmount of considerationItem[0])

--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -165,13 +165,13 @@ contract FulfillOrderTest is BaseOrderTest {
             context.consideration.getOrderHash(orderComponents)
         );
 
+        uint256 startTime = block.timestamp;
         vm.warp(block.timestamp + context.args.warpAmount);
         uint256 expectedAmount = _locateCurrentAmount(
             context.args.startAmount.mul(1000),
             context.args.endAmount.mul(1000),
-            context.args.warpAmount,
-            1000 - context.args.warpAmount,
-            1000,
+            startTime,
+            startTime + 1000,
             true // for consideration
         );
         vm.expectEmit(true, true, true, false, address(token1));
@@ -241,13 +241,13 @@ contract FulfillOrderTest is BaseOrderTest {
             context.consideration.getOrderHash(orderComponents)
         );
 
+        uint256 startTime = block.timestamp;
         vm.warp(block.timestamp + context.args.warpAmount);
         uint256 expectedAmount = _locateCurrentAmount(
             context.args.startAmount.mul(1000),
             context.args.endAmount.mul(1000),
-            context.args.warpAmount,
-            1000 - context.args.warpAmount,
-            1000,
+            startTime,
+            startTime + 1000,
             true // for consideration
         );
         token1.mint(address(this), expectedAmount);

--- a/test/foundry/MatchAdvancedOrder.t.sol
+++ b/test/foundry/MatchAdvancedOrder.t.sol
@@ -645,14 +645,15 @@ contract MatchAdvancedOrder is BaseOrderTest {
             20
         );
 
+        uint256 startTime = block.timestamp;
         OrderParameters memory orderParameters = OrderParameters(
             address(alice),
             context.args.zone,
             offerItems,
             considerationItems,
             OrderType.PARTIAL_OPEN,
-            block.timestamp,
-            block.timestamp + 1000,
+            startTime,
+            startTime + 1000,
             context.args.zoneHash,
             context.args.salt,
             conduitKey,
@@ -673,13 +674,14 @@ contract MatchAdvancedOrder is BaseOrderTest {
         delete offerItems;
         delete considerationItems;
 
+        vm.warp(startTime + 500);
+
         // current amount should be mean of start and end amounts
         uint256 currentAmount = _locateCurrentAmount(
             context.args.baseStart.mul(20), // start amount
             context.args.baseEnd.mul(20), // end amount
-            500, // elapsed
-            500, // remaining
-            1000, // duration
+            startTime, // starTime
+            startTime + 1000, // endTime
             false // roundUp
         );
 
@@ -706,8 +708,8 @@ contract MatchAdvancedOrder is BaseOrderTest {
             offerItems,
             considerationItems,
             OrderType.PARTIAL_OPEN,
-            block.timestamp,
-            block.timestamp + 1000,
+            startTime,
+            startTime + 1000,
             context.args.zoneHash,
             context.args.salt,
             conduitKey,
@@ -758,8 +760,6 @@ contract MatchAdvancedOrder is BaseOrderTest {
         delete fulfillmentComponents;
         delete fulfillment;
 
-        vm.warp(block.timestamp + 500);
-
         uint256 balanceBeforeOrder = token1.balanceOf(bob);
         context.consideration.matchAdvancedOrders(
             orders,
@@ -808,14 +808,15 @@ contract MatchAdvancedOrder is BaseOrderTest {
             alice
         );
 
+        uint256 startTime = block.timestamp;
         OrderParameters memory orderParameters = OrderParameters(
             address(alice),
             context.args.zone,
             offerItems,
             considerationItems,
             OrderType.PARTIAL_OPEN,
-            block.timestamp,
-            block.timestamp + 1000,
+            startTime,
+            startTime + 1000,
             context.args.zoneHash,
             context.args.salt,
             conduitKey,
@@ -836,13 +837,14 @@ contract MatchAdvancedOrder is BaseOrderTest {
         delete offerItems;
         delete considerationItems;
 
+        vm.warp(startTime + 500);
+
         // current amount should be mean of start and end amounts
         uint256 currentAmount = _locateCurrentAmount(
             context.args.baseStart.mul(20), // start amount
             context.args.baseEnd.mul(20), // end amount
-            500, // elapsed
-            500, // remaining
-            1000, // duration
+            startTime, // startTime
+            startTime + 1000, // endTime
             false // roundUp
         );
 
@@ -926,8 +928,6 @@ contract MatchAdvancedOrder is BaseOrderTest {
         fulfillments.push(fulfillment);
         delete fulfillmentComponents;
         delete fulfillment;
-
-        vm.warp(block.timestamp + 500);
 
         uint256 balanceBeforeOrder = token1.balanceOf(alice);
         context.consideration.matchAdvancedOrders(

--- a/test/foundry/MatchOrders.t.sol
+++ b/test/foundry/MatchOrders.t.sol
@@ -670,12 +670,14 @@ contract MatchOrders is BaseOrderTest {
         delete offerItems;
         delete considerationItems;
 
+        uint256 startTime = 1;
+        vm.warp(startTime + context.args.warp);
+
         uint256 currentAmount = _locateCurrentAmount(
             context.args.amount, // start amount
             context.args.amount * 2, // end amount
-            context.args.warp, // elapsed
-            1000 - context.args.warp, // remaining
-            1000, // duration
+            startTime, // startTime
+            startTime + 1000, // endTime
             false // roundUp
         );
 
@@ -766,12 +768,14 @@ contract MatchOrders is BaseOrderTest {
         delete offerItems;
         delete considerationItems;
 
+        uint256 startTime = 1;
+        vm.warp(startTime + context.args.warp);
+
         uint256 currentAmount = _locateCurrentAmount(
             context.args.amount, // start amount
             context.args.amount * 2, // end amount
-            context.args.warp, // elapsed
-            1000 - context.args.warp, // remaining
-            1000, // duration
+            startTime, // startTime
+            startTime + 1000, // endTime
             true // roundUp
         );
         _configureOfferItem(ItemType.ERC20, 0, currentAmount, currentAmount);
@@ -827,8 +831,6 @@ contract MatchOrders is BaseOrderTest {
         delete fulfillmentComponents;
         delete fulfillment;
 
-        vm.warp(1 + context.args.warp);
-
         uint256 balanceBeforeOrder = token1.balanceOf(alice);
         context.consideration.matchOrders(orders, fulfillments);
         uint256 balanceAfterOrder = token1.balanceOf(alice);
@@ -854,13 +856,15 @@ contract MatchOrders is BaseOrderTest {
         delete offerItems;
         delete considerationItems;
 
+        uint256 startTime = 1;
+        vm.warp(startTime + context.args.warp);
+
         uint256 currentAmount = _locateCurrentAmount(
             context.args.amount * 2, // start amount
             context.args.amount, // end amount
-            context.args.warp, // elapsed
-            1000 - context.args.warp, // remaining
-            1000, // duration
-            false // roundUp
+            startTime, // startTime
+            startTime + 1000, // endTime
+            true // roundUp
         );
 
         _configureOfferItem(ItemType.ERC721, context.args.id, 1);
@@ -924,8 +928,6 @@ contract MatchOrders is BaseOrderTest {
         delete fulfillmentComponents;
         delete fulfillment;
 
-        vm.warp(1 + context.args.warp);
-
         uint256 balaceBeforeOrder = token1.balanceOf(bob);
         context.consideration.matchOrders(orders, fulfillments);
         uint256 balanceAfterOrder = token1.balanceOf(bob);
@@ -951,14 +953,17 @@ contract MatchOrders is BaseOrderTest {
         delete offerItems;
         delete considerationItems;
 
+        uint256 startTime = 1;
+        vm.warp(startTime + context.args.warp);
+
         uint256 currentAmount = _locateCurrentAmount(
-            context.args.amount * 2,
-            context.args.amount,
-            context.args.warp,
-            1000 - context.args.warp,
-            1000,
-            true
+            context.args.amount * 2, // start amount
+            context.args.amount, // end amount
+            startTime, // startTime
+            startTime + 1000, // endTime
+            true // roundUp
         );
+
         emit log_named_uint("Current Amount: ", currentAmount);
 
         _configureOfferItem(
@@ -1021,7 +1026,6 @@ contract MatchOrders is BaseOrderTest {
         delete fulfillmentComponents;
         delete fulfillment;
 
-        vm.warp(1 + context.args.warp);
         uint256 balanceBeforeOrder = token1.balanceOf(alice);
         context.consideration.matchOrders(orders, fulfillments);
 


### PR DESCRIPTION
## Motivation

Critical code paths for order fulfillment are preemptively computing `duration`, `elapsed` and `remaining` timestamps for all orders.
In particular, `remaining` can always be derived from the other two, and it's only actually necessary when `startAmount != endAmount`. For static-price orders, it ends up never actually being used (both `_locateCurrentAmount` and `_applyFraction` branch out and never use it).

This opens the door to a couple of optimizations:
* we can remove this argument from internal calls, and derive it from `duration` and `elapsed` when necessary
* we end up not actually computing it at all when `startAmount == endAmount`, which should be a significant number of orders

`yarn coverage` of the relevant section (before and after shown below) shows gains of 130 to 160 gas for all `fulfill*` and `match*` calls.

**TODO**:
- [x] Update reference implementation as well

main:

```
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  fulfillAdvancedOrder            ·     100495  ·     209321  ·      160454  ·          126  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  fulfillAvailableAdvancedOrders  ·     137853  ·     227269  ·      193361  ·           19  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  fulfillAvailableOrders          ·     171746  ·     226914  ·      205200  ·           13  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  fulfillBasicOrder               ·      92295  ·    1628323  ·      665700  ·          160  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  fulfillOrder                    ·     101861  ·     212811  ·      173831  ·          105  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  incrementCounter                ·          -  ·          -  ·       47029  ·            6  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  matchAdvancedOrders             ·     204305  ·     271088  ·      252862  ·           67  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  matchOrders                     ·     164525  ·     363989  ·      265784  ·          105  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
```

patched:

```
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  fulfillAdvancedOrder            ·     100247  ·     209063  ·      160207  ·          126  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  fulfillAvailableAdvancedOrders  ·     137767  ·     227033  ·      193234  ·           19  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  fulfillAvailableOrders          ·     171646  ·     226690  ·      205057  ·           13  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  fulfillBasicOrder               ·      92295  ·    1628323  ·      665700  ·          160  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  fulfillOrder                    ·     101613  ·     212553  ·      173575  ·          105  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  incrementCounter                ·          -  ·          -  ·       47029  ·            6  ·          -  │                
······························|··································|·············|·············|··············|···············|··············                
|  Seaport                    ·  matchAdvancedOrders             ·     204109  ·     270892  ·      252636  ·           67  ·          -  │                
······························|··································|·············|·············|··············|···············|··············
```