### PR TITLE
Reconfigure remappings and refactor imports

### DIFF
--- a/contracts/conduit/Conduit.sol
+++ b/contracts/conduit/Conduit.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
+import { ConduitInterface } from "seaport/interfaces/ConduitInterface.sol";
 
 import { ConduitItemType } from "./lib/ConduitEnums.sol";
 
-import { TokenTransferrer } from "../lib/TokenTransferrer.sol";
+import { TokenTransferrer } from "seaport/lib/TokenTransferrer.sol";
 
 // prettier-ignore
 import {

--- a/contracts/conduit/ConduitController.sol
+++ b/contracts/conduit/ConduitController.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.7;
 // prettier-ignore
 import {
 	ConduitControllerInterface
-} from "../interfaces/ConduitControllerInterface.sol";
+} from "seaport/interfaces/ConduitControllerInterface.sol";
 
-import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
+import { ConduitInterface } from "seaport/interfaces/ConduitInterface.sol";
 
 import { Conduit } from "./Conduit.sol";
 

--- a/contracts/helpers/TransferHelper.sol
+++ b/contracts/helpers/TransferHelper.sol
@@ -3,23 +3,23 @@ pragma solidity ^0.8.7;
 
 import "./TransferHelperStructs.sol";
 
-import { TokenTransferrer } from "../lib/TokenTransferrer.sol";
+import { TokenTransferrer } from "seaport/lib/TokenTransferrer.sol";
 
-import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
+import { ConduitInterface } from "seaport/interfaces/ConduitInterface.sol";
 
 // prettier-ignore
 import {
     ConduitControllerInterface
-} from "../interfaces/ConduitControllerInterface.sol";
+} from "seaport/interfaces/ConduitControllerInterface.sol";
 
-import { Conduit } from "../conduit/Conduit.sol";
+import { Conduit } from "seaport/conduit/Conduit.sol";
 
-import { ConduitTransfer } from "../conduit/lib/ConduitStructs.sol";
+import { ConduitTransfer } from "seaport/conduit/lib/ConduitStructs.sol";
 
 // prettier-ignore
 import {
     TransferHelperInterface
-} from "../interfaces/TransferHelperInterface.sol";
+} from "seaport/interfaces/TransferHelperInterface.sol";
 
 /**
  * @title TransferHelper

--- a/contracts/helpers/TransferHelperStructs.sol
+++ b/contracts/helpers/TransferHelperStructs.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { ConduitItemType } from "../conduit/lib/ConduitEnums.sol";
+import { ConduitItemType } from "seaport/conduit/lib/ConduitEnums.sol";
 
 struct TransferHelperItem {
     ConduitItemType itemType;

--- a/contracts/interfaces/ConduitInterface.sol
+++ b/contracts/interfaces/ConduitInterface.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.7;
 import {
     ConduitTransfer,
     ConduitBatch1155Transfer
-} from "../conduit/lib/ConduitStructs.sol";
+} from "seaport/conduit/lib/ConduitStructs.sol";
 
 /**
  * @title ConduitInterface

--- a/contracts/interfaces/ConsiderationEventsAndErrors.sol
+++ b/contracts/interfaces/ConsiderationEventsAndErrors.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { SpentItem, ReceivedItem } from "../lib/ConsiderationStructs.sol";
+import { SpentItem, ReceivedItem } from "seaport/lib/ConsiderationStructs.sol";
 
 /**
  * @title ConsiderationEventsAndErrors

--- a/contracts/interfaces/ConsiderationInterface.sol
+++ b/contracts/interfaces/ConsiderationInterface.sol
@@ -12,7 +12,7 @@ import {
     AdvancedOrder,
     OrderStatus,
     CriteriaResolver
-} from "../lib/ConsiderationStructs.sol";
+} from "seaport/lib/ConsiderationStructs.sol";
 
 /**
  * @title ConsiderationInterface

--- a/contracts/interfaces/FulfillmentApplicationErrors.sol
+++ b/contracts/interfaces/FulfillmentApplicationErrors.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { Side } from "../lib/ConsiderationEnums.sol";
+import { Side } from "seaport/lib/ConsiderationEnums.sol";
 
 /**
  * @title FulfillmentApplicationErrors

--- a/contracts/interfaces/SeaportInterface.sol
+++ b/contracts/interfaces/SeaportInterface.sol
@@ -12,7 +12,7 @@ import {
     AdvancedOrder,
     OrderStatus,
     CriteriaResolver
-} from "../lib/ConsiderationStructs.sol";
+} from "seaport/lib/ConsiderationStructs.sol";
 
 /**
  * @title SeaportInterface

--- a/contracts/interfaces/TransferHelperInterface.sol
+++ b/contracts/interfaces/TransferHelperInterface.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { TransferHelperItem } from "../helpers/TransferHelperStructs.sol";
+import { TransferHelperItem } from "seaport/helpers/TransferHelperStructs.sol";
 
 interface TransferHelperInterface {
     /**

--- a/contracts/interfaces/ZoneInterface.sol
+++ b/contracts/interfaces/ZoneInterface.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.7;
 import {
     AdvancedOrder,
     CriteriaResolver
-} from "../lib/ConsiderationStructs.sol";
+} from "seaport/lib/ConsiderationStructs.sol";
 
 interface ZoneInterface {
     // Called by Consideration whenever extraData is not provided by the caller.

--- a/contracts/lib/AmountDeriver.sol
+++ b/contracts/lib/AmountDeriver.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 // prettier-ignore
 import {
     AmountDerivationErrors
-} from "../interfaces/AmountDerivationErrors.sol";
+} from "seaport/interfaces/AmountDerivationErrors.sol";
 
 import "./ConsiderationConstants.sol";
 

--- a/contracts/lib/Assertions.sol
+++ b/contracts/lib/Assertions.sol
@@ -8,7 +8,7 @@ import { GettersAndDerivers } from "./GettersAndDerivers.sol";
 // prettier-ignore
 import {
     TokenTransferrerErrors
-} from "../interfaces/TokenTransferrerErrors.sol";
+} from "seaport/interfaces/TokenTransferrerErrors.sol";
 
 import { CounterManager } from "./CounterManager.sol";
 

--- a/contracts/lib/BasicOrderFulfiller.sol
+++ b/contracts/lib/BasicOrderFulfiller.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
+import { ConduitInterface } from "seaport/interfaces/ConduitInterface.sol";
 
 // prettier-ignore
 import {

--- a/contracts/lib/Consideration.sol
+++ b/contracts/lib/Consideration.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 // prettier-ignore
 import {
     ConsiderationInterface
-} from "../interfaces/ConsiderationInterface.sol";
+} from "seaport/interfaces/ConsiderationInterface.sol";
 
 // prettier-ignore
 import {

--- a/contracts/lib/ConsiderationBase.sol
+++ b/contracts/lib/ConsiderationBase.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.13;
 // prettier-ignore
 import {
     ConduitControllerInterface
-} from "../interfaces/ConduitControllerInterface.sol";
+} from "seaport/interfaces/ConduitControllerInterface.sol";
 
 // prettier-ignore
 import {
     ConsiderationEventsAndErrors
-} from "../interfaces/ConsiderationEventsAndErrors.sol";
+} from "seaport/interfaces/ConsiderationEventsAndErrors.sol";
 
 import "./ConsiderationConstants.sol";
 

--- a/contracts/lib/CounterManager.sol
+++ b/contracts/lib/CounterManager.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 // prettier-ignore
 import {
     ConsiderationEventsAndErrors
-} from "../interfaces/ConsiderationEventsAndErrors.sol";
+} from "seaport/interfaces/ConsiderationEventsAndErrors.sol";
 
 import { ReentrancyGuard } from "./ReentrancyGuard.sol";
 

--- a/contracts/lib/CriteriaResolution.sol
+++ b/contracts/lib/CriteriaResolution.sol
@@ -17,7 +17,7 @@ import "./ConsiderationConstants.sol";
 // prettier-ignore
 import {
     CriteriaResolutionErrors
-} from "../interfaces/CriteriaResolutionErrors.sol";
+} from "seaport/interfaces/CriteriaResolutionErrors.sol";
 
 /**
  * @title CriteriaResolution

--- a/contracts/lib/Executor.sol
+++ b/contracts/lib/Executor.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
+import { ConduitInterface } from "seaport/interfaces/ConduitInterface.sol";
 
-import { ConduitItemType } from "../conduit/lib/ConduitEnums.sol";
+import { ConduitItemType } from "seaport/conduit/lib/ConduitEnums.sol";
 
 import { ItemType } from "./ConsiderationEnums.sol";
 

--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -19,7 +19,7 @@ import "./ConsiderationConstants.sol";
 // prettier-ignore
 import {
     FulfillmentApplicationErrors
-} from "../interfaces/FulfillmentApplicationErrors.sol";
+} from "seaport/interfaces/FulfillmentApplicationErrors.sol";
 
 /**
  * @title FulfillmentApplier

--- a/contracts/lib/ReentrancyGuard.sol
+++ b/contracts/lib/ReentrancyGuard.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { ReentrancyErrors } from "../interfaces/ReentrancyErrors.sol";
+import { ReentrancyErrors } from "seaport/interfaces/ReentrancyErrors.sol";
 
 import "./ConsiderationConstants.sol";
 

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { EIP1271Interface } from "../interfaces/EIP1271Interface.sol";
+import { EIP1271Interface } from "seaport/interfaces/EIP1271Interface.sol";
 
 // prettier-ignore
 import {
     SignatureVerificationErrors
-} from "../interfaces/SignatureVerificationErrors.sol";
+} from "seaport/interfaces/SignatureVerificationErrors.sol";
 
 import { LowLevelHelpers } from "./LowLevelHelpers.sol";
 

--- a/contracts/lib/TokenTransferrer.sol
+++ b/contracts/lib/TokenTransferrer.sol
@@ -6,9 +6,9 @@ import "./TokenTransferrerConstants.sol";
 // prettier-ignore
 import {
     TokenTransferrerErrors
-} from "../interfaces/TokenTransferrerErrors.sol";
+} from "seaport/interfaces/TokenTransferrerErrors.sol";
 
-import { ConduitBatch1155Transfer } from "../conduit/lib/ConduitStructs.sol";
+import { ConduitBatch1155Transfer } from "seaport/conduit/lib/ConduitStructs.sol";
 
 /**
  * @title TokenTransferrer

--- a/contracts/lib/ZoneInteraction.sol
+++ b/contracts/lib/ZoneInteraction.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { ZoneInterface } from "../interfaces/ZoneInterface.sol";
+import { ZoneInterface } from "seaport/interfaces/ZoneInterface.sol";
 
 import { OrderType } from "./ConsiderationEnums.sol";
 
@@ -13,7 +13,7 @@ import "./ConsiderationConstants.sol";
 // prettier-ignore
 import {
     ZoneInteractionErrors
-} from "../interfaces/ZoneInteractionErrors.sol";
+} from "seaport/interfaces/ZoneInteractionErrors.sol";
 
 import { LowLevelHelpers } from "./LowLevelHelpers.sol";
 

--- a/contracts/test/TestZone.sol
+++ b/contracts/test/TestZone.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { ZoneInterface } from "../interfaces/ZoneInterface.sol";
+import { ZoneInterface } from "seaport/interfaces/ZoneInterface.sol";
 
 // prettier-ignore
 import {
     AdvancedOrder,
     CriteriaResolver
-} from "../lib/ConsiderationStructs.sol";
+} from "seaport/lib/ConsiderationStructs.sol";
 
 contract TestZone is ZoneInterface {
     function isValidOrder(

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,7 +11,7 @@ remappings = [
     '@rari-capital/solmate/=lib/solmate/',
     'murky/=lib/murky/src/',
     'seaport/=contracts/',
-    'seaport-reference/=seaport-reference/',
+    'seaport-reference/=reference/',
     'seaport-test/=test/foundry/'
 ]
 fuzz_runs = 5000

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,8 +9,10 @@ remappings = [
     'ds-test=lib/ds-test/src/',
     'forge-std=lib/forge-std/src/',
     '@rari-capital/solmate/=lib/solmate/',
-    'contracts/=contracts/',
     'murky/=lib/murky/src/',
+    'seaport/=contracts/',
+    'seaport-reference/=seaport-reference/',
+    'seaport-test/=test/foundry/'
 ]
 fuzz_runs = 5000
 fuzz_max_global_rejects = 2_000_000

--- a/reference/ReferenceConsideration.sol
+++ b/reference/ReferenceConsideration.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.7;
 // prettier-ignore
 import {
     ConsiderationInterface
-} from "contracts/interfaces/ConsiderationInterface.sol";
+} from "seaport/interfaces/ConsiderationInterface.sol";
 
 // prettier-ignore
 import {
@@ -15,14 +15,14 @@ import {
     AdvancedOrder,
     OrderStatus,
     CriteriaResolver,
-    Fulfillment,
+    Fulfillment, 
     FulfillmentComponent,
     Execution
-} from "contracts/lib/ConsiderationStructs.sol";
+} from "seaport/lib/ConsiderationStructs.sol";
 
-import { ReferenceOrderCombiner } from "./lib/ReferenceOrderCombiner.sol";
+import { ReferenceOrderCombiner } from "seaport-reference/lib/ReferenceOrderCombiner.sol";
 
-import { OrderToExecute, AccumulatorStruct } from "./lib/ReferenceConsiderationStructs.sol";
+import { OrderToExecute, AccumulatorStruct } from "seaport-reference/lib/ReferenceConsiderationStructs.sol";
 
 /**
  * @title ReferenceConsideration

--- a/reference/conduit/ReferenceConduit.sol
+++ b/reference/conduit/ReferenceConduit.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { ConduitInterface } from "contracts/interfaces/ConduitInterface.sol";
+import { ConduitInterface } from "seaport/interfaces/ConduitInterface.sol";
 
-import { ConduitItemType } from "contracts/conduit/lib/ConduitEnums.sol";
+import { ConduitItemType } from "seaport/conduit/lib/ConduitEnums.sol";
 
 // prettier-ignore
 import {
     ReferenceTokenTransferrer
-} from "../lib/ReferenceTokenTransferrer.sol";
+} from "seaport-reference/lib/ReferenceTokenTransferrer.sol";
 
 // prettier-ignore
 import {
     ConduitTransfer,
     ConduitBatch1155Transfer
-} from "contracts/conduit/lib/ConduitStructs.sol";
+} from "seaport/conduit/lib/ConduitStructs.sol";
 
 /**
  * @title ReferenceConduit

--- a/reference/conduit/ReferenceConduitController.sol
+++ b/reference/conduit/ReferenceConduitController.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { ReferenceConduit } from "./ReferenceConduit.sol";
+import { ReferenceConduit } from "seaport-reference/conduit/ReferenceConduit.sol";
 
 // prettier-ignore
 import {
 	ConduitControllerInterface
-} from "contracts/interfaces/ConduitControllerInterface.sol";
+} from "seaport/interfaces/ConduitControllerInterface.sol";
 
-import { ConduitInterface } from "contracts/interfaces/ConduitInterface.sol";
+import { ConduitInterface } from "seaport/interfaces/ConduitInterface.sol";
 
 /**
  * @title ConduitController

--- a/reference/lib/ReferenceAmountDeriver.sol
+++ b/reference/lib/ReferenceAmountDeriver.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.7;
 // prettier-ignore
 import {
     AmountDerivationErrors
-} from "contracts/interfaces/AmountDerivationErrors.sol";
+} from "seaport/interfaces/AmountDerivationErrors.sol";
 
-import { FractionData } from "./ReferenceConsiderationStructs.sol";
+import { FractionData } from "seaport-reference/lib/ReferenceConsiderationStructs.sol";
 
 /**
  * @title ReferenceAmountDeriver

--- a/reference/lib/ReferenceAssertions.sol
+++ b/reference/lib/ReferenceAssertions.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { OrderParameters } from "contracts/lib/ConsiderationStructs.sol";
+import { OrderParameters } from "seaport/lib/ConsiderationStructs.sol";
 
-import { ReferenceGettersAndDerivers } from "./ReferenceGettersAndDerivers.sol";
+import { ReferenceGettersAndDerivers } from "seaport-reference/lib/ReferenceGettersAndDerivers.sol";
 
-import { TokenTransferrerErrors } from "contracts/interfaces/TokenTransferrerErrors.sol";
+import { TokenTransferrerErrors } from "seaport/interfaces/TokenTransferrerErrors.sol";
 
-import { ReferenceCounterManager } from "./ReferenceCounterManager.sol";
+import { ReferenceCounterManager } from "seaport-reference/lib/ReferenceCounterManager.sol";
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
 /**
  * @title Assertions

--- a/reference/lib/ReferenceBasicOrderFulfiller.sol
+++ b/reference/lib/ReferenceBasicOrderFulfiller.sol
@@ -7,7 +7,7 @@ import {
     BasicOrderType,
     ItemType,
     BasicOrderRouteType
-} from "contracts/lib/ConsiderationEnums.sol";
+} from "seaport/lib/ConsiderationEnums.sol";
 
 // prettier-ignore
 import {
@@ -17,18 +17,18 @@ import {
     ConsiderationItem,
     SpentItem,
     ReceivedItem
-} from "contracts/lib/ConsiderationStructs.sol";
+} from "seaport/lib/ConsiderationStructs.sol";
 
 // prettier-ignore
 import {
     AccumulatorStruct,
     BasicFulfillmentHashes,
     FulfillmentItemTypes
-} from "./ReferenceConsiderationStructs.sol";
+} from "seaport-reference/lib/ReferenceConsiderationStructs.sol";
 
-import { ReferenceOrderValidator } from "./ReferenceOrderValidator.sol";
+import { ReferenceOrderValidator } from "seaport-reference/lib/ReferenceOrderValidator.sol";
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
 /**
  * @title BasicOrderFulfiller

--- a/reference/lib/ReferenceConsiderationBase.sol
+++ b/reference/lib/ReferenceConsiderationBase.sol
@@ -4,16 +4,16 @@ pragma solidity ^0.8.7;
 // prettier-ignore
 import {
     ConduitControllerInterface
-} from "contracts/interfaces/ConduitControllerInterface.sol";
+} from "seaport/interfaces/ConduitControllerInterface.sol";
 
 // prettier-ignore
 import {
     ConsiderationEventsAndErrors
-} from "contracts/interfaces/ConsiderationEventsAndErrors.sol";
+} from "seaport/interfaces/ConsiderationEventsAndErrors.sol";
 
-import { OrderStatus } from "contracts/lib/ConsiderationStructs.sol";
+import { OrderStatus } from "seaport/lib/ConsiderationStructs.sol";
 
-import { ReentrancyErrors } from "contracts/interfaces/ReentrancyErrors.sol";
+import { ReentrancyErrors } from "seaport/interfaces/ReentrancyErrors.sol";
 
 /**
  * @title ConsiderationBase

--- a/reference/lib/ReferenceConsiderationStructs.sol
+++ b/reference/lib/ReferenceConsiderationStructs.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.7;
 import {
     OrderType,
     ItemType
-} from "contracts/lib/ConsiderationEnums.sol";
+} from "seaport/lib/ConsiderationEnums.sol";
 
-import { SpentItem, ReceivedItem } from "contracts/lib/ConsiderationStructs.sol";
+import { SpentItem, ReceivedItem } from "seaport/lib/ConsiderationStructs.sol";
 
-import { ConduitTransfer } from "contracts/conduit/lib/ConduitStructs.sol";
+import { ConduitTransfer } from "seaport/conduit/lib/ConduitStructs.sol";
 
 // This file should only be used by the Reference Implementation
 

--- a/reference/lib/ReferenceCounterManager.sol
+++ b/reference/lib/ReferenceCounterManager.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.7;
 // prettier-ignore
 import {
     ConsiderationEventsAndErrors
-} from "contracts/interfaces/ConsiderationEventsAndErrors.sol";
+} from "seaport/interfaces/ConsiderationEventsAndErrors.sol";
 
-import { ReferenceReentrancyGuard } from "./ReferenceReentrancyGuard.sol";
+import { ReferenceReentrancyGuard } from "seaport-reference/lib/ReferenceReentrancyGuard.sol";
 
 /**
  * @title CounterManager

--- a/reference/lib/ReferenceCriteriaResolution.sol
+++ b/reference/lib/ReferenceCriteriaResolution.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { ItemType, Side } from "contracts/lib/ConsiderationEnums.sol";
+import { ItemType, Side } from "seaport/lib/ConsiderationEnums.sol";
 
 // prettier-ignore
 import {
@@ -12,16 +12,16 @@ import {
     CriteriaResolver,
     SpentItem,
     ReceivedItem
-} from "contracts/lib/ConsiderationStructs.sol";
+} from "seaport/lib/ConsiderationStructs.sol";
 
-import { OrderToExecute } from "./ReferenceConsiderationStructs.sol";
+import { OrderToExecute } from "seaport-reference/lib/ReferenceConsiderationStructs.sol";
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
 // prettier-ignore
 import {
     CriteriaResolutionErrors
-} from "contracts/interfaces/CriteriaResolutionErrors.sol";
+} from "seaport/interfaces/CriteriaResolutionErrors.sol";
 
 /**
  * @title CriteriaResolution

--- a/reference/lib/ReferenceExecutor.sol
+++ b/reference/lib/ReferenceExecutor.sol
@@ -6,25 +6,25 @@ import {
     ERC20Interface,
     ERC721Interface,
     ERC1155Interface
-} from "contracts/interfaces/AbridgedTokenInterfaces.sol";
+} from "seaport/interfaces/AbridgedTokenInterfaces.sol";
 
-import { ConduitItemType } from "contracts/conduit/lib/ConduitEnums.sol";
+import { ConduitItemType } from "seaport/conduit/lib/ConduitEnums.sol";
 
-import { ConduitInterface } from "contracts/interfaces/ConduitInterface.sol";
+import { ConduitInterface } from "seaport/interfaces/ConduitInterface.sol";
 
-import { ConduitTransfer, ConduitBatch1155Transfer } from "contracts/conduit/lib/ConduitStructs.sol";
+import { ConduitTransfer, ConduitBatch1155Transfer } from "seaport/conduit/lib/ConduitStructs.sol";
 
-import { ItemType } from "contracts/lib/ConsiderationEnums.sol";
+import { ItemType } from "seaport/lib/ConsiderationEnums.sol";
 
-import { ReceivedItem } from "contracts/lib/ConsiderationStructs.sol";
+import { ReceivedItem } from "seaport/lib/ConsiderationStructs.sol";
 
-import { ReferenceVerifiers } from "./ReferenceVerifiers.sol";
+import { ReferenceVerifiers } from "seaport-reference/lib/ReferenceVerifiers.sol";
 
-import { ReferenceTokenTransferrer } from "./ReferenceTokenTransferrer.sol";
+import { ReferenceTokenTransferrer } from "seaport-reference/lib/ReferenceTokenTransferrer.sol";
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
-import { AccumulatorStruct } from "./ReferenceConsiderationStructs.sol";
+import { AccumulatorStruct } from "seaport-reference/lib/ReferenceConsiderationStructs.sol";
 
 /**
  * @title Executor

--- a/reference/lib/ReferenceFulfillmentApplier.sol
+++ b/reference/lib/ReferenceFulfillmentApplier.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { ItemType, Side } from "contracts/lib/ConsiderationEnums.sol";
+import { ItemType, Side } from "seaport/lib/ConsiderationEnums.sol";
 
 // prettier-ignore
 import {
@@ -13,16 +13,16 @@ import {
     Execution,
     FulfillmentComponent,
     SpentItem
-} from "contracts/lib/ConsiderationStructs.sol";
+} from "seaport/lib/ConsiderationStructs.sol";
 
-import { ConsiderationItemIndicesAndValidity, OrderToExecute } from "./ReferenceConsiderationStructs.sol";
+import { ConsiderationItemIndicesAndValidity, OrderToExecute } from "seaport-reference/lib/ReferenceConsiderationStructs.sol";
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
 // prettier-ignore
 import {
     FulfillmentApplicationErrors
-} from "contracts/interfaces/FulfillmentApplicationErrors.sol";
+} from "seaport/interfaces/FulfillmentApplicationErrors.sol";
 
 /**
  * @title FulfillmentApplier

--- a/reference/lib/ReferenceGettersAndDerivers.sol
+++ b/reference/lib/ReferenceGettersAndDerivers.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { ConsiderationItem, OfferItem, OrderParameters } from "../../contracts/lib/ConsiderationStructs.sol";
+import { ConsiderationItem, OfferItem, OrderParameters } from "seaport/lib/ConsiderationStructs.sol";
 
-import { ReferenceConsiderationBase } from "./ReferenceConsiderationBase.sol";
+import { ReferenceConsiderationBase } from "seaport-reference/lib/ReferenceConsiderationBase.sol";
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
 /**
  * @title GettersAndDerivers

--- a/reference/lib/ReferenceOrderCombiner.sol
+++ b/reference/lib/ReferenceOrderCombiner.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { Side, ItemType } from "contracts/lib/ConsiderationEnums.sol";
+import { Side, ItemType } from "seaport/lib/ConsiderationEnums.sol";
 
 // prettier-ignore
 import {
@@ -17,17 +17,17 @@ import {
     Order,
     AdvancedOrder,
     CriteriaResolver
-} from "contracts/lib/ConsiderationStructs.sol";
+} from "seaport/lib/ConsiderationStructs.sol";
 
-import { AccumulatorStruct, OrderToExecute } from "./ReferenceConsiderationStructs.sol";
+import { AccumulatorStruct, OrderToExecute } from "seaport-reference/lib/ReferenceConsiderationStructs.sol";
 
-import { ReferenceOrderFulfiller } from "./ReferenceOrderFulfiller.sol";
+import { ReferenceOrderFulfiller } from "seaport-reference/lib/ReferenceOrderFulfiller.sol";
 
-import { ReferenceFulfillmentApplier } from "./ReferenceFulfillmentApplier.sol";
+import { ReferenceFulfillmentApplier } from "seaport-reference/lib/ReferenceFulfillmentApplier.sol";
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
-import { SeaportInterface } from "contracts/interfaces/SeaportInterface.sol";
+import { SeaportInterface } from "seaport/interfaces/SeaportInterface.sol";
 
 /**
  * @title OrderCombiner

--- a/reference/lib/ReferenceOrderFulfiller.sol
+++ b/reference/lib/ReferenceOrderFulfiller.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { OrderType, ItemType } from "contracts/lib/ConsiderationEnums.sol";
+import { OrderType, ItemType } from "seaport/lib/ConsiderationEnums.sol";
 
 // prettier-ignore
 import {
@@ -13,22 +13,22 @@ import {
     Order,
     AdvancedOrder,
     CriteriaResolver
-} from "contracts/lib/ConsiderationStructs.sol";
+} from "seaport/lib/ConsiderationStructs.sol";
 
 // prettier-ignore
 import { 
     AccumulatorStruct,
     FractionData, 
     OrderToExecute
-} from "./ReferenceConsiderationStructs.sol";
+} from "seaport-reference/lib/ReferenceConsiderationStructs.sol";
 
-import { ReferenceBasicOrderFulfiller } from "./ReferenceBasicOrderFulfiller.sol";
+import { ReferenceBasicOrderFulfiller } from "seaport-reference/lib/ReferenceBasicOrderFulfiller.sol";
 
-import { ReferenceCriteriaResolution } from "./ReferenceCriteriaResolution.sol";
+import { ReferenceCriteriaResolution } from "seaport-reference/lib/ReferenceCriteriaResolution.sol";
 
-import { ReferenceAmountDeriver } from "./ReferenceAmountDeriver.sol";
+import { ReferenceAmountDeriver } from "seaport-reference/lib/ReferenceAmountDeriver.sol";
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
 /**
  * @title OrderFulfiller

--- a/reference/lib/ReferenceOrderValidator.sol
+++ b/reference/lib/ReferenceOrderValidator.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { OrderType } from "contracts/lib/ConsiderationEnums.sol";
+import { OrderType } from "seaport/lib/ConsiderationEnums.sol";
 
 // prettier-ignore
 import {
@@ -11,11 +11,11 @@ import {
     OrderComponents,
     OrderStatus,
     CriteriaResolver
-} from "contracts/lib/ConsiderationStructs.sol";
+} from "seaport/lib/ConsiderationStructs.sol";
 
-import { ReferenceExecutor } from "./ReferenceExecutor.sol";
+import { ReferenceExecutor } from "seaport-reference/lib/ReferenceExecutor.sol";
 
-import { ReferenceZoneInteraction } from "./ReferenceZoneInteraction.sol";
+import { ReferenceZoneInteraction } from "seaport-reference/lib/ReferenceZoneInteraction.sol";
 
 /**
  * @title OrderValidator

--- a/reference/lib/ReferenceReentrancyGuard.sol
+++ b/reference/lib/ReferenceReentrancyGuard.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { ReentrancyErrors } from "contracts/interfaces/ReentrancyErrors.sol";
+import { ReentrancyErrors } from "seaport/interfaces/ReentrancyErrors.sol";
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
 /**
  * @title ReentrancyGuard

--- a/reference/lib/ReferenceSignatureVerification.sol
+++ b/reference/lib/ReferenceSignatureVerification.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { EIP1271Interface } from "contracts/interfaces/EIP1271Interface.sol";
+import { EIP1271Interface } from "seaport/interfaces/EIP1271Interface.sol";
 
 // prettier-ignore
 import {
     SignatureVerificationErrors
-} from "contracts/interfaces/SignatureVerificationErrors.sol";
+} from "seaport/interfaces/SignatureVerificationErrors.sol";
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
 /**
  * @title SignatureVerification

--- a/reference/lib/ReferenceTokenTransferrer.sol
+++ b/reference/lib/ReferenceTokenTransferrer.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
 // prettier-ignore
 import {
     ERC20Interface,
     ERC721Interface,
     ERC1155Interface
-} from "contracts/interfaces/AbridgedTokenInterfaces.sol";
+} from "seaport/interfaces/AbridgedTokenInterfaces.sol";
 
-import { TokenTransferrerErrors } from "contracts/interfaces/TokenTransferrerErrors.sol";
+import { TokenTransferrerErrors } from "seaport/interfaces/TokenTransferrerErrors.sol";
 
 contract ReferenceTokenTransferrer is TokenTransferrerErrors {
     /**

--- a/reference/lib/ReferenceVerifiers.sol
+++ b/reference/lib/ReferenceVerifiers.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { OrderStatus } from "contracts/lib/ConsiderationStructs.sol";
+import { OrderStatus } from "seaport/lib/ConsiderationStructs.sol";
 
-import { ReferenceAssertions } from "./ReferenceAssertions.sol";
+import { ReferenceAssertions } from "seaport-reference/lib/ReferenceAssertions.sol";
 
-import { ReferenceSignatureVerification } from "./ReferenceSignatureVerification.sol";
+import { ReferenceSignatureVerification } from "seaport-reference/lib/ReferenceSignatureVerification.sol";
 
 /**
  * @title Verifiers

--- a/reference/lib/ReferenceZoneInteraction.sol
+++ b/reference/lib/ReferenceZoneInteraction.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { ZoneInterface } from "contracts/interfaces/ZoneInterface.sol";
+import { ZoneInterface } from "seaport/interfaces/ZoneInterface.sol";
 
-import { OrderType } from "contracts/lib/ConsiderationEnums.sol";
+import { OrderType } from "seaport/lib/ConsiderationEnums.sol";
 
 // prettier-ignore
-import { AdvancedOrder, CriteriaResolver } from "contracts/lib/ConsiderationStructs.sol";
+import { AdvancedOrder, CriteriaResolver } from "seaport/lib/ConsiderationStructs.sol";
 
-import "contracts/lib/ConsiderationConstants.sol";
+import "seaport/lib/ConsiderationConstants.sol";
 
 // prettier-ignore
 import {
     ZoneInteractionErrors
-} from "contracts/interfaces/ZoneInteractionErrors.sol";
+} from "seaport/interfaces/ZoneInteractionErrors.sol";
 
 /**
  * @title ZoneInteraction

--- a/reference/shim/Shim.sol
+++ b/reference/shim/Shim.sol
@@ -6,14 +6,14 @@ pragma solidity ^0.8.7;
  * extra that reference tests rely on so they get compiled. Allows for faster
  * feedback than running an extra yarn build
  */
-import { EIP1271Wallet } from "contracts/test/EIP1271Wallet.sol";
-import { Reenterer } from "contracts/test/Reenterer.sol";
-import { TestERC20 } from "contracts/test/TestERC20.sol";
-import { TestERC721 } from "contracts/test/TestERC721.sol";
-import { TestERC1155 } from "contracts/test/TestERC1155.sol";
-import { TestZone } from "contracts/test/TestZone.sol";
-import { TransferHelper } from "contracts/helpers/TransferHelper.sol";
+import { EIP1271Wallet } from "seaport/test/EIP1271Wallet.sol";
+import { Reenterer } from "seaport/test/Reenterer.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
+import { TestZone } from "seaport/test/TestZone.sol";
+import { TransferHelper } from "seaport/helpers/TransferHelper.sol";
 // prettier-ignore
 import {
     ImmutableCreate2FactoryInterface
-} from "contracts/interfaces/ImmutableCreate2FactoryInterface.sol";
+} from "seaport/interfaces/ImmutableCreate2FactoryInterface.sol";

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,7 @@
-murky/=./lib/murky/src/
-ds-test/=./lib/ds-test/src/
-solmate/=./lib/solmate/src/
-forge-std/=./lib/forge-std/src/
-@rari-capital/solmate=./lib/solmate/
+murky/=lib/murky/src/
+ds-test/=lib/ds-test/src/
+forge-std/=lib/forge-std/src/
+@rari-capital/solmate=lib/solmate/
+seaport/=contracts/
+seaport-reference/=reference/
+seaport-test/=test/foundry

--- a/test/foundry/FulfillAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAdvancedOrder.t.sol
@@ -2,13 +2,13 @@
 
 pragma solidity ^0.8.13;
 
-import { OneWord } from "../../contracts/lib/ConsiderationConstants.sol";
-import { OrderType, ItemType } from "../../contracts/lib/ConsiderationEnums.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { AdvancedOrder, OrderParameters, OrderComponents, CriteriaResolver } from "../../contracts/lib/ConsiderationStructs.sol";
+import { OneWord } from "seaport/lib/ConsiderationConstants.sol";
+import { OrderType, ItemType } from "seaport/lib/ConsiderationEnums.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { AdvancedOrder, OrderParameters, OrderComponents, CriteriaResolver } from "seaport/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { ERC1155Recipient } from "./utils/ERC1155Recipient.sol";
-import { ConsiderationEventsAndErrors } from "../../contracts/interfaces/ConsiderationEventsAndErrors.sol";
+import { ConsiderationEventsAndErrors } from "seaport/interfaces/ConsiderationEventsAndErrors.sol";
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
 
 contract FulfillAdvancedOrder is BaseOrderTest {

--- a/test/foundry/FulfillAdvancedOrderCriteria.t.sol
+++ b/test/foundry/FulfillAdvancedOrderCriteria.t.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.13;
 
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { Merkle } from "murky/Merkle.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { CriteriaResolver, OfferItem, OrderComponents, AdvancedOrder } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { CriteriaResolver, OfferItem, OrderComponents, AdvancedOrder } from "seaport/lib/ConsiderationStructs.sol";
+import { ItemType, Side } from "seaport/lib/ConsiderationEnums.sol";
 
 contract FulfillAdvancedOrderCriteria is BaseOrderTest {
     Merkle merkle = new Merkle();

--- a/test/foundry/FulfillAvailableAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAvailableAdvancedOrder.t.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
-import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { Order, AdvancedOrder, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters, FulfillmentComponent, CriteriaResolver } from "../../contracts/lib/ConsiderationStructs.sol";
+import { OrderType, BasicOrderType, ItemType, Side } from "seaport/lib/ConsiderationEnums.sol";
+import { AdditionalRecipient } from "seaport/lib/ConsiderationStructs.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { Order, AdvancedOrder, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters, FulfillmentComponent, CriteriaResolver } from "seaport/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { TestERC721 } from "../../contracts/test/TestERC721.sol";
-import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../contracts/test/TestERC20.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
 import { ProxyRegistry } from "./interfaces/ProxyRegistry.sol";
 import { OwnableDelegateProxy } from "./interfaces/OwnableDelegateProxy.sol";
 import { ERC1155Recipient } from "./utils/ERC1155Recipient.sol";

--- a/test/foundry/FulfillAvailableAdvancedOrderCriteria.t.sol
+++ b/test/foundry/FulfillAvailableAdvancedOrderCriteria.t.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.13;
 
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { Merkle } from "murky/Merkle.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { CriteriaResolver, OfferItem, OrderComponents, AdvancedOrder, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { CriteriaResolver, OfferItem, OrderComponents, AdvancedOrder, FulfillmentComponent } from "seaport/lib/ConsiderationStructs.sol";
+import { ItemType, Side } from "seaport/lib/ConsiderationEnums.sol";
 
 contract FulfillAdvancedOrderCriteria is BaseOrderTest {
     Merkle merkle = new Merkle();

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -3,17 +3,17 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
-import { AdditionalRecipient, Order } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { OfferItem, ConsiderationItem, OrderComponents, BasicOrderParameters } from "../../contracts/lib/ConsiderationStructs.sol";
+import { OrderType, BasicOrderType, ItemType, Side } from "seaport/lib/ConsiderationEnums.sol";
+import { AdditionalRecipient, Order } from "seaport/lib/ConsiderationStructs.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { OfferItem, ConsiderationItem, OrderComponents, BasicOrderParameters } from "seaport/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 
-import { TestERC721 } from "../../contracts/test/TestERC721.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
 
-import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
 
-import { TestERC20 } from "../../contracts/test/TestERC20.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
 
 import { OrderParameters } from "./utils/reentrancy/ReentrantStructs.sol";

--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
-import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { Order, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters } from "../../contracts/lib/ConsiderationStructs.sol";
+import { OrderType, BasicOrderType, ItemType, Side } from "seaport/lib/ConsiderationEnums.sol";
+import { AdditionalRecipient } from "seaport/lib/ConsiderationStructs.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { Order, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters } from "seaport/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { TestERC721 } from "../../contracts/test/TestERC721.sol";
-import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../contracts/test/TestERC20.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
 import { ProxyRegistry } from "./interfaces/ProxyRegistry.sol";
 import { OwnableDelegateProxy } from "./interfaces/OwnableDelegateProxy.sol";
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";

--- a/test/foundry/FullfillAvailableOrder.t.sol
+++ b/test/foundry/FullfillAvailableOrder.t.sol
@@ -2,13 +2,13 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { Order, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";
+import { OrderType, BasicOrderType, ItemType, Side } from "seaport/lib/ConsiderationEnums.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { Order, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters, FulfillmentComponent } from "seaport/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { TestERC721 } from "../../contracts/test/TestERC721.sol";
-import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../contracts/test/TestERC20.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
 import { stdError } from "forge-std/Test.sol";
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
 

--- a/test/foundry/MatchAdvancedOrder.t.sol
+++ b/test/foundry/MatchAdvancedOrder.t.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, ItemType } from "../../contracts/lib/ConsiderationEnums.sol";
-import { Order } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { AdvancedOrder, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, CriteriaResolver, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";
+import { OrderType, ItemType } from "seaport/lib/ConsiderationEnums.sol";
+import { Order } from "seaport/lib/ConsiderationStructs.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { AdvancedOrder, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, CriteriaResolver, FulfillmentComponent } from "seaport/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { stdError } from "forge-std/Test.sol";
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";

--- a/test/foundry/MatchOrders.t.sol
+++ b/test/foundry/MatchOrders.t.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, ItemType } from "../../contracts/lib/ConsiderationEnums.sol";
-import { Order, Fulfillment, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { ConsiderationEventsAndErrors } from "../../contracts/interfaces/ConsiderationEventsAndErrors.sol";
+import { OrderType, ItemType } from "seaport/lib/ConsiderationEnums.sol";
+import { Order, Fulfillment, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, FulfillmentComponent } from "seaport/lib/ConsiderationStructs.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { ConsiderationEventsAndErrors } from "seaport/interfaces/ConsiderationEventsAndErrors.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { TestERC721 } from "../../contracts/test/TestERC721.sol";
-import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../contracts/test/TestERC20.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
 import { stdError } from "forge-std/Test.sol";
 

--- a/test/foundry/NonReentrant.t.sol
+++ b/test/foundry/NonReentrant.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { AdditionalRecipient, Fulfillment, OfferItem, ConsiderationItem, FulfillmentComponent, OrderComponents, AdvancedOrder, BasicOrderParameters, Order } from "../../contracts/lib/ConsiderationStructs.sol";
-import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
+import { OrderType, BasicOrderType, ItemType, Side } from "seaport/lib/ConsiderationEnums.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { AdditionalRecipient, Fulfillment, OfferItem, ConsiderationItem, FulfillmentComponent, OrderComponents, AdvancedOrder, BasicOrderParameters, Order } from "seaport/lib/ConsiderationStructs.sol";
+import { BaseOrderTest } from "seaport-test/utils/BaseOrderTest.sol";
 import { EntryPoint, ReentryPoint } from "./utils/reentrancy/ReentrantEnums.sol";
 import { OrderParameters, CriteriaResolver } from "./utils/reentrancy/ReentrantStructs.sol";
 

--- a/test/foundry/SignatureVerification.t.sol
+++ b/test/foundry/SignatureVerification.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { SignatureVerification } from "../../contracts/lib/SignatureVerification.sol";
-import { ReferenceSignatureVerification } from "../../reference/lib/ReferenceSignatureVerification.sol";
-import { GettersAndDerivers } from "../../contracts/lib/GettersAndDerivers.sol";
-import { ReferenceGettersAndDerivers } from "../../reference/lib/ReferenceGettersAndDerivers.sol";
+import { SignatureVerification } from "seaport/lib/SignatureVerification.sol";
+import { ReferenceSignatureVerification } from "reference/lib/ReferenceSignatureVerification.sol";
+import { GettersAndDerivers } from "seaport/lib/GettersAndDerivers.sol";
+import { ReferenceGettersAndDerivers } from "reference/lib/ReferenceGettersAndDerivers.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { OrderParameters } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
+import { OrderParameters } from "seaport/lib/ConsiderationStructs.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
 
 interface GetterAndDeriver {
     function deriveOrderHash(

--- a/test/foundry/TransferHelperTest.sol
+++ b/test/foundry/TransferHelperTest.sol
@@ -5,21 +5,21 @@ import { BaseConsiderationTest } from "./utils/BaseConsiderationTest.sol";
 
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 
-import { ConduitInterface } from "../../contracts/interfaces/ConduitInterface.sol";
+import { ConduitInterface } from "seaport/interfaces/ConduitInterface.sol";
 
-import { ConduitItemType } from "../../contracts/conduit/lib/ConduitEnums.sol";
+import { ConduitItemType } from "seaport/conduit/lib/ConduitEnums.sol";
 
-import { TransferHelper } from "../../contracts/helpers/TransferHelper.sol";
+import { TransferHelper } from "seaport/helpers/TransferHelper.sol";
 
-import { TransferHelperItem } from "../../contracts/helpers/TransferHelperStructs.sol";
+import { TransferHelperItem } from "seaport/helpers/TransferHelperStructs.sol";
 
-import { TestERC20 } from "../../contracts/test/TestERC20.sol";
-import { TestERC721 } from "../../contracts/test/TestERC721.sol";
-import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
 
-import { TokenTransferrerErrors } from "../../contracts/interfaces/TokenTransferrerErrors.sol";
+import { TokenTransferrerErrors } from "seaport/interfaces/TokenTransferrerErrors.sol";
 
-import { TransferHelperInterface } from "../../contracts/interfaces/TransferHelperInterface.sol";
+import { TransferHelperInterface } from "seaport/interfaces/TransferHelperInterface.sol";
 
 contract TransferHelperTest is BaseOrderTest {
     TransferHelper transferHelper;

--- a/test/foundry/conduit/BaseConduitTest.sol
+++ b/test/foundry/conduit/BaseConduitTest.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "../utils/BaseConsiderationTest.sol";
-import { ConduitTransfer, ConduitItemType, ConduitBatch1155Transfer } from "../../../contracts/conduit/lib/ConduitStructs.sol";
-import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
-import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
+import { ConduitTransfer, ConduitItemType, ConduitBatch1155Transfer } from "seaport/conduit/lib/ConduitStructs.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
 import { ERC721Recipient } from "../utils/ERC721Recipient.sol";
 import { ERC1155Recipient } from "../utils/ERC1155Recipient.sol";
 import { ERC1155TokenReceiver } from "@rari-capital/solmate/src/tokens/ERC1155.sol";

--- a/test/foundry/conduit/ConduitExecute.t.sol
+++ b/test/foundry/conduit/ConduitExecute.t.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "../utils/BaseConsiderationTest.sol";
-import { ConduitTransfer, ConduitItemType } from "../../../contracts/conduit/lib/ConduitStructs.sol";
-import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
-import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
+import { ConduitTransfer, ConduitItemType } from "seaport/conduit/lib/ConduitStructs.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
 import { ERC721Recipient } from "../utils/ERC721Recipient.sol";
 import { ERC1155Recipient } from "../utils/ERC1155Recipient.sol";
 import { BaseConduitTest } from "./BaseConduitTest.sol";
-import { Conduit } from "../../../contracts/conduit/Conduit.sol";
+import { Conduit } from "seaport/conduit/Conduit.sol";
 
 contract ConduitExecuteTest is BaseConduitTest {
     struct FuzzInputs {

--- a/test/foundry/conduit/ConduitExecuteBatch1155.t.sol
+++ b/test/foundry/conduit/ConduitExecuteBatch1155.t.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "../utils/BaseConsiderationTest.sol";
-import { ConduitTransfer, ConduitBatch1155Transfer, ConduitItemType } from "../../../contracts/conduit/lib/ConduitStructs.sol";
-import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
-import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
+import { ConduitTransfer, ConduitBatch1155Transfer, ConduitItemType } from "seaport/conduit/lib/ConduitStructs.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
 import { ERC721Recipient } from "../utils/ERC721Recipient.sol";
 import { ERC1155Recipient } from "../utils/ERC1155Recipient.sol";
 import { BaseConduitTest } from "./BaseConduitTest.sol";
-import { Conduit } from "../../../contracts/conduit/Conduit.sol";
+import { Conduit } from "seaport/conduit/Conduit.sol";
 
 contract ConduitExecuteBatch1155Test is BaseConduitTest {
     struct FuzzInputs {

--- a/test/foundry/conduit/ConduitExecuteWithBatch1155.t.sol
+++ b/test/foundry/conduit/ConduitExecuteWithBatch1155.t.sol
@@ -2,13 +2,13 @@
 
 pragma solidity ^0.8.13;
 
-import { Conduit } from "../../../contracts/conduit/Conduit.sol";
-import { ConduitController } from "../../../contracts/conduit/ConduitController.sol";
+import { Conduit } from "seaport/conduit/Conduit.sol";
+import { ConduitController } from "seaport/conduit/ConduitController.sol";
 import { BaseConduitTest } from "./BaseConduitTest.sol";
-import { ConduitTransfer, ConduitBatch1155Transfer, ConduitItemType } from "../../../contracts/conduit/lib/ConduitStructs.sol";
-import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
-import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
+import { ConduitTransfer, ConduitBatch1155Transfer, ConduitItemType } from "seaport/conduit/lib/ConduitStructs.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
 import { ERC721Recipient } from "../utils/ERC721Recipient.sol";
 import { ERC1155Recipient } from "../utils/ERC1155Recipient.sol";
 

--- a/test/foundry/utils/BaseConsiderationTest.sol
+++ b/test/foundry/utils/BaseConsiderationTest.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { ConduitController } from "../../../contracts/conduit/ConduitController.sol";
-import { ConsiderationInterface } from "../../../contracts/interfaces/ConsiderationInterface.sol";
-import { OrderType, BasicOrderType, ItemType, Side } from "../../../contracts/lib/ConsiderationEnums.sol";
-import { OfferItem, ConsiderationItem, OrderComponents, BasicOrderParameters } from "../../../contracts/lib/ConsiderationStructs.sol";
+import { ConduitController } from "seaport/conduit/ConduitController.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { OrderType, BasicOrderType, ItemType, Side } from "seaport/lib/ConsiderationEnums.sol";
+import { OfferItem, ConsiderationItem, OrderComponents, BasicOrderParameters } from "seaport/lib/ConsiderationStructs.sol";
 import { Test } from "forge-std/Test.sol";
 import { DifferentialTest } from "./DifferentialTest.sol";
 import { StructCopier } from "./StructCopier.sol";
 import { stdStorage, StdStorage } from "forge-std/Test.sol";
-import { ReferenceConduitController } from "../../../reference/conduit/ReferenceConduitController.sol";
-import { ReferenceConsideration } from "../../../reference/ReferenceConsideration.sol";
-import { Conduit } from "../../../contracts/conduit/Conduit.sol";
-import { Consideration } from "../../../contracts/lib/Consideration.sol";
+import { ReferenceConduitController } from "seaport-reference/conduit/ReferenceConduitController.sol";
+import { ReferenceConsideration } from "seaport-reference/ReferenceConsideration.sol";
+import { Conduit } from "seaport/conduit/Conduit.sol";
+import { Consideration } from "seaport/lib/Consideration.sol";
 
 /// @dev Base test case that deploys Consideration and its dependencies
 contract BaseConsiderationTest is DifferentialTest, StructCopier {

--- a/test/foundry/utils/BaseOrderTest.sol
+++ b/test/foundry/utils/BaseOrderTest.sol
@@ -3,15 +3,15 @@ pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "./BaseConsiderationTest.sol";
 import { stdStorage, StdStorage } from "forge-std/Test.sol";
-import { ProxyRegistry } from "../interfaces/ProxyRegistry.sol";
-import { OwnableDelegateProxy } from "../interfaces/OwnableDelegateProxy.sol";
-import { OneWord } from "../../../contracts/lib/ConsiderationConstants.sol";
-import { ConsiderationInterface } from "../../../contracts/interfaces/ConsiderationInterface.sol";
-import { BasicOrderType, OrderType } from "../../../contracts/lib/ConsiderationEnums.sol";
-import { BasicOrderParameters, ConsiderationItem, AdditionalRecipient, OfferItem, Fulfillment, FulfillmentComponent, ItemType, Order, OrderComponents, OrderParameters } from "../../../contracts/lib/ConsiderationStructs.sol";
+import { ProxyRegistry } from "seaport-test/interfaces/ProxyRegistry.sol";
+import { OwnableDelegateProxy } from "seaport-test/interfaces/OwnableDelegateProxy.sol";
+import { OneWord } from "seaport/lib/ConsiderationConstants.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
+import { BasicOrderType, OrderType } from "seaport/lib/ConsiderationEnums.sol";
+import { BasicOrderParameters, ConsiderationItem, AdditionalRecipient, OfferItem, Fulfillment, FulfillmentComponent, ItemType, Order, OrderComponents, OrderParameters } from "seaport/lib/ConsiderationStructs.sol";
 import { ArithmeticUtil } from "./ArithmeticUtil.sol";
 import { OfferConsiderationItemAdder } from "./OfferConsiderationItemAdder.sol";
-import { AmountDeriver } from "../../../contracts/lib/AmountDeriver.sol";
+import { AmountDeriver } from "seaport/lib/AmountDeriver.sol";
 
 /// @dev base test class for cases that depend on pre-deployed token contracts
 contract BaseOrderTest is OfferConsiderationItemAdder, AmountDeriver {

--- a/test/foundry/utils/OfferConsiderationItemAdder.sol
+++ b/test/foundry/utils/OfferConsiderationItemAdder.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { ConsiderationItem, OfferItem, ItemType } from "../../../contracts/lib/ConsiderationStructs.sol";
+import { ConsiderationItem, OfferItem, ItemType } from "seaport/lib/ConsiderationStructs.sol";
 import { TestTokenMinter } from "./TestTokenMinter.sol";
 
 contract OfferConsiderationItemAdder is TestTokenMinter {

--- a/test/foundry/utils/StructCopier.sol
+++ b/test/foundry/utils/StructCopier.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
-import { BasicOrderParameters, CriteriaResolver, AdvancedOrder, AdditionalRecipient, OfferItem, Order, ConsiderationItem, Fulfillment, FulfillmentComponent, OrderParameters, OrderComponents } from "../../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../../contracts/interfaces/ConsiderationInterface.sol";
+import { BasicOrderParameters, CriteriaResolver, AdvancedOrder, AdditionalRecipient, OfferItem, Order, ConsiderationItem, Fulfillment, FulfillmentComponent, OrderParameters, OrderComponents } from "seaport/lib/ConsiderationStructs.sol";
+import { ConsiderationInterface } from "seaport/interfaces/ConsiderationInterface.sol";
 
 contract StructCopier {
     Order _tempOrder;

--- a/test/foundry/utils/TestTokenMinter.sol
+++ b/test/foundry/utils/TestTokenMinter.sol
@@ -1,14 +1,14 @@
-// SPDX-Identifier: MIT
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
-import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
+import { TestERC1155 } from "seaport/test/TestERC1155.sol";
+import { TestERC20 } from "seaport/test/TestERC20.sol";
+import { TestERC721 } from "seaport/test/TestERC721.sol";
 import { ERC721Recipient } from "./ERC721Recipient.sol";
 import { ERC1155Recipient } from "./ERC1155Recipient.sol";
-import { ItemType } from "../../../contracts/lib/ConsiderationEnums.sol";
+import { ItemType } from "seaport/lib/ConsiderationEnums.sol";
 import { BaseConsiderationTest } from "./BaseConsiderationTest.sol";
-import { ERC721 } from "../token/ERC721.sol";
+import { ERC721 } from "seaport-test/token/ERC721.sol";
 
 contract PreapprovedERC721 is ERC721 {
     mapping(address => bool) public preapprovals;

--- a/test/foundry/utils/reentrancy/ReentrantStructs.sol
+++ b/test/foundry/utils/reentrancy/ReentrantStructs.sol
@@ -1,6 +1,6 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
-import { BasicOrderParameters, OfferItem, ConsiderationItem, OrderParameters, OrderComponents, Fulfillment, FulfillmentComponent, Execution, Order, AdvancedOrder, OrderStatus, CriteriaResolver } from "../../../../contracts/lib/ConsiderationStructs.sol";
+import { BasicOrderParameters, OfferItem, ConsiderationItem, OrderParameters, OrderComponents, Fulfillment, FulfillmentComponent, Execution, Order, AdvancedOrder, OrderStatus, CriteriaResolver } from "seaport/lib/ConsiderationStructs.sol";
 
 struct FulfillBasicOrderParameters {
     BasicOrderParameters parameters;


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Intra-directory relative `../` imports don't play well with other projects when importing Seaport as a dependency.

In the case of `ReferenceConsideration` - something about VSCode's current language support was not playing well with even regular relative imports `./`. Any file that imported a Reference file (which used a relative `./` import) using an absolute path would lose language server support, meaning no error highlight or linting.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

- Reconfigure remappings
- Refactor imports not to use `../` relative paths, and in the case of Reference contracts, not `./` paths either

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
