### PR TITLE
WIP (Vyper): connecting `GettersAndDrivers.vy` to `Consideration.vy`

### DIFF
--- a/hardhat-vyper.config.ts
+++ b/hardhat-vyper.config.ts
@@ -17,7 +17,7 @@ subtask(TASK_COMPILE_VYPER_RUN_BINARY).setAction(compileHook);
 
 const config: HardhatUserConfig = {
   vyper: {
-    version: "0.3.3",
+    version: "0.3.4",
   },
   networks: {
     hardhat: {

--- a/vyper/contracts/interfaces/ConduitControllerInterface.vy
+++ b/vyper/contracts/interfaces/ConduitControllerInterface.vy
@@ -1,4 +1,4 @@
-# @version 0.3.3
+# @version 0.3.4
 
 MAX_DYN_ARRAY_LENGTH: constant(uint8) = 100
 

--- a/vyper/contracts/libs/Consideration.vy
+++ b/vyper/contracts/libs/Consideration.vy
@@ -1,0 +1,22 @@
+# @version 0.3.4
+
+#pragma once
+#include "GettersAndDrivers.vy"
+
+# TODO: include the top (grand)children
+
+@external
+def __init__(conduitController: address):
+    # self.consideration_base__init__(conduitController)
+
+    # The following has been hoisted up from ConsiderationBase.vy, Since
+    # Vyper only allows 1 __init__ function per contract and cannot delegate
+    # assignment for immutable variables to other internal functions. This also
+    # stems from lack of inheritance structure for Vyper. Our current strategy of
+    # simulating inheritance is by preprocessing/concatenating parent contracts to
+    # the children.
+    _CHAIN_ID = chain.id
+    _DOMAIN_SEPARATOR = self._deriveDomainSeparator()
+
+
+    _CONDUIT_CONTROLLER = conduitController

--- a/vyper/contracts/libs/ConsiderationBase.vy
+++ b/vyper/contracts/libs/ConsiderationBase.vy
@@ -1,164 +1,49 @@
-# @version 0.3.3
+# @version 0.3.4
 
-from ..interfaces import ConduitControllerInterface
+# pragma once
 
-MAX_BYTE_LENGTH: constant(uint8) = 100
-OFFER_ITEM_TYPE_STRING_LENGTH: constant(uint8) = 106
-CONSIDERATION_ITEM_TYPE_STRING_LENGTH: constant(uint8) = 132
-ORDER_COMPONENT_PARTIAL_TYPE_STRING_LENGTH: constant(uint8) = 210
+CONSIDERATION_LENGTH: constant(uint8) = 13
 
 # Precompute hashes, original chainId, and domain separator on deployment.
-_NAME_HASH: immutable(bytes32)
-_VERSION_HASH: immutable(bytes32)
-_EIP_712_DOMAIN_TYPEHASH: immutable(bytes32)
-_OFFER_ITEM_TYPEHASH: immutable(bytes32)
-_CONSIDERATION_ITEM_TYPEHASH: immutable(bytes32)
-_ORDER_TYPEHASH:immutable(bytes32) 
+_NAME_HASH: constant(bytes32) = keccak256("Consideration")
+_VERSION_HASH: constant(bytes32) = keccak256("1.1")
+
+_EIP_712_DOMAIN_TYPEHASH: constant(bytes32) = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+_OFFER_ITEM_TYPEHASH: constant(bytes32) = keccak256("OfferItem(uint8 itemType,address token,uint256 identifierOrCriteria,uint256 startAmount,uint256 endAmount)")
+_CONSIDERATION_ITEM_TYPEHASH: constant(bytes32) = keccak256("ConsiderationItem(uint8 itemType,address token,uint256 identifierOrCriteria,uint256 startAmount,uint256 endAmount,address recipient)")
+_ORDER_TYPEHASH: constant(bytes32) = keccak256("OrderComponents(address offerer,address zone,OfferItem[] offer,ConsiderationItem[] consideration,uint8 orderType,uint256 startTime,uint256 endTime,bytes32 zoneHash,uint256 salt,bytes32 conduitKey,uint256 counter)ConsiderationItem(uint8 itemType,address token,uint256 identifierOrCriteria,uint256 startAmount,uint256 endAmount,address recipient)OfferItem(uint8 itemType,address token,uint256 identifierOrCriteria,uint256 startAmount,uint256 endAmount)")
+
 _CHAIN_ID: immutable(uint256)
 _DOMAIN_SEPARATOR: immutable(bytes32)
 
 # Allow for interaction with the conduit controller.
-_CONDUIT_CONTROLLER: immutable(ConduitControllerInterface)
+_CONDUIT_CONTROLLER: immutable(address)
 
 # Cache the conduit creation code hash used by the conduit controller.
-_CONDUIT_CREATION_CODE_HASH: immutable(bytes32)
+# TODO: calculate
+_CONDUIT_CREATION_CODE_HASH: constant(bytes32) = 0x0000000000000000000000000000000000000000000000000000000000000000
 
 @pure
 @internal
-def _name() -> (String[MAX_BYTE_LENGTH]):
+def _name() -> (String[CONSIDERATION_LENGTH]):
     """
     @dev Internal pure function to retrieve the default name of this
          contract and return.
     
     @return The name of this contract.
     """
-    raise "Not Implemented"
+    return "Consideration"
 
 @pure
 @internal
-def _nameString() -> (String[MAX_BYTE_LENGTH]):
+def _nameString() -> (String[CONSIDERATION_LENGTH]):
     """
     @dev Internal pure function to retrieve the default name of this contract
          as a string that can be used internally.
         
     @return The name of this contract.
     """
-    # Return the name of the contract.
     return "Consideration"
-
-@view
-@internal
-def _deriveTypehashes() -> (bytes32,bytes32,bytes32,bytes32,bytes32,bytes32):
-    """
-    @dev Internal pure function to derive required EIP-712 typehashes and
-         other hashes during contract creation.
-        
-    @return nameHash                  The hash of the name of the contract.
-    @return versionHash               The hash of the version string of the
-                                      contract.
-    @return eip712DomainTypehash      The primary EIP-712 domain typehash.
-    @return offerItemTypehash         The EIP-712 typehash for OfferItem
-                                      types.
-    @return considerationItemTypehash The EIP-712 typehash for
-                                      ConsiderationItem types.
-    @return orderTypehash             The EIP-712 typehash for Order types.
-    """
-    # Derive hash of the name of the contract.
-    nameHash: bytes32 = keccak256(convert(self._nameString(), Bytes))
-
-    # Derive hash of the version string of the contract.
-    versionHash: bytes32 = keccak256(convert("1", Bytes))
-
-    # Construct the OfferItem type string.
-    offerItemTypeString: Bytes[
-        OFFER_ITEM_TYPE_STRING_LENGTH
-    ] = _abi_encode(
-        concat(
-            "OfferItem(",
-                "uint8 itemType,",
-                "address token,",
-                "uint256 identifierOrCriteria,",
-                "uint256 startAmount,",
-                "uint256 endAmount",
-            ")"
-        )
-    )
-
-    # Construct the ConsiderationItem type string.
-    considerationItemTypeString: Bytes[
-        CONSIDERATION_ITEM_TYPE_STRING_LENGTH
-    ] = _abi_encode(
-        concat(
-            "ConsiderationItem(",
-                "uint8 itemType,",
-                "address token,",
-                "uint256 identifierOrCriteria,",
-                "uint256 startAmount,",
-                "uint256 endAmount,",
-                "address recipient",
-            ")"
-        )
-    )
-
-    # Construct the OrderComponents type string, not including the above.
-    orderComponentsPartialTypeString: Bytes[
-        ORDER_COMPONENT_PARTIAL_TYPE_STRING_LENGTH
-    ] = _abi_encode(
-        concat(
-            "OrderComponents(",
-                "address offerer,",
-                "address zone,",
-                "OfferItem[] offer,",
-                "ConsiderationItem[] consideration,",
-                "uint8 orderType,",
-                "uint256 startTime,",
-                "uint256 endTime,",
-                "bytes32 zoneHash,",
-                "uint256 salt,",
-                "bytes32 conduitKey,",
-                "uint256 nonce",
-            ")"
-        )
-    )
-
-    # Construct the primary EIP-712 domain type string.
-    eip712DomainTypehash: bytes32 = keccak256(
-        _abi_encode(
-            concat(
-                "EIP712Domain(",
-                    "string name,",
-                    "string version,",
-                    "uint256 chainId,",
-                    "address verifyingContract",
-                ")"
-            )
-        )
-    )
-
-    # Derive the OfferItem type hash using the corresponding type string.
-    offerItemTypehash: bytes32 = keccak256(offerItemTypeString)
-
-    # Derive ConsiderationItem type hash using corresponding type string.
-    considerationItemTypehash: bytes32 = keccak256(considerationItemTypeString)
-
-    # Derive OrderItem type hash via combination of relevant type strings.
-    orderTypehash: bytes32 = keccak256(
-        concat(
-            orderComponentsPartialTypeString,
-            considerationItemTypeString,
-            offerItemTypeString
-        )
-    )
-
-    return (
-        nameHash,
-        versionHash,
-        eip712DomainTypehash,
-        offerItemTypehash,
-        considerationItemTypehash,
-        orderTypehash
-    )
-
 
 @view
 @internal
@@ -174,13 +59,13 @@ def _deriveDomainSeparator() -> (bytes32):
             _EIP_712_DOMAIN_TYPEHASH,
             _NAME_HASH,
             _VERSION_HASH,
-            block.chainid,
-            address(this)
+            chain.id,
+            self
         )
     )
 
-@external
-def __init__():
+@internal
+def consideration_base__init__(conduitController: address):
     """
     @dev Derive and set hashes, reference chainId, and associated domain
          separator during deployment.
@@ -189,24 +74,11 @@ def __init__():
                              that may optionally be used to transfer approved
                              ERC20/721/1155 tokens.
     """
-    # Derive name and version hashes alongside required EIP-712 typehashes.
-    (
-        _NAME_HASH,
-        _VERSION_HASH,
-        _EIP_712_DOMAIN_TYPEHASH,
-        _OFFER_ITEM_TYPEHASH,
-        _CONSIDERATION_ITEM_TYPEHASH,
-        _ORDER_TYPEHASH
-    ) = self._deriveTypehashes()
 
     # Store the current chainId and derive the current domain separator.
-    _CHAIN_ID = block.chainid
-    _DOMAIN_SEPARATOR = self._deriveDomainSeparator()
+    # The following assignments are delegated to the __init__ for Consideration.vy
+    # _CHAIN_ID = chain.id
+    # _DOMAIN_SEPARATOR = self._deriveDomainSeparator()
 
-    # Set the supplied conduit controller.
-    _CONDUIT_CONTROLLER = ConduitControllerInterface(conduitController)
-
-    # Retrieve the conduit creation code hash from the supplied controller.
-    (_CONDUIT_CREATION_CODE_HASH, ) = (
-        _CONDUIT_CONTROLLER.getConduitCodeHashes()
-    )
+    # # Set the supplied conduit controller.
+    # _CONDUIT_CONTROLLER = conduitController

--- a/vyper/contracts/libs/ConsiderationEnums.vy
+++ b/vyper/contracts/libs/ConsiderationEnums.vy
@@ -1,0 +1,137 @@
+# @version 0.3.4
+
+#pragma once
+
+enum OrderType:
+    # 0: no partial fills, anyone can execute
+    FULL_OPEN
+
+    # 1: partial fills supported, anyone can execute
+    PARTIAL_OPEN
+
+    # 2: no partial fills, only offerer or zone can execute
+    FULL_RESTRICTED
+
+    # 3: partial fills supported, only offerer or zone can execute
+    PARTIAL_RESTRICTED
+
+enum BasicOrderType:
+    # 0: no partial fills, anyone can execute
+    ETH_TO_ERC721_FULL_OPEN
+
+    # 1: partial fills supported, anyone can execute
+    ETH_TO_ERC721_PARTIAL_OPEN
+
+    # 2: no partial fills, only offerer or zone can execute
+    ETH_TO_ERC721_FULL_RESTRICTED
+
+    # 3: partial fills supported, only offerer or zone can execute
+    ETH_TO_ERC721_PARTIAL_RESTRICTED
+
+    # 4: no partial fills, anyone can execute
+    ETH_TO_ERC1155_FULL_OPEN
+
+    # 5: partial fills supported, anyone can execute
+    ETH_TO_ERC1155_PARTIAL_OPEN
+
+    # 6: no partial fills, only offerer or zone can execute
+    ETH_TO_ERC1155_FULL_RESTRICTED
+
+    # 7: partial fills supported, only offerer or zone can execute
+    ETH_TO_ERC1155_PARTIAL_RESTRICTED
+
+    # 8: no partial fills, anyone can execute
+    ERC20_TO_ERC721_FULL_OPEN
+
+    # 9: partial fills supported, anyone can execute
+    ERC20_TO_ERC721_PARTIAL_OPEN
+
+    # 10: no partial fills, only offerer or zone can execute
+    ERC20_TO_ERC721_FULL_RESTRICTED
+
+    # 11: partial fills supported, only offerer or zone can execute
+    ERC20_TO_ERC721_PARTIAL_RESTRICTED
+
+    # 12: no partial fills, anyone can execute
+    ERC20_TO_ERC1155_FULL_OPEN
+
+    # 13: partial fills supported, anyone can execute
+    ERC20_TO_ERC1155_PARTIAL_OPEN
+
+    # 14: no partial fills, only offerer or zone can execute
+    ERC20_TO_ERC1155_FULL_RESTRICTED
+
+    # 15: partial fills supported, only offerer or zone can execute
+    ERC20_TO_ERC1155_PARTIAL_RESTRICTED
+
+    # 16: no partial fills, anyone can execute
+    ERC721_TO_ERC20_FULL_OPEN
+
+    # 17: partial fills supported, anyone can execute
+    ERC721_TO_ERC20_PARTIAL_OPEN
+
+    # 18: no partial fills, only offerer or zone can execute
+    ERC721_TO_ERC20_FULL_RESTRICTED
+
+    # 19: partial fills supported, only offerer or zone can execute
+    ERC721_TO_ERC20_PARTIAL_RESTRICTED
+
+    # 20: no partial fills, anyone can execute
+    ERC1155_TO_ERC20_FULL_OPEN
+
+    # 21: partial fills supported, anyone can execute
+    ERC1155_TO_ERC20_PARTIAL_OPEN
+
+    # 22: no partial fills, only offerer or zone can execute
+    ERC1155_TO_ERC20_FULL_RESTRICTED
+
+    # 23: partial fills supported, only offerer or zone can execute
+    ERC1155_TO_ERC20_PARTIAL_RESTRICTED
+
+
+enum BasicOrderRouteType:
+    # 0: provide Ether (or other native token) to receive offered ERC721 item.
+    ETH_TO_ERC721
+
+    # 1: provide Ether (or other native token) to receive offered ERC1155 item.
+    ETH_TO_ERC1155
+
+    # 2: provide ERC20 item to receive offered ERC721 item.
+    ERC20_TO_ERC721
+
+    # 3: provide ERC20 item to receive offered ERC1155 item.
+    ERC20_TO_ERC1155
+
+    # 4: provide ERC721 item to receive offered ERC20 item.
+    ERC721_TO_ERC20
+
+    # 5: provide ERC1155 item to receive offered ERC20 item.
+    ERC1155_TO_ERC20
+
+
+enum ItemType:
+    # 0: ETH on mainnet, MATIC on polygon, etc.
+    NATIVE
+
+    # 1: ERC20 items (ERC777 and ERC20 analogues could also technically work)
+    ERC20
+
+    # 2: ERC721 items
+    ERC721
+
+    # 3: ERC1155 items
+    ERC1155
+
+    # 4: ERC721 items where a number of tokenIds are supported
+    ERC721_WITH_CRITERIA
+
+    # 5: ERC1155 items where a number of ids are supported
+    ERC1155_WITH_CRITERIA
+
+
+enum Side:
+    # 0: Items that can be spent
+    OFFER
+
+    # 1: Items that must be received
+    CONSIDERATION

--- a/vyper/contracts/libs/ConsiderationStructs.vy
+++ b/vyper/contracts/libs/ConsiderationStructs.vy
@@ -1,0 +1,226 @@
+# @version 0.3.4
+
+#pragma once
+#include "ConsiderationEnums.vy"
+
+MAX_DYN_ARRAY_LENGTH: constant(uint256) = 100
+
+#
+# @dev An offer item has five components: an item type (ETH or other native
+#      tokens, ERC20, ERC721, and ERC1155, as well as criteria-based ERC721 and
+#      ERC1155), a token address, a dual-purpose "identifierOrCriteria"
+#      component that will either represent a tokenId or a merkle root
+#      depending on the item type, and a start and end amount that support
+#      increasing or decreasing amounts over the duration of the respective
+#      order.
+#
+struct OfferItem:
+    itemType: ItemType
+    token: address
+    identifierOrCriteria: uint256
+    startAmount: uint256
+    endAmount: uint256
+
+#
+# @dev A consideration item has the same five components as an offer item and
+#      an additional sixth component designating the required recipient of the
+#      item.
+#
+struct ConsiderationItem:
+    itemType: ItemType
+    token: address
+    identifierOrCriteria: uint256
+    startAmount: uint256
+    endAmount: uint256
+    recipient: address
+
+#
+# @dev An order contains eleven components: an offerer, a zone (or account that
+#      can cancel the order or restrict who can fulfill the order depending on
+#      the type), the order type (specifying partial fill support as well as
+#      restricted order status), the start and end time, a hash that will be
+#      provided to the zone when validating restricted orders, a salt, a key
+#      corresponding to a given conduit, a counter, and an arbitrary number of
+#      offer items that can be spent along with consideration items that must
+#      be received by their respective recipient.
+#
+struct OrderComponents:
+    offerer: address
+    zone: address
+    offer: DynArray[OfferItem, MAX_DYN_ARRAY_LENGTH]
+    consideration: DynArray[ConsiderationItem, MAX_DYN_ARRAY_LENGTH]
+    orderType: OrderType 
+    startTime: uint256
+    endTime: uint256
+    zoneHash: bytes32
+    salt: uint256
+    conduitKey: bytes32
+    counter: uint256
+
+#
+# @dev A spent item is translated from a utilized offer item and has four
+#      components: an item type (ETH or other native tokens, ERC20, ERC721, and
+#      ERC1155), a token address, a tokenId, and an amount.
+#
+struct SpentItem:
+    itemType: ItemType
+    token: address
+    identifier: uint256
+    amount: uint256
+
+#
+# @dev A received item is translated from a utilized consideration item and has
+#      the same four components as a spent item, as well as an additional fifth
+#      component designating the required recipient of the item.
+#
+struct ReceivedItem:
+    itemType: ItemType
+    token: address
+    identifier: uint256
+    amount: uint256
+    recipient: address
+
+#
+# @dev Basic orders can supply any number of additional recipients, with the
+#      implied assumption that they are supplied from the offered ETH (or other
+#      native token) or ERC20 token for the order.
+#
+struct AdditionalRecipient:
+    amount: uint256
+    recipient: address
+
+#
+# @dev For basic orders involving ETH / native / ERC20 <=> ERC721 / ERC1155
+#      matching, a group of six functions may be called that only requires a
+#      subset of the usual order arguments. Note the use of a "basicOrderType"
+#      enum; this represents both the usual order type as well as the "route"
+#      of the basic order (a simple derivation function for the basic order
+#      type is `basicOrderType = orderType + (4 * basicOrderRoute)`.)
+#
+struct BasicOrderParameters:
+    # calldata offset
+    considerationToken: address # 0x24
+    considerationIdentifier: uint256 # 0x44
+    considerationAmount: uint256 # 0x64
+    offerer: address # 0x84
+    zone: address # 0xa4
+    offerToken: address # 0xc4
+    offerIdentifier: uint256 # 0xe4
+    offerAmount: uint256 # 0x104
+    basicOrderType: BasicOrderType # 0x124
+    startTime: uint256 # 0x144
+    endTime: uint256 # 0x164
+    zoneHash: bytes32 # 0x184
+    salt: uint256 # 0x1a4
+    offererConduitKey: bytes32 # 0x1c4
+    fulfillerConduitKey: bytes32 # 0x1e4
+    totalOriginalAdditionalRecipients: uint256 # 0x204
+    additionalRecipients: DynArray[AdditionalRecipient, MAX_DYN_ARRAY_LENGTH] # 0x224
+    signature: DynArray[bytes1, MAX_DYN_ARRAY_LENGTH] # 0x244
+    # Total length, excluding dynamic array data: 0x264 (580)
+
+#
+# @dev The full set of order components, with the exception of the counter,
+#      must be supplied when fulfilling more sophisticated orders or groups of
+#      orders. The total number of original consideration items must also be
+#      supplied, as the caller may specify additional consideration items.
+#
+struct OrderParameters:
+    offerer: address # 0x00
+    zone: address # 0x20
+    offer: DynArray[OfferItem, MAX_DYN_ARRAY_LENGTH] # 0x40
+    consideration: DynArray[ConsiderationItem, MAX_DYN_ARRAY_LENGTH] # 0x60
+    orderType: OrderType # 0x80
+    startTime: uint256 # 0xa0
+    endTime: uint256 # 0xc0
+    zoneHash: bytes32 # 0xe0
+    salt: uint256 # 0x100
+    conduitKey: bytes32 # 0x120
+    totalOriginalConsiderationItems: uint256 # 0x140
+    # offer.length                          # 0x160
+
+#
+# @dev Orders require a signature in addition to the other order parameters.
+#
+struct Order:
+    parameters: OrderParameters
+    signature: DynArray[bytes1, MAX_DYN_ARRAY_LENGTH]
+
+#
+# @dev Advanced orders include a numerator (i.e. a fraction to attempt to fill)
+#      and a denominator (the total size of the order) in addition to the
+#      signature and other order parameters. It also supports an optional field
+#      for supplying extra data; this data will be included in a staticcall to
+#      `isValidOrderIncludingExtraData` on the zone for the order if the order
+#      type is restricted and the offerer or zone are not the caller.
+#
+struct AdvancedOrder:
+    parameters: OrderParameters
+    numerator: uint120
+    denominator: uint120
+    signature: DynArray[bytes1, MAX_DYN_ARRAY_LENGTH]
+    extraData: DynArray[bytes1, MAX_DYN_ARRAY_LENGTH]
+
+#
+# @dev Orders can be validated (either explicitly via `validate`, or as a
+#      consequence of a full or partial fill), specifically cancelled (they can
+#      also be cancelled in bulk via incrementing a per-zone counter), and
+#      partially or fully filled (with the fraction filled represented by a
+#      numerator and denominator).
+#
+struct OrderStatus:
+    isValidated: bool
+    isCancelled: bool
+    numerator: uint120
+    denominator: uint120
+
+#
+# @dev A criteria resolver specifies an order, side (offer vs. consideration),
+#      and item index. It then provides a chosen identifier (i.e. tokenId)
+#      alongside a merkle proof demonstrating the identifier meets the required
+#      criteria.
+#
+struct CriteriaResolver:
+    orderIndex: uint256
+    side: Side
+    index: uint256
+    identifier: uint256
+    criteriaProof: DynArray[bytes32, MAX_DYN_ARRAY_LENGTH]
+
+
+#
+# @dev Each fulfillment component contains one index referencing a specific
+#      order and another referencing a specific offer or consideration item.
+#
+struct FulfillmentComponent:
+    orderIndex: uint256
+    itemIndex: uint256
+
+#
+# @dev A fulfillment is applied to a group of orders. It decrements a series of
+#      offer and consideration items, then generates a single execution
+#      element. A given fulfillment can be applied to as many offer and
+#      consideration items as desired, but must contain at least one offer and
+#      at least one consideration that match. The fulfillment must also remain
+#      consistent on all key parameters across all offer items (same offerer,
+#      token, type, tokenId, and conduit preference) as well as across all
+#      consideration items (token, type, tokenId, and recipient).
+#
+struct Fulfillment:
+    offerComponents: DynArray[FulfillmentComponent, MAX_DYN_ARRAY_LENGTH]
+    considerationComponents: DynArray[FulfillmentComponent, MAX_DYN_ARRAY_LENGTH]
+
+#
+# @dev An execution is triggered once all consideration items have been zeroed
+#      out. It sends the item in question from the offerer to the item's
+#      recipient, optionally sourcing approvals from either this contract
+#      directly or from the offerer's chosen conduit if one is specified. An
+#      execution is not provided as an argument, but rather is derived via
+#      orders, criteria resolvers, and fulfillments (where the total number of
+#      executions will be less than or equal to the total number of indicated
+#      fulfillments) and returned as part of `matchOrders`.
+#
+struct Execution:
+    item: ReceivedItem
+    offerer: address
+    conduitKey: bytes32

--- a/vyper/contracts/libs/GettersAndDrivers.vy
+++ b/vyper/contracts/libs/GettersAndDrivers.vy
@@ -1,0 +1,174 @@
+# @version 0.3.4
+
+#pragma once
+
+#include "ConsiderationStructs.vy"
+#include "ConsiderationBase.vy"
+
+@view
+@internal
+def _deriveOrderHash(orderParameters: OrderParameters, counter: uint256) -> bytes32:
+    """
+    @dev Internal view function to derive the order hash for a given order.
+         Note that only the original consideration items are included in the
+         order hash, as additional consideration items may be supplied by the
+         caller.
+        
+    @param orderParameters The parameters of the order to hash.
+    @param counter           The counter of the order to hash.
+        
+    @return orderHash The hash.
+    """
+    # Calculate Offer Hash
+    offerHashArr: uint8[32 * MAX_DYN_ARRAY_LENGTH] = empty(uint8[32 * MAX_DYN_ARRAY_LENGTH])
+
+    i: uint256 = 0
+    for offerItem in orderParameters.offer:
+        tempHash: uint256 = convert(
+            keccak256(
+                concat(
+                    _OFFER_ITEM_TYPEHASH,
+                    convert(offerItem.itemType, bytes32),
+                    convert(offerItem.token, bytes32),
+                    convert(offerItem.identifierOrCriteria, bytes32),
+                    convert(offerItem.startAmount, bytes32),
+                    convert(offerItem.endAmount, bytes32)
+                )
+            ), 
+            uint256
+        )
+
+        for j in range(32):
+            offerHashArr[i + j] = shift(tempHash, -31 + j) & 255
+
+        i += 32
+    
+
+    offerHash: bytes32 = keccak256(
+        convert(
+            offerHashArr, 
+            Bytes[32 * MAX_DYN_ARRAY_LENGTH]
+        )
+    )
+
+    # Calculate Consideration Hash
+    considerationHashArr: uint8[32 * MAX_DYN_ARRAY_LENGTH] = empty(uint8[32 * MAX_DYN_ARRAY_LENGTH])
+
+    i = 0
+    for considerationItem in orderParameters.consideration:
+        tempHash: uint256 = convert(
+            keccak256(
+                    concat(
+                    _CONSIDERATION_ITEM_TYPEHASH,
+                    convert(considerationItem.itemType, bytes32),
+                    convert(considerationItem.token, bytes32),
+                    convert(considerationItem.identifierOrCriteria, bytes32),
+                    convert(considerationItem.startAmount, bytes32),
+                    convert(considerationItem.endAmount, bytes32),
+                    convert(considerationItem.recipient, bytes32)
+                )
+            ), 
+            uint256
+        )
+
+        for j in range(32):
+            considerationHashArr[i + j] = shift(tempHash, -31 + j) & 255
+
+        i += 32
+
+    considerationHash: bytes32 = keccak256(
+        convert(
+            considerationHashArr, 
+            Bytes[32 * MAX_DYN_ARRAY_LENGTH]
+        )
+    )
+
+    return keccak256(
+        concat(
+            _ORDER_TYPEHASH,
+            convert(orderParameters.offerer, bytes32),
+            convert(orderParameters.zone, bytes32),
+            offerHash,
+            considerationHash,
+            convert(orderParameters.orderType, bytes32),
+            convert(orderParameters.startTime, bytes32),
+            convert(orderParameters.endTime, bytes32),
+            orderParameters.zoneHash,
+            convert(orderParameters.salt, bytes32),
+            orderParameters.conduitKey,
+            convert(counter, bytes32)
+        )
+    )
+
+
+@view
+@internal
+def _deriveConduit(conduitKey: bytes32) -> address:
+    """
+    @dev Internal view function to derive the address of a given conduit
+         using a corresponding conduit key.
+        
+    @param conduitKey A bytes32 value indicating what corresponding conduit,
+                      if any, to source token approvals from. This value is
+                      the "salt" parameter supplied by the deployer (i.e. the
+                      conduit controller) when deploying the given conduit.
+        
+    @return conduit The address of the conduit associated with the given
+                    conduit key.
+    """
+    return convert(
+        keccak256(
+            concat(
+                0xff, 
+                convert(_CONDUIT_CONTROLLER, bytes20), 
+                _CONDUIT_CREATION_CODE_HASH
+            )
+        ), address
+    )
+
+@view
+@internal
+def _domainSeparator() -> bytes32:
+    """
+    @dev Internal view function to get the EIP-712 domain separator. If the
+         chainId matches the chainId set on deployment, the cached domain
+         separator will be returned; otherwise, it will be derived from
+         scratch.
+        
+    @return The domain separator.
+    """
+    if(chain.id == _CHAIN_ID):
+        return _DOMAIN_SEPARATOR
+
+    return self._deriveDomainSeparator()
+
+@view
+@internal
+def _information() -> (String[3], bytes32, address):
+    """
+    @dev Internal view function to retrieve configuration information for
+         this contract.
+        
+    @return version           The contract version.
+    @return domainSeparator   The domain separator for this contract.
+    @return conduitController The conduit Controller set for this contract.
+    """
+    return (
+        "1.1",
+        self._domainSeparator(),
+        _CONDUIT_CONTROLLER
+    )
+
+@pure
+@internal
+def _deriveEIP712Digest(domainSeparator: bytes32, orderHash: bytes32) -> bytes32:
+    """
+    @dev Internal pure function to efficiently derive an digest to sign for
+         an order in accordance with EIP-712.
+        
+    @param domainSeparator The domain separator.
+    @param orderHash       The order hash.
+        
+    @return value The hash.
+    """
+    return keccak256(_abi_encode(0x1901, domainSeparator, orderHash))


### PR DESCRIPTION
## Motivation

In this PR, we try to connect (via pre-processing macro tags) `GettersAndDrivers.vy` and `Consideration.vy`. The connection is almost done, except there is an issue in the `_deriveOrderHash` method which is not even related to inheritance/pre-processing. The issue is related to type conversion in Vyper.

## Strategy

- Hoist all immutable initializations to the root contract at `Consideration.vy` since Vyper can have only one `__init__` method.
- Examples of pre-processing pragmas used:

```c
#pragma once
#include "GettersAndDrivers.vy"
```

## Issues

### Type Conversion
Juggling type conversions in Vyper is not as easy. In `_deriveOrderHash` we need to loop over `offer` and `consideration` to calculate the `orderHash` (They are arrays of variable size). Concatenating the hashes of individual `offerItems` or `considerationItems` and `keccak`ing the result would require a direct or indirect series of type conversions which are not yet implemented in Vyper.

#### Possible Solutions

These solution needs to be implemented for the compiler to work:

- Ability to `convert` an array of `uint8` to an array of `Bytes`.
- Ability to expand or concatenate more elements to `Bytes[M]`.
- Ability to concatenate `DynArray` types (related to [methods for modifying dynamic arrays vyper#2611](https://github.com/vyperlang/vyper/issues/2611)).
- Ability to iterate over a `Bytes` array.

#### Enum Conversion

Looks like `convert` is not implemented for `Enum` types:

```vyper
Enum A:
   AA
   AAA
   
a: A = AA
b: uint8 = convert(a, uint8)
```

### Bitwise Arithmetic

The latest Vyper compiler gives an error when trying to use `&` (`x: uint256 = 1 & 1`): `vyper.exceptions.SyntaxException: Invalid syntax (unsupported 'BitAnd' Python AST node)`. This one might be related to my environment (platform, `python` version, etc)

## TODO

Calculate `_CONDUIT_CREATION_CODE_HASH` and add it to `ConsiderationBase.vy`
