### PR TITLE
Simplify code for base order test helper function

### DIFF
--- a/test/foundry/utils/BaseOrderTest.sol
+++ b/test/foundry/utils/BaseOrderTest.sol
@@ -151,10 +151,10 @@ contract BaseOrderTest is
     function _validateOrder(
         Order memory order,
         ConsiderationInterface consideration
-    ) internal {
+    ) internal returns (bool) {
         Order[] memory orders = new Order[](1);
         orders[0] = order;
-        consideration.validate(orders);
+        return consideration.validate(orders);
     }
 
     function _prepareOrder(uint256 tokenId, uint256 totalConsiderationItems)
@@ -266,7 +266,7 @@ contract BaseOrderTest is
         uint256 originalItemsLength,
         uint256 amtToSubtractFromItemsLength
     ) internal {
-        _validateOrder(order, consideration);
+        assertTrue(_validateOrder(order, consideration));
 
         bool overwriteItemsLength = amtToSubtractFromItemsLength > 0;
         if (overwriteItemsLength) {
@@ -312,24 +312,7 @@ contract BaseOrderTest is
         address considerationAddress,
         bytes memory orderCalldata
     ) internal returns (bool success) {
-        uint256 calldataLength = orderCalldata.length;
-        assembly {
-            // Call fulfillOrder
-            success := call(
-                gas(),
-                considerationAddress,
-                0,
-                // The fn signature and calldata starts after the
-                // first OneWord bytes, as those initial bytes just
-                // contain the length of orderCalldata
-                add(orderCalldata, OneWord),
-                calldataLength,
-                // Store output at empty storage location,
-                // identified using "free memory pointer".
-                mload(0x40),
-                OneWord
-            )
-        }
+        (success, ) = considerationAddress.call(orderCalldata);
     }
 
     function _configureConsiderationItem(


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

- The code in tests for calling consideration with calldata was unnecessarily using assembly when it could've more cleanly used normal solidity.
- We lacked checks that validation explicitly succeeded when checking invalid lengths of items in consideration fulfill order calldata

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Simplify the code for calling consideration with calldata to not use assembly
- Add checks that validation explicitly succeeded when checking invalid lengths of items in consideration fulfill order calldata