### PR TITLE
Update CriteriaResolution.sol

### DIFF
--- a/contracts/lib/CriteriaResolution.sol
+++ b/contracts/lib/CriteriaResolution.sol
@@ -259,7 +259,7 @@ contract CriteriaResolution is CriteriaResolutionErrors {
             // Iterate over proof elements to compute root hash.
             for {
                 // Left shift by 5 is equivalent to multiplying by 0x20.
-                let end := add(data, shl(5, proof.length))
+                let end := add(data, shl(5, mload(proof)))
             } lt(data, end) {
                 data := add(data, OneWord)
             } {


### PR DESCRIPTION
Optimization of verify() by removing branches with multiplications (as is frequently done in other parts of the code).
Slightly updated from https://github.com/ProjectOpenSea/seaport/pull/393 because this was accidentally closed.
Also add an extra optimization from the source (`shl` instead of `mul`)

## Motivation
To save some gas in the Merkleproof functions.

## Solution
As suggested in the Code4rena Seaport competition and further optimized by Rari-Capital
https://github.com/Rari-Capital/solmate/blob/v7/src/utils/MerkleProof.sol

