### PR TITLE
Revert on dirty bits (unused item parameters)

### DIFF
--- a/contracts/conduit/Conduit.sol
+++ b/contracts/conduit/Conduit.sol
@@ -194,6 +194,10 @@ contract Conduit is ConduitInterface, TokenTransferrer {
     function _transfer(ConduitTransfer calldata item) internal {
         // Determine the transfer method based on the respective item type.
         if (item.itemType == ConduitItemType.ERC20) {
+            if (item.identifier != 0) {
+               revert UnusedItemParameters();
+            }
+
             // Transfer ERC20 token. Note that item.identifier is ignored and
             // therefore ERC20 transfer items are potentially malleable — this
             // check should be performed by the calling channel if a constraint

--- a/contracts/interfaces/TokenTransferrerErrors.sol
+++ b/contracts/interfaces/TokenTransferrerErrors.sol
@@ -18,6 +18,13 @@ interface TokenTransferrerErrors {
     error MissingItemAmount();
 
     /**
+     * @dev Revert with an error when attempting to fulfill an order where an
+     *      item has the unused parameters, this includes token and identifier
+     *      for native transfers and identifier for ERC20 transfers.
+     */
+    error UnusedItemParameters();
+
+    /**
      * @dev Revert with an error when an ERC20, ERC721, or ERC1155 token
      *      transfer reverts.
      *

--- a/contracts/lib/BasicOrderFulfiller.sol
+++ b/contracts/lib/BasicOrderFulfiller.sol
@@ -171,6 +171,10 @@ contract BasicOrderFulfiller is OrderValidator {
 
         // Transfer tokens based on the route.
         if (additionalRecipientsItemType == ItemType.NATIVE) {
+            if ((uint160(parameters.considerationToken) | parameters.considerationIdentifier) != 0) {
+                revert UnusedItemParameters();
+            }
+
             _transferIndividual721Or1155Item(
                 offeredItemType,
                 parameters.offerToken,

--- a/contracts/lib/Executor.sol
+++ b/contracts/lib/Executor.sol
@@ -52,9 +52,17 @@ contract Executor is Verifiers, TokenTransferrer {
     ) internal {
         // If the item type indicates Ether or a native token...
         if (item.itemType == ItemType.NATIVE) {
+            if ((uint160(item.token) | item.identifier) != 0) {
+                revert UnusedItemParameters();
+            }
+
             // transfer the native tokens to the recipient.
             _transferEth(item.recipient, item.amount);
         } else if (item.itemType == ItemType.ERC20) {
+            if (item.identifier != 0) {
+                revert UnusedItemParameters();
+            }
+
             // Transfer ERC20 tokens from the source to the recipient.
             _transferERC20(
                 item.token,


### PR DESCRIPTION
The goal here is to avoid having orders which look like ERC-721 items with a single byte difference (the `ItemType`), i.e. a `ItemType.NATIVE` order ignores the `token` and `identifier` fields and so it can be used to look like a ERC-721 token (such as BAYC).
