### PR TITLE
Add reference shim to solcover skip

### DIFF
--- a/config/.solcover-reference.js
+++ b/config/.solcover-reference.js
@@ -38,5 +38,6 @@ module.exports = {
     "test/ConduitMockInvalidMagic.sol",
     "test/ConduitMockRevertBytes.sol",
     "test/ConduitMockRevertNoReason.sol",
+    "../reference/shim/Shim.sol",
   ],
 };


### PR DESCRIPTION
This PR skips the reference shim for the coverage report.