### PR TITLE
Remove unnecessary address(0) reverts.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,3 +56,4 @@ dmfxyz                         | `dmfxyz.eth`
 daltoncoder                    | `dontkillrobots.eth`
 0xf4ce                         | `0xf4ce.eth`
 phaze                          | `phaze.eth`
+Jonathan Becker                | `jbecker.eth`

--- a/contracts/conduit/ConduitController.sol
+++ b/contracts/conduit/ConduitController.sol
@@ -59,10 +59,6 @@ contract ConduitController is ConduitControllerInterface {
         override
         returns (address conduit)
     {
-        // Ensure that an initial owner has been supplied.
-        if (initialOwner == address(0)) {
-            revert InvalidInitialOwner();
-        }
 
         // If the first 20 bytes of the conduit key do not match the caller...
         if (address(uint160(bytes20(conduitKey))) != msg.sender) {
@@ -201,11 +197,6 @@ contract ConduitController is ConduitControllerInterface {
     {
         // Ensure the caller is the current owner of the conduit in question.
         _assertCallerIsConduitOwner(conduit);
-
-        // Ensure the new potential owner is not an invalid address.
-        if (newPotentialOwner == address(0)) {
-            revert NewPotentialOwnerIsZeroAddress(conduit);
-        }
 
         // Ensure the new potential owner is not already set.
         if (newPotentialOwner == _conduits[conduit].potentialOwner) {


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Sometimes, reverting for the 0 address is a waste of gas. It's a check from when the solidity compiler was less strict with calldata lengths.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

I've removed 2 instances of this check where it might be unnecessary.  

- Lines 62-65 were removed because the initial owner shouldn't ever be the 0 address, unless the caller wants it to be the 0 address, in which case it seems pretty stupid on their part and a waste of gas regardless.

- Lines 205-209 can actually be removed because the check is redundant. If the conduitOwner wants the 0 address to be the newPotentialOwner, there's no real reason to not let that happen. The 0 address can't accept this offer, so ownership won't be transferred to them ever.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
