### PR TITLE
Using SeaportInterface selectors

### DIFF
--- a/reference/lib/ReferenceOrderCombiner.sol
+++ b/reference/lib/ReferenceOrderCombiner.sol
@@ -27,6 +27,8 @@ import { ReferenceFulfillmentApplier } from "./ReferenceFulfillmentApplier.sol";
 
 import "contracts/lib/ConsiderationConstants.sol";
 
+import { SeaportInterface } from "contracts/interfaces/SeaportInterface.sol";
+
 /**
  * @title OrderCombiner
  * @author 0age
@@ -195,7 +197,9 @@ contract ReferenceOrderCombiner is
         bytes32[] memory orderHashes = new bytes32[](totalOrders);
 
         // Check if we are in a match function
-        bool nonMatchFn = msg.sig != 0x55944a42 && msg.sig != 0xa8174404;
+        bool nonMatchFn = msg.sig !=
+            SeaportInterface.matchAdvancedOrders.selector &&
+            msg.sig != SeaportInterface.matchOrders.selector;
         bool anyNativeOfferItems;
 
         // Iterate over each order.


### PR DESCRIPTION
Originally suggested [here](https://github.com/ProjectOpenSea/seaport/pull/464#discussion_r893594020)

There's no `ReferenceSeaportInterface`, so I had to import from `src`, which I'm not thrilled about. Could potentially copy it into reference as well?
Avoided doing that for now until someone reviews and deems this worth the effort

# Motivation

Keeping the reference implementation as readable as possible