### PR TITLE
Prevent compilation with future 0.9.x solidity version

### DIFF
--- a/contracts/Seaport.sol
+++ b/contracts/Seaport.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { Consideration } from "./lib/Consideration.sol";
 

--- a/contracts/conduit/Conduit.sol
+++ b/contracts/conduit/Conduit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 

--- a/contracts/conduit/ConduitController.sol
+++ b/contracts/conduit/ConduitController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 // prettier-ignore
 import {

--- a/contracts/conduit/lib/ConduitConstants.sol
+++ b/contracts/conduit/lib/ConduitConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 // error ChannelClosed(address channel)
 uint256 constant ChannelClosed_error_signature = (

--- a/contracts/conduit/lib/ConduitEnums.sol
+++ b/contracts/conduit/lib/ConduitEnums.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 enum ConduitItemType {
     NATIVE, // unused

--- a/contracts/conduit/lib/ConduitStructs.sol
+++ b/contracts/conduit/lib/ConduitStructs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import { ConduitItemType } from "./ConduitEnums.sol";
 

--- a/contracts/helpers/TransferHelper.sol
+++ b/contracts/helpers/TransferHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import "./TransferHelperStructs.sol";
 

--- a/contracts/helpers/TransferHelperStructs.sol
+++ b/contracts/helpers/TransferHelperStructs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import { ConduitItemType } from "../conduit/lib/ConduitEnums.sol";
 

--- a/contracts/interfaces/AbridgedTokenInterfaces.sol
+++ b/contracts/interfaces/AbridgedTokenInterfaces.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 interface ERC20Interface {
     function transferFrom(

--- a/contracts/interfaces/AmountDerivationErrors.sol
+++ b/contracts/interfaces/AmountDerivationErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 /**
  * @title AmountDerivationErrors

--- a/contracts/interfaces/ConduitControllerInterface.sol
+++ b/contracts/interfaces/ConduitControllerInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 /**
  * @title ConduitControllerInterface

--- a/contracts/interfaces/ConduitInterface.sol
+++ b/contracts/interfaces/ConduitInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 // prettier-ignore
 import {

--- a/contracts/interfaces/ConsiderationEventsAndErrors.sol
+++ b/contracts/interfaces/ConsiderationEventsAndErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import { SpentItem, ReceivedItem } from "../lib/ConsiderationStructs.sol";
 

--- a/contracts/interfaces/ConsiderationInterface.sol
+++ b/contracts/interfaces/ConsiderationInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 // prettier-ignore
 import {

--- a/contracts/interfaces/CriteriaResolutionErrors.sol
+++ b/contracts/interfaces/CriteriaResolutionErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 /**
  * @title CriteriaResolutionErrors

--- a/contracts/interfaces/EIP1271Interface.sol
+++ b/contracts/interfaces/EIP1271Interface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 interface EIP1271Interface {
     function isValidSignature(bytes32 digest, bytes calldata signature)

--- a/contracts/interfaces/FulfillmentApplicationErrors.sol
+++ b/contracts/interfaces/FulfillmentApplicationErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import { Side } from "../lib/ConsiderationEnums.sol";
 

--- a/contracts/interfaces/ImmutableCreate2FactoryInterface.sol
+++ b/contracts/interfaces/ImmutableCreate2FactoryInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 /**
  * @title ImmutableCreate2FactoryInterface

--- a/contracts/interfaces/ReentrancyErrors.sol
+++ b/contracts/interfaces/ReentrancyErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 /**
  * @title ReentrancyErrors

--- a/contracts/interfaces/SeaportInterface.sol
+++ b/contracts/interfaces/SeaportInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 // prettier-ignore
 import {

--- a/contracts/interfaces/SignatureVerificationErrors.sol
+++ b/contracts/interfaces/SignatureVerificationErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 /**
  * @title SignatureVerificationErrors

--- a/contracts/interfaces/TokenTransferrerErrors.sol
+++ b/contracts/interfaces/TokenTransferrerErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 /**
  * @title TokenTransferrerErrors

--- a/contracts/interfaces/TransferHelperInterface.sol
+++ b/contracts/interfaces/TransferHelperInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import { TransferHelperItem } from "../helpers/TransferHelperStructs.sol";
 

--- a/contracts/interfaces/ZoneInteractionErrors.sol
+++ b/contracts/interfaces/ZoneInteractionErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 /**
  * @title ZoneInteractionErrors

--- a/contracts/interfaces/ZoneInterface.sol
+++ b/contracts/interfaces/ZoneInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 // prettier-ignore
 import {

--- a/contracts/lib/AmountDeriver.sol
+++ b/contracts/lib/AmountDeriver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 // prettier-ignore
 import {

--- a/contracts/lib/Assertions.sol
+++ b/contracts/lib/Assertions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OrderParameters } from "./ConsiderationStructs.sol";
 

--- a/contracts/lib/BasicOrderFulfiller.sol
+++ b/contracts/lib/BasicOrderFulfiller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 

--- a/contracts/lib/Consideration.sol
+++ b/contracts/lib/Consideration.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 // prettier-ignore
 import {

--- a/contracts/lib/ConsiderationBase.sol
+++ b/contracts/lib/ConsiderationBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 // prettier-ignore
 import {

--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 /*
  * -------------------------- Disambiguation & Other Notes ---------------------

--- a/contracts/lib/ConsiderationEnums.sol
+++ b/contracts/lib/ConsiderationEnums.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 // prettier-ignore
 enum OrderType {

--- a/contracts/lib/ConsiderationStructs.sol
+++ b/contracts/lib/ConsiderationStructs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 // prettier-ignore
 import {

--- a/contracts/lib/CounterManager.sol
+++ b/contracts/lib/CounterManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 // prettier-ignore
 import {

--- a/contracts/lib/CriteriaResolution.sol
+++ b/contracts/lib/CriteriaResolution.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { ItemType, Side } from "./ConsiderationEnums.sol";
 

--- a/contracts/lib/Executor.sol
+++ b/contracts/lib/Executor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 

--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { ItemType, Side } from "./ConsiderationEnums.sol";
 

--- a/contracts/lib/GettersAndDerivers.sol
+++ b/contracts/lib/GettersAndDerivers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OrderParameters } from "./ConsiderationStructs.sol";
 

--- a/contracts/lib/LowLevelHelpers.sol
+++ b/contracts/lib/LowLevelHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import "./ConsiderationConstants.sol";
 

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { Side, ItemType } from "./ConsiderationEnums.sol";
 

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { ItemType } from "./ConsiderationEnums.sol";
 

--- a/contracts/lib/OrderValidator.sol
+++ b/contracts/lib/OrderValidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OrderType } from "./ConsiderationEnums.sol";
 

--- a/contracts/lib/ReentrancyGuard.sol
+++ b/contracts/lib/ReentrancyGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { ReentrancyErrors } from "../interfaces/ReentrancyErrors.sol";
 

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { EIP1271Interface } from "../interfaces/EIP1271Interface.sol";
 

--- a/contracts/lib/TokenTransferrer.sol
+++ b/contracts/lib/TokenTransferrer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import "./TokenTransferrerConstants.sol";
 

--- a/contracts/lib/TokenTransferrerConstants.sol
+++ b/contracts/lib/TokenTransferrerConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 /*
  * -------------------------- Disambiguation & Other Notes ---------------------

--- a/contracts/lib/Verifiers.sol
+++ b/contracts/lib/Verifiers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OrderStatus } from "./ConsiderationStructs.sol";
 

--- a/contracts/lib/ZoneInteraction.sol
+++ b/contracts/lib/ZoneInteraction.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { ZoneInterface } from "../interfaces/ZoneInterface.sol";
 

--- a/contracts/test/EIP1271Wallet.sol
+++ b/contracts/test/EIP1271Wallet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 interface ERC20ApprovalInterface {
     function approve(address, uint256) external returns (bool);

--- a/contracts/test/ERC1155BatchRecipient.sol
+++ b/contracts/test/ERC1155BatchRecipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 contract ERC1155BatchRecipient {
     error UnexpectedBatchData();

--- a/contracts/test/ExcessReturnDataRecipient.sol
+++ b/contracts/test/ExcessReturnDataRecipient.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 contract ExcessReturnDataRecipient {
     uint256 private revertDataSize;

--- a/contracts/test/Reenterer.sol
+++ b/contracts/test/Reenterer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 contract Reenterer {
     address public target;

--- a/contracts/test/TestERC1155.sol
+++ b/contracts/test/TestERC1155.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import "@rari-capital/solmate/src/tokens/ERC1155.sol";
 

--- a/contracts/test/TestERC20.sol
+++ b/contracts/test/TestERC20.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import "@rari-capital/solmate/src/tokens/ERC20.sol";
 

--- a/contracts/test/TestERC721.sol
+++ b/contracts/test/TestERC721.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import "@rari-capital/solmate/src/tokens/ERC721.sol";
 

--- a/contracts/test/TestZone.sol
+++ b/contracts/test/TestZone.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import { ZoneInterface } from "../interfaces/ZoneInterface.sol";
 

--- a/test/foundry/CeilEquivalenceTest.t.sol
+++ b/test/foundry/CeilEquivalenceTest.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 contract CeilEquivalenceTest {
     function testCeilEquivalence(uint256 numerator, uint256 denominator)

--- a/test/foundry/FulfillAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAdvancedOrder.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OneWord } from "../../contracts/lib/ConsiderationConstants.sol";
 import { OrderType, ItemType } from "../../contracts/lib/ConsiderationEnums.sol";

--- a/test/foundry/FulfillAdvancedOrderCriteria.t.sol
+++ b/test/foundry/FulfillAdvancedOrderCriteria.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { Merkle } from "murky/Merkle.sol";

--- a/test/foundry/FulfillAvailableAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAvailableAdvancedOrder.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";

--- a/test/foundry/FulfillAvailableAdvancedOrderCriteria.t.sol
+++ b/test/foundry/FulfillAvailableAdvancedOrderCriteria.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { Merkle } from "murky/Merkle.sol";

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 //Author: CupOJoseph
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { AdditionalRecipient, Order } from "../../contracts/lib/ConsiderationStructs.sol";

--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";

--- a/test/foundry/FullfillAvailableOrder.t.sol
+++ b/test/foundry/FullfillAvailableOrder.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";

--- a/test/foundry/GetterTests.t.sol
+++ b/test/foundry/GetterTests.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "./utils/BaseConsiderationTest.sol";
 

--- a/test/foundry/MatchAdvancedOrder.t.sol
+++ b/test/foundry/MatchAdvancedOrder.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OrderType, ItemType } from "../../contracts/lib/ConsiderationEnums.sol";
 import { Order } from "../../contracts/lib/ConsiderationStructs.sol";

--- a/test/foundry/MatchOrders.t.sol
+++ b/test/foundry/MatchOrders.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OrderType, ItemType } from "../../contracts/lib/ConsiderationEnums.sol";
 import { Order, Fulfillment, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";

--- a/test/foundry/NonReentrant.t.sol
+++ b/test/foundry/NonReentrant.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";

--- a/test/foundry/SignatureVerification.t.sol
+++ b/test/foundry/SignatureVerification.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { SignatureVerification } from "../../contracts/lib/SignatureVerification.sol";
 import { ReferenceSignatureVerification } from "../../reference/lib/ReferenceSignatureVerification.sol";

--- a/test/foundry/TransferHelperTest.sol
+++ b/test/foundry/TransferHelperTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 // prettier-ignore
 import { BaseConsiderationTest } from "./utils/BaseConsiderationTest.sol";
 

--- a/test/foundry/conduit/BaseConduitTest.sol
+++ b/test/foundry/conduit/BaseConduitTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "../utils/BaseConsiderationTest.sol";
 import { ConduitTransfer, ConduitItemType, ConduitBatch1155Transfer } from "../../../contracts/conduit/lib/ConduitStructs.sol";

--- a/test/foundry/conduit/ConduitExecute.t.sol
+++ b/test/foundry/conduit/ConduitExecute.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "../utils/BaseConsiderationTest.sol";
 import { ConduitTransfer, ConduitItemType } from "../../../contracts/conduit/lib/ConduitStructs.sol";

--- a/test/foundry/conduit/ConduitExecuteBatch1155.t.sol
+++ b/test/foundry/conduit/ConduitExecuteBatch1155.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "../utils/BaseConsiderationTest.sol";
 import { ConduitTransfer, ConduitBatch1155Transfer, ConduitItemType } from "../../../contracts/conduit/lib/ConduitStructs.sol";

--- a/test/foundry/conduit/ConduitExecuteWithBatch1155.t.sol
+++ b/test/foundry/conduit/ConduitExecuteWithBatch1155.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { Conduit } from "../../../contracts/conduit/Conduit.sol";
 import { ConduitController } from "../../../contracts/conduit/ConduitController.sol";

--- a/test/foundry/interfaces/OwnableDelegateProxy.sol
+++ b/test/foundry/interfaces/OwnableDelegateProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 interface OwnableDelegateProxy {
     function name() external returns (string memory);

--- a/test/foundry/interfaces/ProxyRegistry.sol
+++ b/test/foundry/interfaces/ProxyRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { OwnableDelegateProxy } from "./OwnableDelegateProxy.sol";
 

--- a/test/foundry/token/ERC721.sol
+++ b/test/foundry/token/ERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity >=0.8.0;
+pragma solidity ^0.8.0;
 
 /// @notice Modern, minimalist, and gas efficient ERC-721 implementation.
 /// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/tokens/ERC721.sol)

--- a/test/foundry/utils/ArithmeticUtil.sol
+++ b/test/foundry/utils/ArithmeticUtil.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 library ArithmeticUtil {
     ///@dev utility function to avoid overflows when multiplying fuzzed uints with widths <256

--- a/test/foundry/utils/BaseConsiderationTest.sol
+++ b/test/foundry/utils/BaseConsiderationTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { ConduitController } from "../../../contracts/conduit/ConduitController.sol";
 import { ConsiderationInterface } from "../../../contracts/interfaces/ConsiderationInterface.sol";

--- a/test/foundry/utils/BaseOrderTest.sol
+++ b/test/foundry/utils/BaseOrderTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "./BaseConsiderationTest.sol";
 import { stdStorage, StdStorage } from "forge-std/Test.sol";

--- a/test/foundry/utils/DifferentialTest.sol
+++ b/test/foundry/utils/DifferentialTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 import { Test } from "forge-std/Test.sol";
 
 contract DifferentialTest is Test {

--- a/test/foundry/utils/ERC1155Recipient.sol
+++ b/test/foundry/utils/ERC1155Recipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { ERC1155TokenReceiver } from "@rari-capital/solmate/src/tokens/ERC1155.sol";
 

--- a/test/foundry/utils/ERC721Recipient.sol
+++ b/test/foundry/utils/ERC721Recipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { ERC721TokenReceiver } from "@rari-capital/solmate/src/tokens/ERC721.sol";
 

--- a/test/foundry/utils/ExternalCounter.sol
+++ b/test/foundry/utils/ExternalCounter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 contract ExternalCounter {
     uint256 public value;

--- a/test/foundry/utils/OfferConsiderationItemAdder.sol
+++ b/test/foundry/utils/OfferConsiderationItemAdder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import { ConsiderationItem, OfferItem, ItemType } from "../../../contracts/lib/ConsiderationStructs.sol";
 import { TestTokenMinter } from "./TestTokenMinter.sol";

--- a/test/foundry/utils/PseudoRandom.sol
+++ b/test/foundry/utils/PseudoRandom.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 contract PseudoRandom {
     bytes32 seedHash;

--- a/test/foundry/utils/StructCopier.sol
+++ b/test/foundry/utils/StructCopier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 import { BasicOrderParameters, CriteriaResolver, AdvancedOrder, AdditionalRecipient, OfferItem, Order, ConsiderationItem, Fulfillment, FulfillmentComponent, OrderParameters, OrderComponents } from "../../../contracts/lib/ConsiderationStructs.sol";
 import { ConsiderationInterface } from "../../../contracts/interfaces/ConsiderationInterface.sol";
 

--- a/test/foundry/utils/TestTokenMinter.sol
+++ b/test/foundry/utils/TestTokenMinter.sol
@@ -1,5 +1,5 @@
 // SPDX-Identifier: MIT
-pragma solidity >=0.8.7;
+pragma solidity ^0.8.7;
 
 import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
 import { TestERC20 } from "../../../contracts/test/TestERC20.sol";

--- a/test/foundry/utils/reentrancy/ReentrantEnums.sol
+++ b/test/foundry/utils/reentrancy/ReentrantEnums.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 /**
  * @dev Enum of functions that set the reentrancy guard

--- a/test/foundry/utils/reentrancy/ReentrantStructs.sol
+++ b/test/foundry/utils/reentrancy/ReentrantStructs.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 import { BasicOrderParameters, OfferItem, ConsiderationItem, OrderParameters, OrderComponents, Fulfillment, FulfillmentComponent, Execution, Order, AdvancedOrder, OrderStatus, CriteriaResolver } from "../../../../contracts/lib/ConsiderationStructs.sol";
 
 struct FulfillBasicOrderParameters {


### PR DESCRIPTION

## Motivation

This was a mismatch between `reference` and `src`, and it's also arguably dangerous to use a relaxed depedency with so much assembly and low-level optimizations involved, since they could easily break in a future solidity 0.9.0 version

For reference, this was initially reported [here](https://github.com/ProjectOpenSea/seaport/pull/311#discussion_r891562552)

## Solution

Change all pragma directives from `>=` to `^`