### PR TITLE
[WIP] optimize basic order fulfillment

### DIFF
--- a/contracts/conduit/Conduit.sol
+++ b/contracts/conduit/Conduit.sol
@@ -194,10 +194,6 @@ contract Conduit is ConduitInterface, TokenTransferrer {
     function _transfer(ConduitTransfer calldata item) internal {
         // Determine the transfer method based on the respective item type.
         if (item.itemType == ConduitItemType.ERC20) {
-            if (item.identifier != 0) {
-               revert UnusedItemParameters();
-            }
-
             // Transfer ERC20 token. Note that item.identifier is ignored and
             // therefore ERC20 transfer items are potentially malleable — this
             // check should be performed by the calling channel if a constraint

--- a/contracts/interfaces/TokenTransferrerErrors.sol
+++ b/contracts/interfaces/TokenTransferrerErrors.sol
@@ -19,8 +19,11 @@ interface TokenTransferrerErrors {
 
     /**
      * @dev Revert with an error when attempting to fulfill an order where an
-     *      item has the unused parameters, this includes token and identifier
-     *      for native transfers and identifier for ERC20 transfers.
+     *      item has unused parameters. This includes both the token and the
+     *      identifier parameters for native transfers as well as the identifier
+     *      parameter for ERC20 transfers. Note that the conduit does not
+     *      perform this check, leaving it up to the calling channel to enforce
+     *      when desired.
      */
     error UnusedItemParameters();
 

--- a/contracts/lib/BasicOrderFulfiller.sol
+++ b/contracts/lib/BasicOrderFulfiller.sol
@@ -156,9 +156,6 @@ contract BasicOrderFulfiller is OrderValidator {
             offeredItemType
         );
 
-        // Read offerer from calldata and place on the stack.
-        address payable offerer = parameters.offerer;
-
         // Declare conduitKey argument used by transfer functions.
         bytes32 conduitKey;
 
@@ -183,7 +180,7 @@ contract BasicOrderFulfiller is OrderValidator {
             _transferIndividual721Or1155Item(
                 offeredItemType,
                 parameters.offerToken,
-                offerer,
+                parameters.offerer,
                 msg.sender,
                 parameters.offerIdentifier,
                 parameters.offerAmount,
@@ -193,7 +190,7 @@ contract BasicOrderFulfiller is OrderValidator {
             // Transfer native to recipients, return excess to caller & wrap up.
             _transferEthAndFinalize(
                 parameters.considerationAmount,
-                offerer,
+                parameters.offerer,
                 parameters.additionalRecipients
             );
         } else {
@@ -208,7 +205,7 @@ contract BasicOrderFulfiller is OrderValidator {
                 // Transfer ERC721 to caller using offerer's conduit preference.
                 _transferERC721(
                     parameters.offerToken,
-                    offerer,
+                    parameters.offerer,
                     msg.sender,
                     parameters.offerIdentifier,
                     parameters.offerAmount,
@@ -219,7 +216,7 @@ contract BasicOrderFulfiller is OrderValidator {
                 // Transfer ERC1155 to caller with offerer's conduit preference.
                 _transferERC1155(
                     parameters.offerToken,
-                    offerer,
+                    parameters.offerer,
                     msg.sender,
                     parameters.offerIdentifier,
                     parameters.offerAmount,
@@ -231,7 +228,7 @@ contract BasicOrderFulfiller is OrderValidator {
                 _transferERC721(
                     parameters.considerationToken,
                     msg.sender,
-                    offerer,
+                    parameters.offerer,
                     parameters.considerationIdentifier,
                     parameters.considerationAmount,
                     conduitKey,
@@ -244,7 +241,7 @@ contract BasicOrderFulfiller is OrderValidator {
                 _transferERC1155(
                     parameters.considerationToken,
                     msg.sender,
-                    offerer,
+                    parameters.offerer,
                     parameters.considerationIdentifier,
                     parameters.considerationAmount,
                     conduitKey,
@@ -254,7 +251,7 @@ contract BasicOrderFulfiller is OrderValidator {
 
             // Transfer ERC20 tokens to all recipients and wrap up.
             _transferERC20AndFinalize(
-                offerer,
+                parameters.offerer,
                 parameters,
                 offerTypeIsAdditionalRecipientsType,
                 accumulator

--- a/contracts/lib/BasicOrderFulfiller.sol
+++ b/contracts/lib/BasicOrderFulfiller.sol
@@ -171,7 +171,11 @@ contract BasicOrderFulfiller is OrderValidator {
 
         // Transfer tokens based on the route.
         if (additionalRecipientsItemType == ItemType.NATIVE) {
-            if ((uint160(parameters.considerationToken) | parameters.considerationIdentifier) != 0) {
+            // Ensure neither the token nor the identifier parameters are set.
+            if (
+                (uint160(parameters.considerationToken) |
+                    parameters.considerationIdentifier) != 0
+            ) {
                 revert UnusedItemParameters();
             }
 
@@ -216,6 +220,7 @@ contract BasicOrderFulfiller is OrderValidator {
                     msg.sender,
                     offerer,
                     parameters.considerationToken,
+                    parameters.considerationIdentifier,
                     parameters.considerationAmount,
                     parameters.additionalRecipients,
                     false, // Send full amount indicated by consideration items.
@@ -238,6 +243,7 @@ contract BasicOrderFulfiller is OrderValidator {
                     msg.sender,
                     offerer,
                     parameters.considerationToken,
+                    parameters.considerationIdentifier,
                     parameters.considerationAmount,
                     parameters.additionalRecipients,
                     false, // Send full amount indicated by consideration items.
@@ -260,6 +266,7 @@ contract BasicOrderFulfiller is OrderValidator {
                     offerer,
                     msg.sender,
                     parameters.offerToken,
+                    parameters.offerIdentifier,
                     parameters.offerAmount,
                     parameters.additionalRecipients,
                     true, // Reduce fulfiller amount sent by additional amounts.
@@ -284,6 +291,7 @@ contract BasicOrderFulfiller is OrderValidator {
                     offerer,
                     msg.sender,
                     parameters.offerToken,
+                    parameters.offerIdentifier,
                     parameters.offerAmount,
                     parameters.additionalRecipients,
                     true, // Reduce fulfiller amount sent by additional amounts.
@@ -1005,6 +1013,8 @@ contract BasicOrderFulfiller is OrderValidator {
      * @param from                 The originator of the ERC20 token transfer.
      * @param to                   The recipient of the ERC20 token transfer.
      * @param erc20Token           The ERC20 token to transfer.
+     * @param identifier           The identifier set on the item in quesiton;
+     *                             this value must be equal to zero.
      * @param amount               The amount of ERC20 tokens to transfer.
      * @param additionalRecipients The additional recipients of the order.
      * @param fromOfferer          A boolean indicating whether to decrement
@@ -1017,11 +1027,17 @@ contract BasicOrderFulfiller is OrderValidator {
         address from,
         address to,
         address erc20Token,
+        uint256 identifier,
         uint256 amount,
         AdditionalRecipient[] calldata additionalRecipients,
         bool fromOfferer,
         bytes memory accumulator
     ) internal {
+        // Ensure that no identifier is supplied.
+        if (identifier != 0) {
+            revert UnusedItemParameters();
+        }
+
         // Determine the appropriate conduit to utilize.
         bytes32 conduitKey;
 

--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -182,7 +182,7 @@ uint256 constant OrderFulfilled_consideration_body_offset = 0x120;
 // BasicOrderParameters
 uint256 constant BasicOrder_parameters_cdPtr = 0x04;
 uint256 constant BasicOrder_considerationToken_cdPtr = 0x24;
-// uint256 constant BasicOrder_considerationIdentifier_cdPtr = 0x44;
+uint256 constant BasicOrder_considerationIdentifier_cdPtr = 0x44;
 uint256 constant BasicOrder_considerationAmount_cdPtr = 0x64;
 uint256 constant BasicOrder_offerer_cdPtr = 0x84;
 uint256 constant BasicOrder_zone_cdPtr = 0xa4;

--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -202,6 +202,8 @@ uint256 constant BasicOrder_signature_cdPtr = 0x244;
 uint256 constant BasicOrder_additionalRecipients_length_cdPtr = 0x264;
 uint256 constant BasicOrder_additionalRecipients_data_cdPtr = 0x284;
 
+uint256 constant BasicOrder_offerOffsetFromConsideration = 0xa0;
+
 uint256 constant BasicOrder_parameters_ptr = 0x20;
 
 /*

--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -358,7 +358,7 @@ uint256 constant InexactFraction_error_signature = (
 uint256 constant InexactFraction_error_len = 0x20;
 
 uint256 constant UnusedItemParameters_error_signature = (
-  0x6ab37ce700000000000000000000000000000000000000000000000000000000
+    0x6ab37ce700000000000000000000000000000000000000000000000000000000
 );
 
 uint256 constant UnusedItemParameters_error_ptr = 0x00;
@@ -373,4 +373,3 @@ uint256 constant NonMatchSelector_MagicModulus = 69;
 // Of the two match function selectors, the highest
 // remainder modulo 69 is 29.
 uint256 constant NonMatchSelector_MagicRemainder = 0x1d;
-

--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -356,3 +356,10 @@ uint256 constant InexactFraction_error_signature = (
     0xc63cf08900000000000000000000000000000000000000000000000000000000
 );
 uint256 constant InexactFraction_error_len = 0x20;
+
+uint256 constant UnusedItemParameters_error_signature = (
+  0x6ab37ce700000000000000000000000000000000000000000000000000000000
+);
+
+uint256 constant UnusedItemParameters_error_ptr = 0x00;
+uint256 constant UnusedItemParameters_error_len = 0x20;

--- a/contracts/lib/Executor.sol
+++ b/contracts/lib/Executor.sol
@@ -52,6 +52,7 @@ contract Executor is Verifiers, TokenTransferrer {
     ) internal {
         // If the item type indicates Ether or a native token...
         if (item.itemType == ItemType.NATIVE) {
+            // Ensure neither the token nor the identifier parameters are set.
             if ((uint160(item.token) | item.identifier) != 0) {
                 revert UnusedItemParameters();
             }
@@ -59,6 +60,7 @@ contract Executor is Verifiers, TokenTransferrer {
             // transfer the native tokens to the recipient.
             _transferEth(item.recipient, item.amount);
         } else if (item.itemType == ItemType.ERC20) {
+            // Ensure that no identifier is supplied.
             if (item.identifier != 0) {
                 revert UnusedItemParameters();
             }


### PR DESCRIPTION
The `_validateAndFulfillBasicOrder` function has a number of things that can be optimized.

We don't need a branch for each route as we know based on whether route is below 4 which side of the order is transferred to/from which account, and whether it uses 1155 or 721 if it is even or odd.

Currently this branch has some redundant code, e.g. the route is checked initially to set received/offered/additionalRecipient item types, then we check again later when executing the transfers. 

We can also probably remove the transferAndFinalize functions as they just reuse values that are already available in this function, and these internal functions are not reused elsewhere.