### PR TITLE
Test that "fulfill" methods revert on Orders with Native offer items

### DIFF
--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -151,7 +151,7 @@ contract FulfillOrderTest is BaseOrderTest {
         );
 
         vm.expectRevert(abi.encodeWithSignature("InvalidNativeOfferItem()"));
-        
+
         context.consideration.fulfillOrder(
             Order(baseOrderParameters, signature),
             bytes32(0)

--- a/test/foundry/FullfillAvailableOrder.t.sol
+++ b/test/foundry/FullfillAvailableOrder.t.sol
@@ -57,6 +57,98 @@ contract FulfillAvailableOrder is BaseOrderTest {
         }
     }
 
+    function testNoNativeOffersFulfillAvailable(uint8[8] memory itemTypes)
+        public
+    {
+        uint256 tokenId;
+        for (uint256 i; i < 8; i++) {
+            ItemType itemType = ItemType(itemTypes[i] % 4);
+            if (itemType == ItemType.NATIVE) {
+                addEthOfferItem(1);
+            } else if (itemType == ItemType.ERC20) {
+                addErc20OfferItem(1);
+            } else if (itemType == ItemType.ERC1155) {
+                test1155_1.mint(alice, tokenId, 1);
+                addErc1155OfferItem(tokenId, 1);
+            } else {
+                test721_1.mint(alice, tokenId);
+                addErc721OfferItem(tokenId);
+            }
+            tokenId++;
+            offerComponents.push(FulfillmentComponent(1, i));
+        }
+        addEthOfferItem(1);
+
+        addEthConsiderationItem(alice, 1);
+        considerationComponents.push(FulfillmentComponent(1, 0));
+
+        test(
+            this.noNativeOfferItemsFulfillAvailable,
+            Context(consideration, empty, ItemType(0))
+        );
+        test(
+            this.noNativeOfferItemsFulfillAvailable,
+            Context(referenceConsideration, empty, ItemType(0))
+        );
+    }
+
+    function noNativeOfferItemsFulfillAvailable(Context memory context)
+        external
+        stateless
+    {
+        configureOrderParameters(alice);
+        uint256 counter = context.consideration.getCounter(alice);
+        _configureOrderComponents(counter);
+        bytes32 orderHash = context.consideration.getOrderHash(
+            baseOrderComponents
+        );
+        bytes memory signature = signOrder(
+            context.consideration,
+            alicePk,
+            orderHash
+        );
+
+        Order[] memory orders = new Order[](2);
+        orders[1] = Order(baseOrderParameters, signature);
+        offerComponentsArray.push(offerComponents);
+        considerationComponentsArray.push(considerationComponents);
+
+        delete offerItems;
+        delete considerationItems;
+        delete offerComponents;
+        delete considerationComponents;
+
+        token1.mint(alice, 100);
+        addErc20OfferItem(100);
+        addEthConsiderationItem(alice, 1);
+        configureOrderParameters(alice);
+        counter = context.consideration.getCounter(alice);
+        _configureOrderComponents(counter);
+        bytes32 orderHash2 = context.consideration.getOrderHash(
+            baseOrderComponents
+        );
+        bytes memory signature2 = signOrder(
+            context.consideration,
+            alicePk,
+            orderHash2
+        );
+        offerComponents.push(FulfillmentComponent(0, 0));
+        considerationComponents.push(FulfillmentComponent(0, 0));
+        offerComponentsArray.push(offerComponents);
+        considerationComponentsArray.push(considerationComponents);
+
+        orders[0] = Order(baseOrderParameters, signature2);
+
+        vm.expectRevert(abi.encodeWithSignature("InvalidNativeOfferItem()"));
+        context.consideration.fulfillAvailableOrders{ value: 2 }(
+            orders,
+            offerComponentsArray,
+            considerationComponentsArray,
+            bytes32(0),
+            2
+        );
+    }
+
     function testFulfillAvailableOrdersOverflowOfferSide() public {
         // skip eth
         for (uint256 i = 1; i < 4; ++i) {


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Test that the 4 non-basic "fulfill" methods, when handling orders with 9 Offer items (some number >=1 of the offers being native items) reverts as expected.
