### PR TITLE
Ensure revert on non-zero token / identifier (native) and identifier (erc20) in transferred item params

### DIFF
--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -173,7 +173,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         );
     }
 
-    function testRevertUnusedItemParametersAddressSetOnNative(
+    function testRevertUnusedItemParametersAddressSetOnNativeConsideration(
         FuzzInputsCommon memory inputs,
         uint128 tokenAmount,
         address _badToken
@@ -187,16 +187,16 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         addErc1155OfferItem(inputs.tokenId, tokenAmount);
         addEthConsiderationItem(alice, 100);
         test(
-            this.revertUnusedItemParametersAddressSetOnNative,
+            this.revertUnusedItemParametersAddressSetOnNativeConsideration,
             Context(consideration, inputs, tokenAmount)
         );
         test(
-            this.revertUnusedItemParametersAddressSetOnNative,
+            this.revertUnusedItemParametersAddressSetOnNativeConsideration,
             Context(referenceConsideration, inputs, tokenAmount)
         );
     }
 
-    function revertUnusedItemParametersAddressSetOnNative(
+    function revertUnusedItemParametersAddressSetOnNativeConsideration(
         Context memory context
     ) external stateless {
         test1155_1.mint(alice, context.args.tokenId, context.tokenAmount);
@@ -235,7 +235,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         );
     }
 
-    function testRevertUnusedItemParametersIdentifierSetOnNative(
+    function testRevertUnusedItemParametersIdentifierSetOnNativeConsideration(
         FuzzInputsCommon memory inputs,
         uint128 tokenAmount,
         uint256 _badIdentifier
@@ -249,16 +249,16 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         addErc1155OfferItem(inputs.tokenId, tokenAmount);
         addEthConsiderationItem(alice, 100);
         test(
-            this.revertUnusedItemParametersIdentifierSetOnNative,
+            this.revertUnusedItemParametersIdentifierSetOnNativeConsideration,
             Context(consideration, inputs, tokenAmount)
         );
         test(
-            this.revertUnusedItemParametersIdentifierSetOnNative,
+            this.revertUnusedItemParametersIdentifierSetOnNativeConsideration,
             Context(referenceConsideration, inputs, tokenAmount)
         );
     }
 
-    function revertUnusedItemParametersIdentifierSetOnNative(
+    function revertUnusedItemParametersIdentifierSetOnNativeConsideration(
         Context memory context
     ) external stateless {
         test1155_1.mint(alice, context.args.tokenId, context.tokenAmount);
@@ -297,7 +297,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         );
     }
 
-    function testRevertUnusedItemParametersAddressAndIdentifierSetOnNative(
+    function testRevertUnusedItemParametersAddressAndIdentifierSetOnNativeConsideration(
         FuzzInputsCommon memory inputs,
         uint128 tokenAmount,
         uint256 _badIdentifier,
@@ -313,16 +313,18 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         addErc1155OfferItem(inputs.tokenId, tokenAmount);
         addEthConsiderationItem(alice, 100);
         test(
-            this.revertUnusedItemParametersAddressAndIdentifierSetOnNative,
+            this
+                .revertUnusedItemParametersAddressAndIdentifierSetOnNativeConsideration,
             Context(consideration, inputs, tokenAmount)
         );
         test(
-            this.revertUnusedItemParametersAddressAndIdentifierSetOnNative,
+            this
+                .revertUnusedItemParametersAddressAndIdentifierSetOnNativeConsideration,
             Context(referenceConsideration, inputs, tokenAmount)
         );
     }
 
-    function revertUnusedItemParametersAddressAndIdentifierSetOnNative(
+    function revertUnusedItemParametersAddressAndIdentifierSetOnNativeConsideration(
         Context memory context
     ) external stateless {
         test1155_1.mint(alice, context.args.tokenId, context.tokenAmount);
@@ -362,7 +364,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         );
     }
 
-    function testRevertUnusedItemParametersIdentifierSetOnErc20(
+    function testRevertUnusedItemParametersIdentifierSetOnErc20Consideration(
         FuzzInputsCommon memory inputs,
         uint128 tokenAmount,
         uint256 _badIdentifier
@@ -376,16 +378,16 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         addErc721OfferItem(inputs.tokenId);
         addErc20ConsiderationItem(alice, 100);
         test(
-            this.revertUnusedItemParametersIdentifierSetOnErc20,
+            this.revertUnusedItemParametersIdentifierSetOnErc20Consideration,
             Context(consideration, inputs, tokenAmount)
         );
         test(
-            this.revertUnusedItemParametersIdentifierSetOnErc20,
+            this.revertUnusedItemParametersIdentifierSetOnErc20Consideration,
             Context(referenceConsideration, inputs, tokenAmount)
         );
     }
 
-    function revertUnusedItemParametersIdentifierSetOnErc20(
+    function revertUnusedItemParametersIdentifierSetOnErc20Consideration(
         Context memory context
     ) external stateless {
         test721_1.mint(alice, context.args.tokenId);

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -179,15 +179,8 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         public
         validateInputsWithAmount(Context(consideration, inputs, tokenAmount))
     {
-        _configureERC1155OfferItem(inputs.tokenId, tokenAmount);
-        _configureConsiderationItem(
-            ItemType.NATIVE,
-            address(0),
-            69,
-            100,
-            100,
-            alice
-        );
+        addErc1155OfferItem(inputs.tokenId, tokenAmount);
+        addEthConsiderationItem(alice, 100);
         test(
             this.revertUnusedItemParametersIdentifierSetOnNative,
             Context(consideration, inputs, tokenAmount)

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -235,7 +235,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         );
     }
 
-    function testRevertUnusedItemParametersAddressSetOnNativeOffer(
+    function testRevertUnusedItemParametersIdentifierSetOnErc20Offer(
         FuzzInputsCommon memory inputs,
         uint128 tokenAmount,
         uint256 _badIdentifier
@@ -250,21 +250,21 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         addErc1155ConsiderationItem(alice, inputs.tokenId, tokenAmount);
 
         test(
-            this.revertUnusedItemParametersAddressSetOnNativeOffer,
+            this.revertUnusedItemParametersIdentifierSetOnErc20Offer,
             Context(consideration, inputs, tokenAmount)
         );
         test(
-            this.revertUnusedItemParametersAddressSetOnNativeOffer,
+            this.revertUnusedItemParametersIdentifierSetOnErc20Offer,
             Context(referenceConsideration, inputs, tokenAmount)
         );
     }
 
-    function revertUnusedItemParametersAddressSetOnNativeOffer(
+    function revertUnusedItemParametersIdentifierSetOnErc20Offer(
         Context memory context
     ) external stateless {
         test1155_1.mint(bob, context.args.tokenId, context.tokenAmount);
 
-        offerItems[0].token = badToken;
+        offerItems[0].identifierOrCriteria = badIdentifier;
 
         _configureOrderParameters(
             alice,

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -173,7 +173,131 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         );
     }
 
+    function testRevertUnusedItemParametersAddressSetOnNative(
+        FuzzInputsCommon memory inputs,
+        uint128 tokenAmount,
+        address _badToken
+    )
+        public
+        validateInputsWithAmount(Context(consideration, inputs, tokenAmount))
+    {
+        vm.assume(_badToken != address(0));
+        badToken = _badToken;
+
+        addErc1155OfferItem(inputs.tokenId, tokenAmount);
+        addEthConsiderationItem(alice, 100);
+        test(
+            this.revertUnusedItemParametersAddressSetOnNative,
+            Context(consideration, inputs, tokenAmount)
+        );
+        test(
+            this.revertUnusedItemParametersAddressSetOnNative,
+            Context(referenceConsideration, inputs, tokenAmount)
+        );
+    }
+
+    function revertUnusedItemParametersAddressSetOnNative(
+        Context memory context
+    ) external stateless {
+        test1155_1.mint(alice, context.args.tokenId, context.tokenAmount);
+
+        considerationItems[0].token = badToken;
+
+        _configureOrderParameters(
+            alice,
+            address(0),
+            bytes32(0),
+            globalSalt++,
+            false
+        );
+        _configureOrderComponents(context.consideration.getCounter(alice));
+
+        bytes32 orderHash = context.consideration.getOrderHash(
+            baseOrderComponents
+        );
+
+        bytes memory signature = signOrder(
+            context.consideration,
+            alicePk,
+            orderHash
+        );
+
+        BasicOrderParameters
+            memory _basicOrderParameters = toBasicOrderParameters(
+                baseOrderComponents,
+                BasicOrderType.ETH_TO_ERC1155_FULL_OPEN,
+                signature
+            );
+
+        vm.expectRevert(abi.encodeWithSignature("UnusedItemParameters()"));
+        context.consideration.fulfillBasicOrder{ value: 100 }(
+            _basicOrderParameters
+        );
+    }
+
     function testRevertUnusedItemParametersIdentifierSetOnNative(
+        FuzzInputsCommon memory inputs,
+        uint128 tokenAmount,
+        uint256 _badIdentifier
+    )
+        public
+        validateInputsWithAmount(Context(consideration, inputs, tokenAmount))
+    {
+        vm.assume(_badIdentifier != 0);
+        badIdentifier = _badIdentifier;
+
+        addErc1155OfferItem(inputs.tokenId, tokenAmount);
+        addEthConsiderationItem(alice, 100);
+        test(
+            this.revertUnusedItemParametersIdentifierSetOnNative,
+            Context(consideration, inputs, tokenAmount)
+        );
+        test(
+            this.revertUnusedItemParametersIdentifierSetOnNative,
+            Context(referenceConsideration, inputs, tokenAmount)
+        );
+    }
+
+    function revertUnusedItemParametersIdentifierSetOnNative(
+        Context memory context
+    ) external stateless {
+        test1155_1.mint(alice, context.args.tokenId, context.tokenAmount);
+
+        considerationItems[0].identifierOrCriteria = badIdentifier;
+
+        _configureOrderParameters(
+            alice,
+            address(0),
+            bytes32(0),
+            globalSalt++,
+            false
+        );
+        _configureOrderComponents(context.consideration.getCounter(alice));
+
+        bytes32 orderHash = context.consideration.getOrderHash(
+            baseOrderComponents
+        );
+
+        bytes memory signature = signOrder(
+            context.consideration,
+            alicePk,
+            orderHash
+        );
+
+        BasicOrderParameters
+            memory _basicOrderParameters = toBasicOrderParameters(
+                baseOrderComponents,
+                BasicOrderType.ETH_TO_ERC1155_FULL_OPEN,
+                signature
+            );
+
+        vm.expectRevert(abi.encodeWithSignature("UnusedItemParameters()"));
+        context.consideration.fulfillBasicOrder{ value: 100 }(
+            _basicOrderParameters
+        );
+    }
+
+    function testRevertUnusedItemParametersAddressAndIdentifierSetOnNative(
         FuzzInputsCommon memory inputs,
         uint128 tokenAmount,
         uint256 _badIdentifier,

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -262,7 +262,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
     function revertUnusedItemParametersIdentifierSetOnErc20Offer(
         Context memory context
     ) external stateless {
-        test721_1.mint(bob, context.args.tokenId);
+        test721_1.mint(address(this), context.args.tokenId);
 
         offerItems[0].identifierOrCriteria = 69;
 
@@ -288,11 +288,10 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         BasicOrderParameters
             memory _basicOrderParameters = toBasicOrderParameters(
                 baseOrderComponents,
-                BasicOrderType.ERC20_TO_ERC721_FULL_OPEN,
+                BasicOrderType.ERC721_TO_ERC20_FULL_OPEN,
                 signature
             );
 
-        vm.prank(alice);
         vm.expectRevert(abi.encodeWithSignature("UnusedItemParameters()"));
         context.consideration.fulfillBasicOrder(_basicOrderParameters);
     }

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -246,7 +246,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         vm.assume(_badIdentifier != 0);
         badIdentifier = _badIdentifier;
 
-        addEthOfferItem(100, 100);
+        addErc20OfferItem(100);
         addErc1155ConsiderationItem(alice, inputs.tokenId, tokenAmount);
 
         test(
@@ -288,7 +288,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         BasicOrderParameters
             memory _basicOrderParameters = toBasicOrderParameters(
                 baseOrderComponents,
-                BasicOrderType.ETH_TO_ERC721_FULL_OPEN,
+                BasicOrderType.ERC20_TO_ERC1155_FULL_OPEN,
                 signature
             );
 

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -247,7 +247,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         badIdentifier = _badIdentifier;
 
         addErc20OfferItem(100);
-        addErc1155ConsiderationItem(alice, inputs.tokenId, tokenAmount);
+        addErc721ConsiderationItem(alice, inputs.tokenId);
 
         test(
             this.revertUnusedItemParametersIdentifierSetOnErc20Offer,
@@ -262,9 +262,9 @@ contract FulfillBasicOrderTest is BaseOrderTest {
     function revertUnusedItemParametersIdentifierSetOnErc20Offer(
         Context memory context
     ) external stateless {
-        test1155_1.mint(bob, context.args.tokenId, context.tokenAmount);
+        test721_1.mint(bob, context.args.tokenId);
 
-        offerItems[0].identifierOrCriteria = badIdentifier;
+        offerItems[0].identifierOrCriteria = 69;
 
         _configureOrderParameters(
             alice,
@@ -288,14 +288,13 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         BasicOrderParameters
             memory _basicOrderParameters = toBasicOrderParameters(
                 baseOrderComponents,
-                BasicOrderType.ERC20_TO_ERC1155_FULL_OPEN,
+                BasicOrderType.ERC20_TO_ERC721_FULL_OPEN,
                 signature
             );
 
+        vm.prank(alice);
         vm.expectRevert(abi.encodeWithSignature("UnusedItemParameters()"));
-        context.consideration.fulfillBasicOrder{ value: 100 }(
-            _basicOrderParameters
-        );
+        context.consideration.fulfillBasicOrder(_basicOrderParameters);
     }
 
     function testRevertUnusedItemParametersIdentifierSetOnNativeConsideration(

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -180,14 +180,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         validateInputsWithAmount(Context(consideration, inputs, tokenAmount))
     {
         _configureERC1155OfferItem(inputs.tokenId, tokenAmount);
-        _configureConsiderationItem(
-            ItemType.NATIVE,
-            address(0),
-            inputs.tokenId, // set non-zero identifier
-            100,
-            100,
-            alice
-        );
+        _configureEthConsiderationItem(alice, inputs.paymentAmount);
         _configureBasicOrderParametersEthTo1155(inputs, tokenAmount);
         test(
             this.revertUnusedItemParametersIdentifierSetOnNative,
@@ -211,8 +204,8 @@ contract FulfillBasicOrderTest is BaseOrderTest {
             bytes32(0)
         );
 
-        uint256 counter = context.consideration.getCounter(alice);
-        orderComponents.counter = counter;
+        _configureOrderComponents(context.consideration.getCounter(alice));
+
         bytes32 orderHash = context.consideration.getOrderHash(orderComponents);
 
         bytes memory signature = signOrder(
@@ -223,9 +216,9 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         basicOrderParameters.signature = signature;
 
         vm.expectRevert(abi.encodeWithSignature("UnusedItemParameters()"));
-        context.consideration.fulfillBasicOrder{ value: 100 }(
-            basicOrderParameters
-        );
+        context.consideration.fulfillBasicOrder{
+            value: context.args.paymentAmount
+        }(basicOrderParameters);
     }
 
     function prepareBasicOrder(uint256 tokenId)

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -288,7 +288,7 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         BasicOrderParameters
             memory _basicOrderParameters = toBasicOrderParameters(
                 baseOrderComponents,
-                BasicOrderType.ETH_TO_ERC1155_FULL_OPEN,
+                BasicOrderType.ETH_TO_ERC721_FULL_OPEN,
                 signature
             );
 

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -180,8 +180,14 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         validateInputsWithAmount(Context(consideration, inputs, tokenAmount))
     {
         _configureERC1155OfferItem(inputs.tokenId, tokenAmount);
-        _configureEthConsiderationItem(alice, inputs.paymentAmount);
-        _configureBasicOrderParametersEthTo1155(inputs, tokenAmount);
+        _configureConsiderationItem(
+            ItemType.NATIVE,
+            address(0),
+            69,
+            100,
+            100,
+            alice
+        );
         test(
             this.revertUnusedItemParametersIdentifierSetOnNative,
             Context(consideration, inputs, tokenAmount)
@@ -205,6 +211,10 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         );
 
         _configureOrderComponents(context.consideration.getCounter(alice));
+        _configureBasicOrderParametersEthTo1155(
+            context.args,
+            context.tokenAmount
+        );
 
         bytes32 orderHash = context.consideration.getOrderHash(orderComponents);
 
@@ -216,9 +226,9 @@ contract FulfillBasicOrderTest is BaseOrderTest {
         basicOrderParameters.signature = signature;
 
         vm.expectRevert(abi.encodeWithSignature("UnusedItemParameters()"));
-        context.consideration.fulfillBasicOrder{
-            value: context.args.paymentAmount
-        }(basicOrderParameters);
+        context.consideration.fulfillBasicOrder{ value: 100 }(
+            basicOrderParameters
+        );
     }
 
     function prepareBasicOrder(uint256 tokenId)

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -293,7 +293,9 @@ contract FulfillBasicOrderTest is BaseOrderTest {
             );
 
         vm.expectRevert(abi.encodeWithSignature("UnusedItemParameters()"));
-        context.consideration.fulfillBasicOrder(_basicOrderParameters);
+        context.consideration.fulfillBasicOrder{ value: 100 }(
+            _basicOrderParameters
+        );
     }
 
     function testRevertUnusedItemParametersIdentifierSetOnNativeConsideration(

--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -2089,7 +2089,147 @@ contract FulfillOrderTest is BaseOrderTest {
         }(Order(orderParameters, signature), conduitKey);
     }
 
-    function testFulfillOrderRevertUnusedParameterAddressAndIdentifierSetOnNative(
+    function testFulfillOrderRevertUnusedItemParametersAddressSetOnNative(
+        FuzzInputsCommon memory inputs,
+        uint256 tokenAmount,
+        address _badToken
+    ) public validateInputs(inputs) onlyPayable(inputs.zone) {
+        vm.assume(_badToken != address(0));
+        badToken = _badToken;
+
+        vm.assume(inputs.id > 0);
+        vm.assume(tokenAmount > 0);
+        test(
+            this.fulfillOrderRevertUnusedItemParametersAddressSetOnNative,
+            Context(consideration, inputs, tokenAmount, 0, 0)
+        );
+        test(
+            this.fulfillOrderRevertUnusedItemParametersAddressSetOnNative,
+            Context(referenceConsideration, inputs, tokenAmount, 0, 0)
+        );
+    }
+
+    function fulfillOrderRevertUnusedItemParametersAddressSetOnNative(
+        Context memory context
+    ) external stateless {
+        test1155_1.mint(alice, context.args.id, context.erc1155Amt);
+        addErc1155OfferItem(context.args.id, context.erc1155Amt);
+        addEthConsiderationItem(alice, 100);
+
+        considerationItems[0].token = badToken;
+
+        OrderComponents memory orderComponents = OrderComponents(
+            alice,
+            context.args.zone,
+            offerItems,
+            considerationItems,
+            OrderType.FULL_OPEN,
+            block.timestamp,
+            block.timestamp + 1,
+            context.args.zoneHash,
+            context.args.salt,
+            bytes32(0),
+            context.consideration.getCounter(alice)
+        );
+        bytes memory signature = signOrder(
+            context.consideration,
+            alicePk,
+            context.consideration.getOrderHash(orderComponents)
+        );
+
+        OrderParameters memory orderParameters = OrderParameters(
+            address(alice),
+            context.args.zone,
+            offerItems,
+            considerationItems,
+            OrderType.FULL_OPEN,
+            block.timestamp,
+            block.timestamp + 1,
+            context.args.zoneHash,
+            context.args.salt,
+            bytes32(0),
+            considerationItems.length
+        );
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSignature("UnusedItemParameters()"));
+        context.consideration.fulfillOrder{ value: 100 }(
+            Order(orderParameters, signature),
+            bytes32(0)
+        );
+    }
+
+    function testFulfillOrderRevertUnusedItemParametersIdentifierSetOnNative(
+        FuzzInputsCommon memory inputs,
+        uint256 tokenAmount,
+        uint256 _badIdentifier
+    ) public validateInputs(inputs) onlyPayable(inputs.zone) {
+        vm.assume(_badIdentifier != 0);
+        badIdentifier = _badIdentifier;
+
+        vm.assume(inputs.id > 0);
+        vm.assume(tokenAmount > 0);
+        test(
+            this.fulfillOrderRevertUnusedItemParametersAddressSetOnNative,
+            Context(consideration, inputs, tokenAmount, 0, 0)
+        );
+        test(
+            this.fulfillOrderRevertUnusedItemParametersAddressSetOnNative,
+            Context(referenceConsideration, inputs, tokenAmount, 0, 0)
+        );
+    }
+
+    function fulfillOrderRevertUnusedItemParametersIdentifierSetOnNative(
+        Context memory context
+    ) external stateless {
+        test1155_1.mint(alice, context.args.id, context.erc1155Amt);
+        addErc1155OfferItem(context.args.id, context.erc1155Amt);
+        addEthConsiderationItem(alice, 100);
+
+        considerationItems[0].identifierOrCriteria = badIdentifier;
+
+        OrderComponents memory orderComponents = OrderComponents(
+            alice,
+            context.args.zone,
+            offerItems,
+            considerationItems,
+            OrderType.FULL_OPEN,
+            block.timestamp,
+            block.timestamp + 1,
+            context.args.zoneHash,
+            context.args.salt,
+            bytes32(0),
+            context.consideration.getCounter(alice)
+        );
+        bytes memory signature = signOrder(
+            context.consideration,
+            alicePk,
+            context.consideration.getOrderHash(orderComponents)
+        );
+
+        OrderParameters memory orderParameters = OrderParameters(
+            address(alice),
+            context.args.zone,
+            offerItems,
+            considerationItems,
+            OrderType.FULL_OPEN,
+            block.timestamp,
+            block.timestamp + 1,
+            context.args.zoneHash,
+            context.args.salt,
+            bytes32(0),
+            considerationItems.length
+        );
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSignature("UnusedItemParameters()"));
+        context.consideration.fulfillOrder{ value: 100 }(
+            Order(orderParameters, signature),
+            bytes32(0)
+        );
+    }
+
+    function testFulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNative(
         FuzzInputsCommon memory inputs,
         uint256 tokenAmount,
         uint256 _badIdentifier,
@@ -2103,17 +2243,17 @@ contract FulfillOrderTest is BaseOrderTest {
         vm.assume(tokenAmount > 0);
         test(
             this
-                .fulfillOrderRevertUnusedParameterAddressAndIdentifierSetOnNative,
+                .fulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNative,
             Context(consideration, inputs, tokenAmount, 0, 0)
         );
         test(
             this
-                .fulfillOrderRevertUnusedParameterAddressAndIdentifierSetOnNative,
+                .fulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNative,
             Context(referenceConsideration, inputs, tokenAmount, 0, 0)
         );
     }
 
-    function fulfillOrderRevertUnusedParameterAddressAndIdentifierSetOnNative(
+    function fulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNative(
         Context memory context
     ) external stateless {
         test1155_1.mint(alice, context.args.id, context.erc1155Amt);
@@ -2164,7 +2304,7 @@ contract FulfillOrderTest is BaseOrderTest {
         );
     }
 
-    function testFulfillOrderRevertUnusedParameterIdentifierSetOnErc20(
+    function testFulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20(
         FuzzInputsCommon memory inputs,
         uint256 tokenAmount,
         uint256 _badIdentifier
@@ -2175,16 +2315,16 @@ contract FulfillOrderTest is BaseOrderTest {
         vm.assume(inputs.id > 0);
         vm.assume(tokenAmount > 0);
         test(
-            this.fulfillOrderRevertUnusedParameterIdentifierSetOnErc20,
+            this.fulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20,
             Context(consideration, inputs, tokenAmount, 0, 0)
         );
         test(
-            this.fulfillOrderRevertUnusedParameterIdentifierSetOnErc20,
+            this.fulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20,
             Context(referenceConsideration, inputs, tokenAmount, 0, 0)
         );
     }
 
-    function fulfillOrderRevertUnusedParameterIdentifierSetOnErc20(
+    function fulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20(
         Context memory context
     ) external stateless {
         test721_1.mint(alice, context.args.id);

--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -210,8 +210,8 @@ contract FulfillOrderTest is BaseOrderTest {
             ? conduitKeyOne
             : bytes32(0);
 
-        test1155_1.mint(alice, context.args.id, context.erc1155amt);
-        addErc1155OfferItem(context.args.id, context.erc1155amt);
+        test1155_1.mint(alice, context.args.id, context.erc1155Amt);
+        addErc1155OfferItem(context.args.id, context.erc1155Amt);
 
         addErc20ConsiderationItem(
             alice,
@@ -2107,15 +2107,8 @@ contract FulfillOrderTest is BaseOrderTest {
         Context memory context
     ) external stateless {
         test1155_1.mint(alice, context.args.id, context.erc1155Amt);
-        _configureERC1155OfferItem(context.args.id, context.erc1155Amt);
-        _configureConsiderationItem(
-            ItemType.NATIVE,
-            bob,
-            69, // set nonzero identifier
-            100,
-            100,
-            alice
-        );
+        addErc1155OfferItem(context.args.id, context.erc1155Amt);
+        addEthConsiderationItem(alice, 100);
 
         OrderComponents memory orderComponents = OrderComponents(
             alice,

--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -2089,7 +2089,7 @@ contract FulfillOrderTest is BaseOrderTest {
         }(Order(orderParameters, signature), conduitKey);
     }
 
-    function testFulfillOrderRevertUnusedItemParametersAddressSetOnNative(
+    function testFulfillOrderRevertUnusedItemParametersAddressSetOnNativeConsideration(
         FuzzInputsCommon memory inputs,
         uint256 tokenAmount,
         address _badToken
@@ -2100,16 +2100,18 @@ contract FulfillOrderTest is BaseOrderTest {
         vm.assume(inputs.id > 0);
         vm.assume(tokenAmount > 0);
         test(
-            this.fulfillOrderRevertUnusedItemParametersAddressSetOnNative,
+            this
+                .fulfillOrderRevertUnusedItemParametersAddressSetOnNativeConsideration,
             Context(consideration, inputs, tokenAmount, 0, 0)
         );
         test(
-            this.fulfillOrderRevertUnusedItemParametersAddressSetOnNative,
+            this
+                .fulfillOrderRevertUnusedItemParametersAddressSetOnNativeConsideration,
             Context(referenceConsideration, inputs, tokenAmount, 0, 0)
         );
     }
 
-    function fulfillOrderRevertUnusedItemParametersAddressSetOnNative(
+    function fulfillOrderRevertUnusedItemParametersAddressSetOnNativeConsideration(
         Context memory context
     ) external stateless {
         test1155_1.mint(alice, context.args.id, context.erc1155Amt);
@@ -2159,7 +2161,7 @@ contract FulfillOrderTest is BaseOrderTest {
         );
     }
 
-    function testFulfillOrderRevertUnusedItemParametersIdentifierSetOnNative(
+    function testFulfillOrderRevertUnusedItemParametersIdentifierSetOnNativeConsideration(
         FuzzInputsCommon memory inputs,
         uint256 tokenAmount,
         uint256 _badIdentifier
@@ -2170,16 +2172,18 @@ contract FulfillOrderTest is BaseOrderTest {
         vm.assume(inputs.id > 0);
         vm.assume(tokenAmount > 0);
         test(
-            this.fulfillOrderRevertUnusedItemParametersAddressSetOnNative,
+            this
+                .fulfillOrderRevertUnusedItemParametersIdentifierSetOnNativeConsideration,
             Context(consideration, inputs, tokenAmount, 0, 0)
         );
         test(
-            this.fulfillOrderRevertUnusedItemParametersAddressSetOnNative,
+            this
+                .fulfillOrderRevertUnusedItemParametersIdentifierSetOnNativeConsideration,
             Context(referenceConsideration, inputs, tokenAmount, 0, 0)
         );
     }
 
-    function fulfillOrderRevertUnusedItemParametersIdentifierSetOnNative(
+    function fulfillOrderRevertUnusedItemParametersIdentifierSetOnNativeConsideration(
         Context memory context
     ) external stateless {
         test1155_1.mint(alice, context.args.id, context.erc1155Amt);
@@ -2229,7 +2233,7 @@ contract FulfillOrderTest is BaseOrderTest {
         );
     }
 
-    function testFulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNative(
+    function testFulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNativeConsideration(
         FuzzInputsCommon memory inputs,
         uint256 tokenAmount,
         uint256 _badIdentifier,
@@ -2243,17 +2247,17 @@ contract FulfillOrderTest is BaseOrderTest {
         vm.assume(tokenAmount > 0);
         test(
             this
-                .fulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNative,
+                .fulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNativeConsideration,
             Context(consideration, inputs, tokenAmount, 0, 0)
         );
         test(
             this
-                .fulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNative,
+                .fulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNativeConsideration,
             Context(referenceConsideration, inputs, tokenAmount, 0, 0)
         );
     }
 
-    function fulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNative(
+    function fulfillOrderRevertUnusedItemParametersAddressAndIdentifierSetOnNativeConsideration(
         Context memory context
     ) external stateless {
         test1155_1.mint(alice, context.args.id, context.erc1155Amt);
@@ -2304,7 +2308,7 @@ contract FulfillOrderTest is BaseOrderTest {
         );
     }
 
-    function testFulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20(
+    function testFulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20Consideration(
         FuzzInputsCommon memory inputs,
         uint256 tokenAmount,
         uint256 _badIdentifier
@@ -2315,16 +2319,18 @@ contract FulfillOrderTest is BaseOrderTest {
         vm.assume(inputs.id > 0);
         vm.assume(tokenAmount > 0);
         test(
-            this.fulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20,
+            this
+                .fulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20Consideration,
             Context(consideration, inputs, tokenAmount, 0, 0)
         );
         test(
-            this.fulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20,
+            this
+                .fulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20Consideration,
             Context(referenceConsideration, inputs, tokenAmount, 0, 0)
         );
     }
 
-    function fulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20(
+    function fulfillOrderRevertUnusedItemParametersIdentifierSetOnErc20Consideration(
         Context memory context
     ) external stateless {
         test721_1.mint(alice, context.args.id);

--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -38,7 +38,7 @@ contract FulfillOrderTest is BaseOrderTest {
     struct Context {
         ConsiderationInterface consideration;
         FuzzInputsCommon args;
-        uint256 erc1155amt;
+        uint256 erc1155Amt;
         uint128 tipAmt;
         uint8 numTips;
     }
@@ -187,17 +187,17 @@ contract FulfillOrderTest is BaseOrderTest {
 
     function testFulfillAscendingDescendingConsideration(
         FuzzInputsCommon memory inputs,
-        uint256 erc1155amt
+        uint256 erc1155Amt
     ) public validateInputs(inputs) onlyPayable(inputs.zone) {
         vm.assume(inputs.startAmount > 0 && inputs.endAmount > 0);
-        vm.assume(erc1155amt > 0);
+        vm.assume(erc1155Amt > 0);
         test(
             this.fulfillAscendingDescendingConsideration,
-            Context(referenceConsideration, inputs, erc1155amt, 0, 0)
+            Context(referenceConsideration, inputs, erc1155Amt, 0, 0)
         );
         test(
             this.fulfillAscendingDescendingConsideration,
-            Context(consideration, inputs, erc1155amt, 0, 0)
+            Context(consideration, inputs, erc1155Amt, 0, 0)
         );
     }
 
@@ -731,14 +731,14 @@ contract FulfillOrderTest is BaseOrderTest {
             ? conduitKeyOne
             : bytes32(0);
 
-        test1155_1.mint(alice, context.args.id, context.erc1155amt);
+        test1155_1.mint(alice, context.args.id, context.erc1155Amt);
         offerItems.push(
             OfferItem(
                 ItemType.ERC1155,
                 address(test1155_1),
                 context.args.id,
-                context.erc1155amt,
-                context.erc1155amt
+                context.erc1155Amt,
+                context.erc1155Amt
             )
         );
 
@@ -821,15 +821,15 @@ contract FulfillOrderTest is BaseOrderTest {
             ? conduitKeyOne
             : bytes32(0);
 
-        test1155_1.mint(alice, context.args.id, context.erc1155amt);
+        test1155_1.mint(alice, context.args.id, context.erc1155Amt);
 
         offerItems.push(
             OfferItem(
                 ItemType.ERC1155,
                 address(test1155_1),
                 context.args.id,
-                context.erc1155amt,
-                context.erc1155amt
+                context.erc1155Amt,
+                context.erc1155Amt
             )
         );
 
@@ -1017,15 +1017,15 @@ contract FulfillOrderTest is BaseOrderTest {
             ? conduitKeyOne
             : bytes32(0);
 
-        test1155_1.mint(alice, context.args.id, context.erc1155amt);
+        test1155_1.mint(alice, context.args.id, context.erc1155Amt);
 
         offerItems.push(
             OfferItem(
                 ItemType.ERC1155,
                 address(test1155_1),
                 context.args.id,
-                context.erc1155amt,
-                context.erc1155amt
+                context.erc1155Amt,
+                context.erc1155Amt
             )
         );
 
@@ -1236,15 +1236,15 @@ contract FulfillOrderTest is BaseOrderTest {
             ? conduitKeyOne
             : bytes32(0);
 
-        test1155_1.mint(alice, context.args.id, context.erc1155amt);
+        test1155_1.mint(alice, context.args.id, context.erc1155Amt);
 
         offerItems.push(
             OfferItem(
                 ItemType.ERC1155,
                 address(test1155_1),
                 context.args.id,
-                context.erc1155amt,
-                context.erc1155amt
+                context.erc1155Amt,
+                context.erc1155Amt
             )
         );
 
@@ -1460,14 +1460,14 @@ contract FulfillOrderTest is BaseOrderTest {
             ? conduitKeyOne
             : bytes32(0);
 
-        test1155_1.mint(alice, context.args.id, context.erc1155amt);
+        test1155_1.mint(alice, context.args.id, context.erc1155Amt);
         offerItems.push(
             OfferItem(
                 ItemType.ERC1155,
                 address(test1155_1),
                 context.args.id,
-                context.erc1155amt,
-                context.erc1155amt
+                context.erc1155Amt,
+                context.erc1155Amt
             )
         );
 
@@ -1681,14 +1681,14 @@ contract FulfillOrderTest is BaseOrderTest {
             ? conduitKeyOne
             : bytes32(0);
 
-        test1155_1.mint(alice, context.args.id, context.erc1155amt);
+        test1155_1.mint(alice, context.args.id, context.erc1155Amt);
         offerItems.push(
             OfferItem(
                 ItemType.ERC1155,
                 address(test1155_1),
                 context.args.id,
-                context.erc1155amt,
-                context.erc1155amt
+                context.erc1155Amt,
+                context.erc1155Amt
             )
         );
         considerationItems.push(
@@ -1897,14 +1897,14 @@ contract FulfillOrderTest is BaseOrderTest {
             ? conduitKeyOne
             : bytes32(0);
 
-        test1155_1.mint(alice, context.args.id, context.erc1155amt);
+        test1155_1.mint(alice, context.args.id, context.erc1155Amt);
         offerItems.push(
             OfferItem(
                 ItemType.ERC1155,
                 address(test1155_1),
                 context.args.id,
-                context.erc1155amt,
-                context.erc1155amt
+                context.erc1155Amt,
+                context.erc1155Amt
             )
         );
 
@@ -2085,5 +2085,76 @@ contract FulfillOrderTest is BaseOrderTest {
                 .add(context.args.paymentAmts[1])
                 .add(context.args.paymentAmts[2])
         }(Order(orderParameters, signature), conduitKey);
+    }
+
+    function testFulfillOrderRevertUnusedParameterSetIdentifier(
+        FuzzInputsCommon memory inputs,
+        uint256 tokenAmount
+    ) public validateInputs(inputs) onlyPayable(inputs.zone) {
+        vm.assume(inputs.id > 0);
+        vm.assume(tokenAmount > 0);
+        test(
+            this.fulfillOrderRevertUnusedParameterSetIdentifier,
+            Context(consideration, inputs, tokenAmount, 0, 0)
+        );
+        test(
+            this.fulfillOrderRevertUnusedParameterSetIdentifier,
+            Context(referenceConsideration, inputs, tokenAmount, 0, 0)
+        );
+    }
+
+    function fulfillOrderRevertUnusedParameterSetIdentifier(
+        Context memory context
+    ) external stateless {
+        test1155_1.mint(alice, context.args.id, context.erc1155Amt);
+        _configureERC1155OfferItem(context.args.id, context.erc1155Amt);
+        _configureConsiderationItem(
+            ItemType.NATIVE,
+            bob,
+            69, // set nonzero identifier
+            100,
+            100,
+            alice
+        );
+
+        OrderComponents memory orderComponents = OrderComponents(
+            alice,
+            context.args.zone,
+            offerItems,
+            considerationItems,
+            OrderType.FULL_OPEN,
+            block.timestamp,
+            block.timestamp + 1,
+            context.args.zoneHash,
+            context.args.salt,
+            bytes32(0),
+            context.consideration.getCounter(alice)
+        );
+        bytes memory signature = signOrder(
+            context.consideration,
+            alicePk,
+            context.consideration.getOrderHash(orderComponents)
+        );
+
+        OrderParameters memory orderParameters = OrderParameters(
+            address(alice),
+            context.args.zone,
+            offerItems,
+            considerationItems,
+            OrderType.FULL_OPEN,
+            block.timestamp,
+            block.timestamp + 1,
+            context.args.zoneHash,
+            context.args.salt,
+            bytes32(0),
+            considerationItems.length
+        );
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSignature("UnusedItemParameters()"));
+        context.consideration.fulfillOrder{ value: 100 }(
+            Order(orderParameters, signature),
+            bytes32(0)
+        );
     }
 }


### PR DESCRIPTION
- test revert when token address and/or identifier is set for native consideration item when calling `fulfillBasicOrder` or `fulfillOrder`
- test revert when identifier is set for erc20 offer/consideration item when calling `fulfillBasicOrder` or `fulfillOrder`