### PR TITLE
Reverts unchecked blocks on ref implementation

### DIFF
--- a/reference/lib/ReferenceOrderCombiner.sol
+++ b/reference/lib/ReferenceOrderCombiner.sol
@@ -244,11 +244,8 @@ contract ReferenceOrderCombiner is
             // Otherwise, track the order hash in question.
             orderHashes[i] = orderHash;
 
-            // Skip underflow check as maximumFulfilled is nonzero.
-            unchecked {
-                // Decrement the number of fulfilled orders.
-                maximumFulfilled--;
-            }
+            // Decrement the number of fulfilled orders.
+            maximumFulfilled--;
 
             // Place the start time for the order on the stack.
             uint256 startTime = advancedOrder.parameters.startTime;
@@ -493,11 +490,8 @@ contract ReferenceOrderCombiner is
 
             // If offerer and recipient on the execution are the same...
             if (execution.item.recipient == execution.offerer) {
-                // Executions start at 0, infeasible to increment > 2^256.
-                unchecked {
-                    // Increment total filtered executions.
-                    ++totalFilteredExecutions;
-                }
+                // Increment total filtered executions.
+                ++totalFilteredExecutions;
             } else {
                 // Otherwise, assign the execution to the executions array.
                 executions[i - totalFilteredExecutions] = execution;
@@ -522,11 +516,8 @@ contract ReferenceOrderCombiner is
 
             // If offerer and recipient on the execution are the same...
             if (execution.item.recipient == execution.offerer) {
-                // Executions start at 0, infeasible to increment > 2^256.
-                unchecked {
-                    // Increment total filtered executions.
-                    ++totalFilteredExecutions;
-                }
+                // Increment total filtered executions.
+                ++totalFilteredExecutions;
             } else {
                 // Otherwise, assign the execution to the executions array.
                 executions[
@@ -782,11 +773,8 @@ contract ReferenceOrderCombiner is
 
             // If offerer and recipient on the execution are the same...
             if (execution.item.recipient == execution.offerer) {
-                // Executions start at 0, infeasible to increment > 2^256.
-                unchecked {
-                    // Increment total filtered executions.
-                    ++totalFilteredExecutions;
-                }
+                // Increment total filtered executions.
+                ++totalFilteredExecutions;
             } else {
                 // Otherwise, assign the execution to the executions array.
                 executions[i - totalFilteredExecutions] = execution;


### PR DESCRIPTION
#350 introduced some new unchecked blocks to OrderCombiner. But it also did it for the reference implementation,  which seems to not be in line with the intended design.