### PR TITLE
Set prettierrc compiler version to support multi-line imports

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,6 +6,7 @@ module.exports = {
         tabWidth: 4,
         printWidth: 80,
         bracketSpacing: true,
+        compiler: "0.8.14",
       },
     },
   ],

--- a/contracts/conduit/Conduit.sol
+++ b/contracts/conduit/Conduit.sol
@@ -7,7 +7,6 @@ import { ConduitItemType } from "./lib/ConduitEnums.sol";
 
 import { TokenTransferrer } from "../lib/TokenTransferrer.sol";
 
-// prettier-ignore
 import {
     ConduitTransfer,
     ConduitBatch1155Transfer

--- a/contracts/conduit/ConduitController.sol
+++ b/contracts/conduit/ConduitController.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
-	ConduitControllerInterface
+    ConduitControllerInterface
 } from "../interfaces/ConduitControllerInterface.sol";
 
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";

--- a/contracts/helpers/TransferHelper.sol
+++ b/contracts/helpers/TransferHelper.sol
@@ -7,7 +7,6 @@ import { TokenTransferrer } from "../lib/TokenTransferrer.sol";
 
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 
-// prettier-ignore
 import {
     ConduitControllerInterface
 } from "../interfaces/ConduitControllerInterface.sol";
@@ -16,7 +15,6 @@ import { Conduit } from "../conduit/Conduit.sol";
 
 import { ConduitTransfer } from "../conduit/lib/ConduitStructs.sol";
 
-// prettier-ignore
 import {
     TransferHelperInterface
 } from "../interfaces/TransferHelperInterface.sol";

--- a/contracts/interfaces/ConduitInterface.sol
+++ b/contracts/interfaces/ConduitInterface.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
     ConduitTransfer,
     ConduitBatch1155Transfer

--- a/contracts/interfaces/ConsiderationInterface.sol
+++ b/contracts/interfaces/ConsiderationInterface.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
     BasicOrderParameters,
     OrderComponents,

--- a/contracts/interfaces/SeaportInterface.sol
+++ b/contracts/interfaces/SeaportInterface.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
     BasicOrderParameters,
     OrderComponents,

--- a/contracts/interfaces/ZoneInterface.sol
+++ b/contracts/interfaces/ZoneInterface.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
     AdvancedOrder,
     CriteriaResolver

--- a/contracts/lib/AmountDeriver.sol
+++ b/contracts/lib/AmountDeriver.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-// prettier-ignore
 import {
     AmountDerivationErrors
 } from "../interfaces/AmountDerivationErrors.sol";

--- a/contracts/lib/Assertions.sol
+++ b/contracts/lib/Assertions.sol
@@ -5,7 +5,6 @@ import { OrderParameters } from "./ConsiderationStructs.sol";
 
 import { GettersAndDerivers } from "./GettersAndDerivers.sol";
 
-// prettier-ignore
 import {
     TokenTransferrerErrors
 } from "../interfaces/TokenTransferrerErrors.sol";

--- a/contracts/lib/BasicOrderFulfiller.sol
+++ b/contracts/lib/BasicOrderFulfiller.sol
@@ -3,14 +3,12 @@ pragma solidity ^0.8.13;
 
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 
-// prettier-ignore
 import {
     OrderType,
     ItemType,
     BasicOrderRouteType
 } from "./ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     AdditionalRecipient,
     BasicOrderParameters,

--- a/contracts/lib/Consideration.sol
+++ b/contracts/lib/Consideration.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-// prettier-ignore
 import {
     ConsiderationInterface
 } from "../interfaces/ConsiderationInterface.sol";
 
-// prettier-ignore
 import {
     OrderComponents,
     BasicOrderParameters,

--- a/contracts/lib/ConsiderationBase.sol
+++ b/contracts/lib/ConsiderationBase.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-// prettier-ignore
 import {
     ConduitControllerInterface
 } from "../interfaces/ConduitControllerInterface.sol";
 
-// prettier-ignore
 import {
     ConsiderationEventsAndErrors
 } from "../interfaces/ConsiderationEventsAndErrors.sol";

--- a/contracts/lib/ConsiderationStructs.sol
+++ b/contracts/lib/ConsiderationStructs.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
     OrderType,
     BasicOrderType,

--- a/contracts/lib/CounterManager.sol
+++ b/contracts/lib/CounterManager.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-// prettier-ignore
 import {
     ConsiderationEventsAndErrors
 } from "../interfaces/ConsiderationEventsAndErrors.sol";

--- a/contracts/lib/CriteriaResolution.sol
+++ b/contracts/lib/CriteriaResolution.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import { ItemType, Side } from "./ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     OfferItem,
     ConsiderationItem,
@@ -14,7 +13,6 @@ import {
 
 import "./ConsiderationConstants.sol";
 
-// prettier-ignore
 import {
     CriteriaResolutionErrors
 } from "../interfaces/CriteriaResolutionErrors.sol";

--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import { ItemType, Side } from "./ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     OfferItem,
     ConsiderationItem,
@@ -16,7 +15,6 @@ import {
 
 import "./ConsiderationConstants.sol";
 
-// prettier-ignore
 import {
     FulfillmentApplicationErrors
 } from "../interfaces/FulfillmentApplicationErrors.sol";

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import { Side, ItemType } from "./ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     OfferItem,
     ConsiderationItem,

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import { ItemType } from "./ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     OfferItem,
     ConsiderationItem,

--- a/contracts/lib/OrderValidator.sol
+++ b/contracts/lib/OrderValidator.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import { OrderType } from "./ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     OrderParameters,
     Order,

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import { EIP1271Interface } from "../interfaces/EIP1271Interface.sol";
 
-// prettier-ignore
 import {
     SignatureVerificationErrors
 } from "../interfaces/SignatureVerificationErrors.sol";

--- a/contracts/lib/TokenTransferrer.sol
+++ b/contracts/lib/TokenTransferrer.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.7;
 
 import "./TokenTransferrerConstants.sol";
 
-// prettier-ignore
 import {
     TokenTransferrerErrors
 } from "../interfaces/TokenTransferrerErrors.sol";

--- a/contracts/lib/ZoneInteraction.sol
+++ b/contracts/lib/ZoneInteraction.sol
@@ -5,15 +5,11 @@ import { ZoneInterface } from "../interfaces/ZoneInterface.sol";
 
 import { OrderType } from "./ConsiderationEnums.sol";
 
-// prettier-ignore
 import { AdvancedOrder, CriteriaResolver } from "./ConsiderationStructs.sol";
 
 import "./ConsiderationConstants.sol";
 
-// prettier-ignore
-import {
-    ZoneInteractionErrors
-} from "../interfaces/ZoneInteractionErrors.sol";
+import { ZoneInteractionErrors } from "../interfaces/ZoneInteractionErrors.sol";
 
 import { LowLevelHelpers } from "./LowLevelHelpers.sol";
 

--- a/contracts/test/TestZone.sol
+++ b/contracts/test/TestZone.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.7;
 
 import { ZoneInterface } from "../interfaces/ZoneInterface.sol";
 
-// prettier-ignore
 import {
     AdvancedOrder,
     CriteriaResolver

--- a/reference/ReferenceConsideration.sol
+++ b/reference/ReferenceConsideration.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
     ConsiderationInterface
 } from "contracts/interfaces/ConsiderationInterface.sol";
 
-// prettier-ignore
 import {
     OrderComponents,
     BasicOrderParameters,
@@ -22,7 +20,10 @@ import {
 
 import { ReferenceOrderCombiner } from "./lib/ReferenceOrderCombiner.sol";
 
-import { OrderToExecute, AccumulatorStruct } from "./lib/ReferenceConsiderationStructs.sol";
+import {
+    OrderToExecute,
+    AccumulatorStruct
+} from "./lib/ReferenceConsiderationStructs.sol";
 
 /**
  * @title ReferenceConsideration

--- a/reference/conduit/ReferenceConduit.sol
+++ b/reference/conduit/ReferenceConduit.sol
@@ -5,12 +5,10 @@ import { ConduitInterface } from "contracts/interfaces/ConduitInterface.sol";
 
 import { ConduitItemType } from "contracts/conduit/lib/ConduitEnums.sol";
 
-// prettier-ignore
 import {
     ReferenceTokenTransferrer
 } from "../lib/ReferenceTokenTransferrer.sol";
 
-// prettier-ignore
 import {
     ConduitTransfer,
     ConduitBatch1155Transfer

--- a/reference/conduit/ReferenceConduitController.sol
+++ b/reference/conduit/ReferenceConduitController.sol
@@ -3,9 +3,8 @@ pragma solidity ^0.8.7;
 
 import { ReferenceConduit } from "./ReferenceConduit.sol";
 
-// prettier-ignore
 import {
-	ConduitControllerInterface
+    ConduitControllerInterface
 } from "contracts/interfaces/ConduitControllerInterface.sol";
 
 import { ConduitInterface } from "contracts/interfaces/ConduitInterface.sol";

--- a/reference/lib/ReferenceAmountDeriver.sol
+++ b/reference/lib/ReferenceAmountDeriver.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
     AmountDerivationErrors
 } from "contracts/interfaces/AmountDerivationErrors.sol";

--- a/reference/lib/ReferenceAssertions.sol
+++ b/reference/lib/ReferenceAssertions.sol
@@ -5,7 +5,9 @@ import { OrderParameters } from "contracts/lib/ConsiderationStructs.sol";
 
 import { ReferenceGettersAndDerivers } from "./ReferenceGettersAndDerivers.sol";
 
-import { TokenTransferrerErrors } from "contracts/interfaces/TokenTransferrerErrors.sol";
+import {
+    TokenTransferrerErrors
+} from "contracts/interfaces/TokenTransferrerErrors.sol";
 
 import { ReferenceCounterManager } from "./ReferenceCounterManager.sol";
 

--- a/reference/lib/ReferenceBasicOrderFulfiller.sol
+++ b/reference/lib/ReferenceBasicOrderFulfiller.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
     OrderType,
     BasicOrderType,
@@ -9,7 +8,6 @@ import {
     BasicOrderRouteType
 } from "contracts/lib/ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     AdditionalRecipient,
     BasicOrderParameters,
@@ -19,7 +17,6 @@ import {
     ReceivedItem
 } from "contracts/lib/ConsiderationStructs.sol";
 
-// prettier-ignore
 import {
     AccumulatorStruct,
     BasicFulfillmentHashes,

--- a/reference/lib/ReferenceConsiderationBase.sol
+++ b/reference/lib/ReferenceConsiderationBase.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
     ConduitControllerInterface
 } from "contracts/interfaces/ConduitControllerInterface.sol";
 
-// prettier-ignore
 import {
     ConsiderationEventsAndErrors
 } from "contracts/interfaces/ConsiderationEventsAndErrors.sol";

--- a/reference/lib/ReferenceConsiderationStructs.sol
+++ b/reference/lib/ReferenceConsiderationStructs.sol
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
-import {
-    OrderType,
-    ItemType
-} from "contracts/lib/ConsiderationEnums.sol";
+import { OrderType, ItemType } from "contracts/lib/ConsiderationEnums.sol";
 
-import { SpentItem, ReceivedItem } from "contracts/lib/ConsiderationStructs.sol";
+import {
+    SpentItem,
+    ReceivedItem
+} from "contracts/lib/ConsiderationStructs.sol";
 
 import { ConduitTransfer } from "contracts/conduit/lib/ConduitStructs.sol";
 

--- a/reference/lib/ReferenceCounterManager.sol
+++ b/reference/lib/ReferenceCounterManager.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
     ConsiderationEventsAndErrors
 } from "contracts/interfaces/ConsiderationEventsAndErrors.sol";

--- a/reference/lib/ReferenceCriteriaResolution.sol
+++ b/reference/lib/ReferenceCriteriaResolution.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.7;
 
 import { ItemType, Side } from "contracts/lib/ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     OfferItem,
     ConsiderationItem,
@@ -18,7 +17,6 @@ import { OrderToExecute } from "./ReferenceConsiderationStructs.sol";
 
 import "contracts/lib/ConsiderationConstants.sol";
 
-// prettier-ignore
 import {
     CriteriaResolutionErrors
 } from "contracts/interfaces/CriteriaResolutionErrors.sol";

--- a/reference/lib/ReferenceExecutor.sol
+++ b/reference/lib/ReferenceExecutor.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-// prettier-ignore
 import {
     ERC20Interface,
     ERC721Interface,
@@ -12,7 +11,10 @@ import { ConduitItemType } from "contracts/conduit/lib/ConduitEnums.sol";
 
 import { ConduitInterface } from "contracts/interfaces/ConduitInterface.sol";
 
-import { ConduitTransfer, ConduitBatch1155Transfer } from "contracts/conduit/lib/ConduitStructs.sol";
+import {
+    ConduitTransfer,
+    ConduitBatch1155Transfer
+} from "contracts/conduit/lib/ConduitStructs.sol";
 
 import { ItemType } from "contracts/lib/ConsiderationEnums.sol";
 

--- a/reference/lib/ReferenceFulfillmentApplier.sol
+++ b/reference/lib/ReferenceFulfillmentApplier.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.7;
 
 import { ItemType, Side } from "contracts/lib/ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     OfferItem,
     ConsiderationItem,
@@ -15,11 +14,13 @@ import {
     SpentItem
 } from "contracts/lib/ConsiderationStructs.sol";
 
-import { ConsiderationItemIndicesAndValidity, OrderToExecute } from "./ReferenceConsiderationStructs.sol";
+import {
+    ConsiderationItemIndicesAndValidity,
+    OrderToExecute
+} from "./ReferenceConsiderationStructs.sol";
 
 import "contracts/lib/ConsiderationConstants.sol";
 
-// prettier-ignore
 import {
     FulfillmentApplicationErrors
 } from "contracts/interfaces/FulfillmentApplicationErrors.sol";

--- a/reference/lib/ReferenceGettersAndDerivers.sol
+++ b/reference/lib/ReferenceGettersAndDerivers.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import { ConsiderationItem, OfferItem, OrderParameters } from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConsiderationItem,
+    OfferItem,
+    OrderParameters
+} from "../../contracts/lib/ConsiderationStructs.sol";
 
 import { ReferenceConsiderationBase } from "./ReferenceConsiderationBase.sol";
 

--- a/reference/lib/ReferenceOrderCombiner.sol
+++ b/reference/lib/ReferenceOrderCombiner.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.7;
 
 import { Side, ItemType } from "contracts/lib/ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     AdditionalRecipient,
     OfferItem,
@@ -19,7 +18,10 @@ import {
     CriteriaResolver
 } from "contracts/lib/ConsiderationStructs.sol";
 
-import { AccumulatorStruct, OrderToExecute } from "./ReferenceConsiderationStructs.sol";
+import {
+    AccumulatorStruct,
+    OrderToExecute
+} from "./ReferenceConsiderationStructs.sol";
 
 import { ReferenceOrderFulfiller } from "./ReferenceOrderFulfiller.sol";
 

--- a/reference/lib/ReferenceOrderFulfiller.sol
+++ b/reference/lib/ReferenceOrderFulfiller.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.7;
 
 import { OrderType, ItemType } from "contracts/lib/ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     OfferItem,
     ConsiderationItem,
@@ -15,14 +14,15 @@ import {
     CriteriaResolver
 } from "contracts/lib/ConsiderationStructs.sol";
 
-// prettier-ignore
-import { 
+import {
     AccumulatorStruct,
-    FractionData, 
+    FractionData,
     OrderToExecute
 } from "./ReferenceConsiderationStructs.sol";
 
-import { ReferenceBasicOrderFulfiller } from "./ReferenceBasicOrderFulfiller.sol";
+import {
+    ReferenceBasicOrderFulfiller
+} from "./ReferenceBasicOrderFulfiller.sol";
 
 import { ReferenceCriteriaResolution } from "./ReferenceCriteriaResolution.sol";
 

--- a/reference/lib/ReferenceOrderValidator.sol
+++ b/reference/lib/ReferenceOrderValidator.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.7;
 
 import { OrderType } from "contracts/lib/ConsiderationEnums.sol";
 
-// prettier-ignore
 import {
     OrderParameters,
     Order,

--- a/reference/lib/ReferenceSignatureVerification.sol
+++ b/reference/lib/ReferenceSignatureVerification.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.7;
 
 import { EIP1271Interface } from "contracts/interfaces/EIP1271Interface.sol";
 
-// prettier-ignore
 import {
     SignatureVerificationErrors
 } from "contracts/interfaces/SignatureVerificationErrors.sol";

--- a/reference/lib/ReferenceTokenTransferrer.sol
+++ b/reference/lib/ReferenceTokenTransferrer.sol
@@ -3,14 +3,15 @@ pragma solidity ^0.8.7;
 
 import "contracts/lib/ConsiderationConstants.sol";
 
-// prettier-ignore
 import {
     ERC20Interface,
     ERC721Interface,
     ERC1155Interface
 } from "contracts/interfaces/AbridgedTokenInterfaces.sol";
 
-import { TokenTransferrerErrors } from "contracts/interfaces/TokenTransferrerErrors.sol";
+import {
+    TokenTransferrerErrors
+} from "contracts/interfaces/TokenTransferrerErrors.sol";
 
 contract ReferenceTokenTransferrer is TokenTransferrerErrors {
     /**

--- a/reference/lib/ReferenceVerifiers.sol
+++ b/reference/lib/ReferenceVerifiers.sol
@@ -5,7 +5,9 @@ import { OrderStatus } from "contracts/lib/ConsiderationStructs.sol";
 
 import { ReferenceAssertions } from "./ReferenceAssertions.sol";
 
-import { ReferenceSignatureVerification } from "./ReferenceSignatureVerification.sol";
+import {
+    ReferenceSignatureVerification
+} from "./ReferenceSignatureVerification.sol";
 
 /**
  * @title Verifiers

--- a/reference/lib/ReferenceZoneInteraction.sol
+++ b/reference/lib/ReferenceZoneInteraction.sol
@@ -5,12 +5,13 @@ import { ZoneInterface } from "contracts/interfaces/ZoneInterface.sol";
 
 import { OrderType } from "contracts/lib/ConsiderationEnums.sol";
 
-// prettier-ignore
-import { AdvancedOrder, CriteriaResolver } from "contracts/lib/ConsiderationStructs.sol";
+import {
+    AdvancedOrder,
+    CriteriaResolver
+} from "contracts/lib/ConsiderationStructs.sol";
 
 import "contracts/lib/ConsiderationConstants.sol";
 
-// prettier-ignore
 import {
     ZoneInteractionErrors
 } from "contracts/interfaces/ZoneInteractionErrors.sol";

--- a/reference/shim/Shim.sol
+++ b/reference/shim/Shim.sol
@@ -13,7 +13,6 @@ import { TestERC721 } from "contracts/test/TestERC721.sol";
 import { TestERC1155 } from "contracts/test/TestERC1155.sol";
 import { TestZone } from "contracts/test/TestZone.sol";
 import { TransferHelper } from "contracts/helpers/TransferHelper.sol";
-// prettier-ignore
 import {
     ImmutableCreate2FactoryInterface
 } from "contracts/interfaces/ImmutableCreate2FactoryInterface.sol";

--- a/test/foundry/FulfillAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAdvancedOrder.t.sol
@@ -3,12 +3,24 @@
 pragma solidity ^0.8.13;
 
 import { OneWord } from "../../contracts/lib/ConsiderationConstants.sol";
-import { OrderType, ItemType } from "../../contracts/lib/ConsiderationEnums.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { AdvancedOrder, OrderParameters, OrderComponents, CriteriaResolver } from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    OrderType,
+    ItemType
+} from "../../contracts/lib/ConsiderationEnums.sol";
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    AdvancedOrder,
+    OrderParameters,
+    OrderComponents,
+    CriteriaResolver
+} from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { ERC1155Recipient } from "./utils/ERC1155Recipient.sol";
-import { ConsiderationEventsAndErrors } from "../../contracts/interfaces/ConsiderationEventsAndErrors.sol";
+import {
+    ConsiderationEventsAndErrors
+} from "../../contracts/interfaces/ConsiderationEventsAndErrors.sol";
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
 
 contract FulfillAdvancedOrder is BaseOrderTest {

--- a/test/foundry/FulfillAdvancedOrderCriteria.t.sol
+++ b/test/foundry/FulfillAdvancedOrderCriteria.t.sol
@@ -4,8 +4,15 @@ pragma solidity ^0.8.13;
 
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { Merkle } from "murky/Merkle.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { CriteriaResolver, OfferItem, OrderComponents, AdvancedOrder } from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    CriteriaResolver,
+    OfferItem,
+    OrderComponents,
+    AdvancedOrder
+} from "../../contracts/lib/ConsiderationStructs.sol";
 import { ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 
 contract FulfillAdvancedOrderCriteria is BaseOrderTest {

--- a/test/foundry/FulfillAvailableAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAvailableAdvancedOrder.t.sol
@@ -2,10 +2,29 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
-import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { Order, AdvancedOrder, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters, FulfillmentComponent, CriteriaResolver } from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    OrderType,
+    BasicOrderType,
+    ItemType,
+    Side
+} from "../../contracts/lib/ConsiderationEnums.sol";
+import {
+    AdditionalRecipient
+} from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    Order,
+    AdvancedOrder,
+    OfferItem,
+    OrderParameters,
+    ConsiderationItem,
+    OrderComponents,
+    BasicOrderParameters,
+    FulfillmentComponent,
+    CriteriaResolver
+} from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
 import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";

--- a/test/foundry/FulfillAvailableAdvancedOrderCriteria.t.sol
+++ b/test/foundry/FulfillAvailableAdvancedOrderCriteria.t.sol
@@ -4,8 +4,16 @@ pragma solidity ^0.8.13;
 
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { Merkle } from "murky/Merkle.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { CriteriaResolver, OfferItem, OrderComponents, AdvancedOrder, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    CriteriaResolver,
+    OfferItem,
+    OrderComponents,
+    AdvancedOrder,
+    FulfillmentComponent
+} from "../../contracts/lib/ConsiderationStructs.sol";
 import { ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 
 contract FulfillAdvancedOrderCriteria is BaseOrderTest {

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -3,10 +3,25 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
-import { AdditionalRecipient, Order } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { OfferItem, ConsiderationItem, OrderComponents, BasicOrderParameters } from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    OrderType,
+    BasicOrderType,
+    ItemType,
+    Side
+} from "../../contracts/lib/ConsiderationEnums.sol";
+import {
+    AdditionalRecipient,
+    Order
+} from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    OfferItem,
+    ConsiderationItem,
+    OrderComponents,
+    BasicOrderParameters
+} from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";

--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -2,10 +2,26 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
-import { AdditionalRecipient } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { Order, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters } from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    OrderType,
+    BasicOrderType,
+    ItemType,
+    Side
+} from "../../contracts/lib/ConsiderationEnums.sol";
+import {
+    AdditionalRecipient
+} from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    Order,
+    OfferItem,
+    OrderParameters,
+    ConsiderationItem,
+    OrderComponents,
+    BasicOrderParameters
+} from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
 import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";

--- a/test/foundry/FullfillAvailableOrder.t.sol
+++ b/test/foundry/FullfillAvailableOrder.t.sol
@@ -2,9 +2,24 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { Order, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, BasicOrderParameters, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    OrderType,
+    BasicOrderType,
+    ItemType,
+    Side
+} from "../../contracts/lib/ConsiderationEnums.sol";
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    Order,
+    OfferItem,
+    OrderParameters,
+    ConsiderationItem,
+    OrderComponents,
+    BasicOrderParameters,
+    FulfillmentComponent
+} from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
 import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";

--- a/test/foundry/MatchAdvancedOrder.t.sol
+++ b/test/foundry/MatchAdvancedOrder.t.sol
@@ -2,10 +2,23 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, ItemType } from "../../contracts/lib/ConsiderationEnums.sol";
+import {
+    OrderType,
+    ItemType
+} from "../../contracts/lib/ConsiderationEnums.sol";
 import { Order } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { AdvancedOrder, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, CriteriaResolver, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    AdvancedOrder,
+    OfferItem,
+    OrderParameters,
+    ConsiderationItem,
+    OrderComponents,
+    CriteriaResolver,
+    FulfillmentComponent
+} from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { stdError } from "forge-std/Test.sol";
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";

--- a/test/foundry/MatchOrders.t.sol
+++ b/test/foundry/MatchOrders.t.sol
@@ -2,10 +2,25 @@
 
 pragma solidity ^0.8.13;
 
-import { OrderType, ItemType } from "../../contracts/lib/ConsiderationEnums.sol";
-import { Order, Fulfillment, OfferItem, OrderParameters, ConsiderationItem, OrderComponents, FulfillmentComponent } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { ConsiderationEventsAndErrors } from "../../contracts/interfaces/ConsiderationEventsAndErrors.sol";
+import {
+    OrderType,
+    ItemType
+} from "../../contracts/lib/ConsiderationEnums.sol";
+import {
+    Order,
+    Fulfillment,
+    OfferItem,
+    OrderParameters,
+    ConsiderationItem,
+    OrderComponents,
+    FulfillmentComponent
+} from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    ConsiderationEventsAndErrors
+} from "../../contracts/interfaces/ConsiderationEventsAndErrors.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
 import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";

--- a/test/foundry/NonReentrant.t.sol
+++ b/test/foundry/NonReentrant.t.sol
@@ -1,12 +1,35 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { OrderType, BasicOrderType, ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import { AdditionalRecipient, Fulfillment, OfferItem, ConsiderationItem, FulfillmentComponent, OrderComponents, AdvancedOrder, BasicOrderParameters, Order } from "../../contracts/lib/ConsiderationStructs.sol";
+import {
+    OrderType,
+    BasicOrderType,
+    ItemType,
+    Side
+} from "../../contracts/lib/ConsiderationEnums.sol";
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    AdditionalRecipient,
+    Fulfillment,
+    OfferItem,
+    ConsiderationItem,
+    FulfillmentComponent,
+    OrderComponents,
+    AdvancedOrder,
+    BasicOrderParameters,
+    Order
+} from "../../contracts/lib/ConsiderationStructs.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { EntryPoint, ReentryPoint } from "./utils/reentrancy/ReentrantEnums.sol";
-import { OrderParameters, CriteriaResolver } from "./utils/reentrancy/ReentrantStructs.sol";
+import {
+    EntryPoint,
+    ReentryPoint
+} from "./utils/reentrancy/ReentrantEnums.sol";
+import {
+    OrderParameters,
+    CriteriaResolver
+} from "./utils/reentrancy/ReentrantStructs.sol";
 
 contract NonReentrantTest is BaseOrderTest {
     BasicOrderParameters basicOrderParameters;

--- a/test/foundry/SignatureVerification.t.sol
+++ b/test/foundry/SignatureVerification.t.sol
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { SignatureVerification } from "../../contracts/lib/SignatureVerification.sol";
-import { ReferenceSignatureVerification } from "../../reference/lib/ReferenceSignatureVerification.sol";
+import {
+    SignatureVerification
+} from "../../contracts/lib/SignatureVerification.sol";
+import {
+    ReferenceSignatureVerification
+} from "../../reference/lib/ReferenceSignatureVerification.sol";
 import { GettersAndDerivers } from "../../contracts/lib/GettersAndDerivers.sol";
-import { ReferenceGettersAndDerivers } from "../../reference/lib/ReferenceGettersAndDerivers.sol";
+import {
+    ReferenceGettersAndDerivers
+} from "../../reference/lib/ReferenceGettersAndDerivers.sol";
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 import { OrderParameters } from "../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
 
 interface GetterAndDeriver {
     function deriveOrderHash(

--- a/test/foundry/TransferHelperTest.sol
+++ b/test/foundry/TransferHelperTest.sol
@@ -1,25 +1,33 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
-// prettier-ignore
+
 import { BaseConsiderationTest } from "./utils/BaseConsiderationTest.sol";
 
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 
-import { ConduitInterface } from "../../contracts/interfaces/ConduitInterface.sol";
+import {
+    ConduitInterface
+} from "../../contracts/interfaces/ConduitInterface.sol";
 
 import { ConduitItemType } from "../../contracts/conduit/lib/ConduitEnums.sol";
 
 import { TransferHelper } from "../../contracts/helpers/TransferHelper.sol";
 
-import { TransferHelperItem } from "../../contracts/helpers/TransferHelperStructs.sol";
+import {
+    TransferHelperItem
+} from "../../contracts/helpers/TransferHelperStructs.sol";
 
 import { TestERC20 } from "../../contracts/test/TestERC20.sol";
 import { TestERC721 } from "../../contracts/test/TestERC721.sol";
 import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
 
-import { TokenTransferrerErrors } from "../../contracts/interfaces/TokenTransferrerErrors.sol";
+import {
+    TokenTransferrerErrors
+} from "../../contracts/interfaces/TokenTransferrerErrors.sol";
 
-import { TransferHelperInterface } from "../../contracts/interfaces/TransferHelperInterface.sol";
+import {
+    TransferHelperInterface
+} from "../../contracts/interfaces/TransferHelperInterface.sol";
 
 contract TransferHelperTest is BaseOrderTest {
     TransferHelper transferHelper;

--- a/test/foundry/conduit/BaseConduitTest.sol
+++ b/test/foundry/conduit/BaseConduitTest.sol
@@ -2,13 +2,19 @@
 pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "../utils/BaseConsiderationTest.sol";
-import { ConduitTransfer, ConduitItemType, ConduitBatch1155Transfer } from "../../../contracts/conduit/lib/ConduitStructs.sol";
+import {
+    ConduitTransfer,
+    ConduitItemType,
+    ConduitBatch1155Transfer
+} from "../../../contracts/conduit/lib/ConduitStructs.sol";
 import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
 import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
 import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
 import { ERC721Recipient } from "../utils/ERC721Recipient.sol";
 import { ERC1155Recipient } from "../utils/ERC1155Recipient.sol";
-import { ERC1155TokenReceiver } from "@rari-capital/solmate/src/tokens/ERC1155.sol";
+import {
+    ERC1155TokenReceiver
+} from "@rari-capital/solmate/src/tokens/ERC1155.sol";
 
 contract BaseConduitTest is
     BaseConsiderationTest,

--- a/test/foundry/conduit/ConduitExecute.t.sol
+++ b/test/foundry/conduit/ConduitExecute.t.sol
@@ -2,7 +2,10 @@
 pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "../utils/BaseConsiderationTest.sol";
-import { ConduitTransfer, ConduitItemType } from "../../../contracts/conduit/lib/ConduitStructs.sol";
+import {
+    ConduitTransfer,
+    ConduitItemType
+} from "../../../contracts/conduit/lib/ConduitStructs.sol";
 import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
 import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
 import { TestERC721 } from "../../../contracts/test/TestERC721.sol";

--- a/test/foundry/conduit/ConduitExecuteBatch1155.t.sol
+++ b/test/foundry/conduit/ConduitExecuteBatch1155.t.sol
@@ -2,7 +2,11 @@
 pragma solidity ^0.8.13;
 
 import { BaseConsiderationTest } from "../utils/BaseConsiderationTest.sol";
-import { ConduitTransfer, ConduitBatch1155Transfer, ConduitItemType } from "../../../contracts/conduit/lib/ConduitStructs.sol";
+import {
+    ConduitTransfer,
+    ConduitBatch1155Transfer,
+    ConduitItemType
+} from "../../../contracts/conduit/lib/ConduitStructs.sol";
 import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
 import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
 import { TestERC721 } from "../../../contracts/test/TestERC721.sol";

--- a/test/foundry/conduit/ConduitExecuteWithBatch1155.t.sol
+++ b/test/foundry/conduit/ConduitExecuteWithBatch1155.t.sol
@@ -3,9 +3,15 @@
 pragma solidity ^0.8.13;
 
 import { Conduit } from "../../../contracts/conduit/Conduit.sol";
-import { ConduitController } from "../../../contracts/conduit/ConduitController.sol";
+import {
+    ConduitController
+} from "../../../contracts/conduit/ConduitController.sol";
 import { BaseConduitTest } from "./BaseConduitTest.sol";
-import { ConduitTransfer, ConduitBatch1155Transfer, ConduitItemType } from "../../../contracts/conduit/lib/ConduitStructs.sol";
+import {
+    ConduitTransfer,
+    ConduitBatch1155Transfer,
+    ConduitItemType
+} from "../../../contracts/conduit/lib/ConduitStructs.sol";
 import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
 import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
 import { TestERC721 } from "../../../contracts/test/TestERC721.sol";

--- a/test/foundry/utils/BaseConsiderationTest.sol
+++ b/test/foundry/utils/BaseConsiderationTest.sol
@@ -1,16 +1,34 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { ConduitController } from "../../../contracts/conduit/ConduitController.sol";
-import { ConsiderationInterface } from "../../../contracts/interfaces/ConsiderationInterface.sol";
-import { OrderType, BasicOrderType, ItemType, Side } from "../../../contracts/lib/ConsiderationEnums.sol";
-import { OfferItem, ConsiderationItem, OrderComponents, BasicOrderParameters } from "../../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConduitController
+} from "../../../contracts/conduit/ConduitController.sol";
+import {
+    ConsiderationInterface
+} from "../../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    OrderType,
+    BasicOrderType,
+    ItemType,
+    Side
+} from "../../../contracts/lib/ConsiderationEnums.sol";
+import {
+    OfferItem,
+    ConsiderationItem,
+    OrderComponents,
+    BasicOrderParameters
+} from "../../../contracts/lib/ConsiderationStructs.sol";
 import { Test } from "forge-std/Test.sol";
 import { DifferentialTest } from "./DifferentialTest.sol";
 import { StructCopier } from "./StructCopier.sol";
 import { stdStorage, StdStorage } from "forge-std/Test.sol";
-import { ReferenceConduitController } from "../../../reference/conduit/ReferenceConduitController.sol";
-import { ReferenceConsideration } from "../../../reference/ReferenceConsideration.sol";
+import {
+    ReferenceConduitController
+} from "../../../reference/conduit/ReferenceConduitController.sol";
+import {
+    ReferenceConsideration
+} from "../../../reference/ReferenceConsideration.sol";
 import { Conduit } from "../../../contracts/conduit/Conduit.sol";
 import { Consideration } from "../../../contracts/lib/Consideration.sol";
 

--- a/test/foundry/utils/BaseOrderTest.sol
+++ b/test/foundry/utils/BaseOrderTest.sol
@@ -6,9 +6,25 @@ import { stdStorage, StdStorage } from "forge-std/Test.sol";
 import { ProxyRegistry } from "../interfaces/ProxyRegistry.sol";
 import { OwnableDelegateProxy } from "../interfaces/OwnableDelegateProxy.sol";
 import { OneWord } from "../../../contracts/lib/ConsiderationConstants.sol";
-import { ConsiderationInterface } from "../../../contracts/interfaces/ConsiderationInterface.sol";
-import { BasicOrderType, OrderType } from "../../../contracts/lib/ConsiderationEnums.sol";
-import { BasicOrderParameters, ConsiderationItem, AdditionalRecipient, OfferItem, Fulfillment, FulfillmentComponent, ItemType, Order, OrderComponents, OrderParameters } from "../../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConsiderationInterface
+} from "../../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    BasicOrderType,
+    OrderType
+} from "../../../contracts/lib/ConsiderationEnums.sol";
+import {
+    BasicOrderParameters,
+    ConsiderationItem,
+    AdditionalRecipient,
+    OfferItem,
+    Fulfillment,
+    FulfillmentComponent,
+    ItemType,
+    Order,
+    OrderComponents,
+    OrderParameters
+} from "../../../contracts/lib/ConsiderationStructs.sol";
 import { ArithmeticUtil } from "./ArithmeticUtil.sol";
 import { OfferConsiderationItemAdder } from "./OfferConsiderationItemAdder.sol";
 import { AmountDeriver } from "../../../contracts/lib/AmountDeriver.sol";

--- a/test/foundry/utils/ERC1155Recipient.sol
+++ b/test/foundry/utils/ERC1155Recipient.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.13;
 
-import { ERC1155TokenReceiver } from "@rari-capital/solmate/src/tokens/ERC1155.sol";
+import {
+    ERC1155TokenReceiver
+} from "@rari-capital/solmate/src/tokens/ERC1155.sol";
 
 contract ERC1155Recipient is ERC1155TokenReceiver {
     function onERC1155Received(

--- a/test/foundry/utils/ERC721Recipient.sol
+++ b/test/foundry/utils/ERC721Recipient.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.13;
 
-import { ERC721TokenReceiver } from "@rari-capital/solmate/src/tokens/ERC721.sol";
+import {
+    ERC721TokenReceiver
+} from "@rari-capital/solmate/src/tokens/ERC721.sol";
 
 contract ERC721Recipient is ERC721TokenReceiver {
     function onERC721Received(

--- a/test/foundry/utils/OfferConsiderationItemAdder.sol
+++ b/test/foundry/utils/OfferConsiderationItemAdder.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { ConsiderationItem, OfferItem, ItemType } from "../../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConsiderationItem,
+    OfferItem,
+    ItemType
+} from "../../../contracts/lib/ConsiderationStructs.sol";
 import { TestTokenMinter } from "./TestTokenMinter.sol";
 
 contract OfferConsiderationItemAdder is TestTokenMinter {

--- a/test/foundry/utils/StructCopier.sol
+++ b/test/foundry/utils/StructCopier.sol
@@ -1,7 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
-import { BasicOrderParameters, CriteriaResolver, AdvancedOrder, AdditionalRecipient, OfferItem, Order, ConsiderationItem, Fulfillment, FulfillmentComponent, OrderParameters, OrderComponents } from "../../../contracts/lib/ConsiderationStructs.sol";
-import { ConsiderationInterface } from "../../../contracts/interfaces/ConsiderationInterface.sol";
+import {
+    BasicOrderParameters,
+    CriteriaResolver,
+    AdvancedOrder,
+    AdditionalRecipient,
+    OfferItem,
+    Order,
+    ConsiderationItem,
+    Fulfillment,
+    FulfillmentComponent,
+    OrderParameters,
+    OrderComponents
+} from "../../../contracts/lib/ConsiderationStructs.sol";
+import {
+    ConsiderationInterface
+} from "../../../contracts/interfaces/ConsiderationInterface.sol";
 
 contract StructCopier {
     Order _tempOrder;

--- a/test/foundry/utils/reentrancy/ReentrantStructs.sol
+++ b/test/foundry/utils/reentrancy/ReentrantStructs.sol
@@ -1,6 +1,19 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
-import { BasicOrderParameters, OfferItem, ConsiderationItem, OrderParameters, OrderComponents, Fulfillment, FulfillmentComponent, Execution, Order, AdvancedOrder, OrderStatus, CriteriaResolver } from "../../../../contracts/lib/ConsiderationStructs.sol";
+import {
+    BasicOrderParameters,
+    OfferItem,
+    ConsiderationItem,
+    OrderParameters,
+    OrderComponents,
+    Fulfillment,
+    FulfillmentComponent,
+    Execution,
+    Order,
+    AdvancedOrder,
+    OrderStatus,
+    CriteriaResolver
+} from "../../../../contracts/lib/ConsiderationStructs.sol";
 
 struct FulfillBasicOrderParameters {
     BasicOrderParameters parameters;


### PR DESCRIPTION
I was reading the prettier-solidity readme and it says if you pass the [compiler](https://github.com/prettier-solidity/prettier-plugin-solidity#compiler-experimental) option prettier can format multi-line solidity imports when past solidity v0.7.4

This PR provides the prettierrc compiler version and removes now-redundant prettier-ignore statements.