### PR TITLE
Use local var instead of reading from storage in `ReferenceVerifiers`

### DIFF
--- a/reference/lib/ReferenceVerifiers.sol
+++ b/reference/lib/ReferenceVerifiers.sol
@@ -125,13 +125,13 @@ contract ReferenceVerifiers is
         uint256 orderStatusNumerator = orderStatus.numerator;
 
         // If the order is not entirely unused...
-        if (orderStatus.numerator != 0) {
+        if (orderStatusNumerator != 0) {
             // ensure the order has not been partially filled when not allowed.
             if (onlyAllowUnused) {
                 // Always revert on partial fills when onlyAllowUnused is true.
                 revert OrderPartiallyFilled(orderHash);
                 // Otherwise, ensure that order has not been entirely filled.
-            } else if (orderStatus.numerator >= orderStatus.denominator) {
+            } else if (orderStatusNumerator >= orderStatus.denominator) {
                 // Only revert if revertOnInvalid has been supplied as true.
                 if (revertOnInvalid) {
                     revert OrderAlreadyFilled(orderHash);


### PR DESCRIPTION
Gets rid of compiler warning during build

<img width="484" alt="image" src="https://user-images.githubusercontent.com/27727946/172643239-706a952b-7dd4-4601-94f3-63d56f1ce7ca.png">
