### PR TITLE
Apply suggested changes from Spearbit

### DIFF
--- a/contracts/helpers/TransferHelper.sol
+++ b/contracts/helpers/TransferHelper.sol
@@ -272,7 +272,8 @@ contract TransferHelper is TransferHelperInterface, TransferHelperErrors {
      *         to provide an additional layer of assurance that the recipient
      *         can receive the tokens — any hooks or post-transfer checks will
      *         fail and the caller will be the transfer helper rather than the
-     *         ERC721 contract.
+     *         ERC721 contract. Note that the conduit is set as the operator, as
+     *         it will be the caller once the transfer is performed.
      *
      * @param conduit   The conduit to provide as the operator when calling
      *                  onERC721Received.

--- a/contracts/interfaces/TransferHelperErrors.sol
+++ b/contracts/interfaces/TransferHelperErrors.sol
@@ -12,6 +12,12 @@ interface TransferHelperErrors {
     error InvalidItemType();
 
     /**
+     * @dev Revert with an error when an ERC721 transfer with amount other than
+     *      one is attempted.
+     */
+    error InvalidERC721TransferAmount();
+
+    /**
      * @dev Revert with an error when attempting to execute an ERC721 transfer
      *      to an invalid recipient.
      */

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -32,7 +32,7 @@ const config: HardhatUserConfig = {
           viaIR: true,
           optimizer: {
             enabled: true,
-            runs: 19066,
+            runs: 18000,
           },
         },
       },

--- a/script/TransferHelperDeployer.s.sol
+++ b/script/TransferHelperDeployer.s.sol
@@ -12,7 +12,6 @@ contract TransferHelperDeployer is Script {
     function setUp() public {}
 
     function run() public {
-        address deployer = 0x43Eb2499553a4cb062cfeD09407F6c94C1494F86;
         vm.broadcast();
         ImmutableCreate2Factory factory = ImmutableCreate2Factory(
             0x0000000000FFe8B47B3e2130213B802212439497

--- a/test/foundry/FulfillAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAdvancedOrder.t.sol
@@ -600,38 +600,13 @@ contract FulfillAdvancedOrder is BaseOrderTest {
             mstore(add(0x40, advancedOrder), shl(120, 1))
         }
 
-        bytes4 fulfillAdvancedOrderSelector = consideration
-            .fulfillAdvancedOrder
-            .selector;
-        bytes memory fulfillAdvancedOrderCalldata = abi.encodeWithSelector(
-            fulfillAdvancedOrderSelector,
+        vm.expectRevert(abi.encodeWithSignature("BadFraction()"));
+        context.consideration.fulfillAdvancedOrder(
             advancedOrder,
             new CriteriaResolver[](0),
             bytes32(0),
             address(0)
         );
-
-        address considerationAddress = address(consideration);
-        uint256 calldataLength = fulfillAdvancedOrderCalldata.length;
-        bool success;
-
-        assembly {
-            // Call fulfillBasicOrders
-            success := call(
-                gas(),
-                considerationAddress,
-                50,
-                // The fn signature and calldata starts after the
-                // first OneWord bytes, as those initial bytes just
-                // contain the length of fulfillAdvancedOrderCalldata
-                add(fulfillAdvancedOrderCalldata, OneWord),
-                calldataLength,
-                // Store output at empty storage location,
-                // identified using "free memory pointer".
-                mload(0x40),
-                OneWord
-            )
-        }
     }
 
     function testPartialFulfillEthTo1155NumeratorOverflowToZero() public {
@@ -694,38 +669,13 @@ contract FulfillAdvancedOrder is BaseOrderTest {
             mstore(add(0x20, advancedOrder), shl(120, 1))
         }
 
-        bytes4 fulfillAdvancedOrderSelector = consideration
-            .fulfillAdvancedOrder
-            .selector;
-        bytes memory fulfillAdvancedOrderCalldata = abi.encodeWithSelector(
-            fulfillAdvancedOrderSelector,
+        vm.expectRevert(abi.encodeWithSignature("BadFraction()"));
+        context.consideration.fulfillAdvancedOrder(
             advancedOrder,
             new CriteriaResolver[](0),
             bytes32(0),
             address(0)
         );
-
-        address considerationAddress = address(consideration);
-        uint256 calldataLength = fulfillAdvancedOrderCalldata.length;
-        bool success;
-
-        assembly {
-            // Call fulfillBasicOrders
-            success := call(
-                gas(),
-                considerationAddress,
-                50,
-                // The fn signature and calldata starts after the
-                // first OneWord bytes, as those initial bytes just
-                // contain the length of fulfillAdvancedOrderCalldata
-                add(fulfillAdvancedOrderCalldata, OneWord),
-                calldataLength,
-                // Store output at empty storage location,
-                // identified using "free memory pointer".
-                mload(0x40),
-                OneWord
-            )
-        }
     }
 
     function testPartialFulfillEthTo1155NumeratorDenominatorOverflowToZero()
@@ -791,38 +741,13 @@ contract FulfillAdvancedOrder is BaseOrderTest {
             mstore(add(0x40, advancedOrder), shl(120, 1))
         }
 
-        bytes4 fulfillAdvancedOrderSelector = consideration
-            .fulfillAdvancedOrder
-            .selector;
-        bytes memory fulfillAdvancedOrderCalldata = abi.encodeWithSelector(
-            fulfillAdvancedOrderSelector,
+        vm.expectRevert(abi.encodeWithSignature("BadFraction()"));
+        context.consideration.fulfillAdvancedOrder(
             advancedOrder,
             new CriteriaResolver[](0),
             bytes32(0),
             address(0)
         );
-
-        address considerationAddress = address(consideration);
-        uint256 calldataLength = fulfillAdvancedOrderCalldata.length;
-        bool success;
-
-        assembly {
-            // Call fulfillBasicOrders
-            success := call(
-                gas(),
-                considerationAddress,
-                50,
-                // The fn signature and calldata starts after the
-                // first OneWord bytes, as those initial bytes just
-                // contain the length of fulfillAdvancedOrderCalldata
-                add(fulfillAdvancedOrderCalldata, OneWord),
-                calldataLength,
-                // Store output at empty storage location,
-                // identified using "free memory pointer".
-                mload(0x40),
-                OneWord
-            )
-        }
     }
 
     function testPartialFulfillEthTo1155NumeratorSetToZero() public {

--- a/test/foundry/FulfillAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAdvancedOrder.t.sol
@@ -632,7 +632,6 @@ contract FulfillAdvancedOrder is BaseOrderTest {
                 OneWord
             )
         }
-        vm.expectRevert(abi.encodeWithSignature("BadFraction()"));
     }
 
     function testPartialFulfillEthTo1155NumeratorOverflowToZero() public {
@@ -727,7 +726,6 @@ contract FulfillAdvancedOrder is BaseOrderTest {
                 OneWord
             )
         }
-        vm.expectRevert(abi.encodeWithSignature("BadFraction()"));
     }
 
     function testPartialFulfillEthTo1155NumeratorDenominatorOverflowToZero()
@@ -825,7 +823,6 @@ contract FulfillAdvancedOrder is BaseOrderTest {
                 OneWord
             )
         }
-        vm.expectRevert(abi.encodeWithSignature("BadFraction()"));
     }
 
     function testPartialFulfillEthTo1155NumeratorSetToZero() public {

--- a/test/foundry/TransferHelperMultipleRecipientsTest.sol
+++ b/test/foundry/TransferHelperMultipleRecipientsTest.sol
@@ -92,8 +92,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
     }
 
     struct FuzzInputsCommon {
-        // Indicates if a conduit should be used for the transfer
-        bool useConduit;
         // Amounts that can be used for the amount field on TransferHelperItem
         uint256[10] amounts;
         // Identifiers that can be used for the identifier field on TransferHelperItem
@@ -303,7 +301,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
         TransferHelperItem memory item,
         address from,
         address[10] memory recipients,
-        bool useConduit,
         bool makeSafeRecipient,
         bytes memory expectRevertData
     ) public {
@@ -314,7 +311,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             from,
             recipients,
-            useConduit,
             makeSafeRecipient,
             expectRevertData
         );
@@ -324,7 +320,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
         TransferHelperItem[] memory items,
         address from,
         address[10] memory recipients,
-        bool useConduit,
         bool makeSafeRecipient,
         bytes memory expectRevertData
     ) public {
@@ -354,9 +349,7 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
         } else {
             // otherwise register expected emits
 
-            address operator = useConduit
-                ? address(conduit)
-                : address(transferHelper);
+            address operator = address(conduit);
 
             for (uint256 i; i < itemsWithRecipient.length; i++) {
                 TransferHelperItemsWithRecipient
@@ -400,10 +393,7 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
 
         // Perform transfer.
         vm.prank(from);
-        transferHelper.bulkTransfer(
-            itemsWithRecipient,
-            useConduit ? conduitKeyOne : bytes32(0)
-        );
+        transferHelper.bulkTransfer(itemsWithRecipient, conduitKeyOne);
 
         // vm.stopPrank();
     }
@@ -412,9 +402,7 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
         TransferHelperItem[] memory items,
         address from,
         address[10] memory recipients,
-        bool useConduit,
-        bytes memory expectRevertDataWithConduit,
-        bytes memory expectRevertDataWithoutConduit
+        bytes memory expectRevertDataWithConduit
     ) public {
         TransferHelperItemsWithRecipient[]
             memory itemsWithRecipient = _getTransferHelperItemsWithMultipleRecipientsFromTransferHelperItems(
@@ -425,24 +413,16 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
         // Register expected revert if present.
         if (
             // Compare hashes as we cannot directly compare bytes memory with bytes storage.
-            (keccak256(expectRevertDataWithConduit) ==
-                keccak256(REVERT_DATA_NO_MSG) &&
-                useConduit) ||
-            (keccak256(expectRevertDataWithoutConduit) ==
-                keccak256(REVERT_DATA_NO_MSG) &&
-                !useConduit)
+            keccak256(expectRevertDataWithConduit) ==
+            keccak256(REVERT_DATA_NO_MSG)
         ) {
             vm.expectRevert();
-        } else if (expectRevertDataWithConduit.length > 0 && useConduit) {
+        } else if (expectRevertDataWithConduit.length > 0) {
             vm.expectRevert(expectRevertDataWithConduit);
-        } else if (expectRevertDataWithoutConduit.length > 0 && !useConduit) {
-            vm.expectRevert(expectRevertDataWithoutConduit);
         } else {
             // otherwise register expected emits
 
-            address operator = useConduit
-                ? address(conduit)
-                : address(transferHelper);
+            address operator = address(conduit);
 
             for (uint256 i; i < itemsWithRecipient.length; i++) {
                 TransferHelperItemsWithRecipient
@@ -487,10 +467,7 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
         }
         // Perform transfer.
         vm.prank(from);
-        transferHelper.bulkTransfer(
-            itemsWithRecipient,
-            useConduit ? conduitKeyOne : bytes32(0)
-        );
+        transferHelper.bulkTransfer(itemsWithRecipient, conduitKeyOne);
     }
 
     function _makeSafeRecipient(address from, address fuzzRecipient)
@@ -557,7 +534,7 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
                 uint256 index = fuzzIndex % erc20s.length;
                 erc20 = address(erc20s[index]);
             }
-            return TransferHelperItem(itemType, erc20, identifier, amount);
+            return TransferHelperItem(itemType, erc20, 0, amount);
         } else if (itemType == ConduitItemType.ERC1155) {
             address erc1155;
             if (useStub) {
@@ -569,7 +546,7 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             }
             return TransferHelperItem(itemType, erc1155, identifier, amount);
         } else if (itemType == ConduitItemType.NATIVE) {
-            return TransferHelperItem(itemType, address(0), identifier, amount);
+            return TransferHelperItem(itemType, address(0), 0, amount);
         } else if (itemType == ConduitItemType.ERC721) {
             address erc721;
             if (useStub) {
@@ -629,7 +606,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            inputs.useConduit,
             true,
             ""
         );
@@ -651,7 +627,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            inputs.useConduit,
             true,
             ""
         );
@@ -678,7 +653,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            inputs.useConduit,
             true,
             ""
         );
@@ -713,7 +687,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            inputs.useConduit,
             true,
             ""
         );
@@ -746,7 +719,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            inputs.useConduit,
             true,
             ""
         );
@@ -773,7 +745,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            inputs.useConduit,
             true,
             ""
         );
@@ -807,7 +778,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            inputs.useConduit,
             true,
             ""
         );
@@ -844,7 +814,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            inputs.useConduit,
             true,
             ""
         );
@@ -870,7 +839,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            false,
             true,
             ""
         );
@@ -900,7 +868,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            false,
             true,
             ""
         );
@@ -928,7 +895,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            false,
             true,
             ""
         );
@@ -952,7 +918,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             item,
             alice,
             inputs.recipients,
-            false,
             true,
             abi.encodePacked(
                 TransferHelperErrors.InvalidERC20Identifier.selector
@@ -984,7 +949,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             alice,
             invalidRecipients,
             false,
-            false,
             abi.encodeWithSignature(
                 "InvalidERC721Recipient(address)",
                 invalidRecipients[0]
@@ -1003,32 +967,10 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             inputs.identifiers[0]
         );
 
-        bytes memory returnedData;
-        TransferHelperItemsWithRecipient[]
-            memory itemsWithRecipient = _getTransferHelperItemsWithMultipleRecipientsFromTransferHelperItems(
-                alice,
-                items,
-                inputs.recipients
-            );
-        try
-            transferHelper.bulkTransfer(itemsWithRecipient, conduitKeyOne)
-        returns (
-            bytes4 /* magicValue */
-        ) {} catch (bytes memory reason) {
-            returnedData = this.getSelector(reason);
-        }
-
         _performMultiItemTransferAndCheckBalances(
             items,
             alice,
             inputs.recipients,
-            inputs.useConduit,
-            abi.encodeWithSignature(
-                "ConduitErrorRevertBytes(bytes,bytes32,address)",
-                returnedData,
-                conduitKeyOne,
-                conduit
-            ),
             abi.encodePacked(TransferHelperErrors.InvalidItemType.selector)
         );
     }
@@ -1050,32 +992,10 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             inputs.identifiers[1]
         );
 
-        bytes memory returnedData;
-        TransferHelperItemsWithRecipient[]
-            memory itemsWithRecipient = _getTransferHelperItemsWithMultipleRecipientsFromTransferHelperItems(
-                alice,
-                items,
-                inputs.recipients
-            );
-        try
-            transferHelper.bulkTransfer(itemsWithRecipient, conduitKeyOne)
-        returns (
-            bytes4 /* magicValue */
-        ) {} catch (bytes memory reason) {
-            returnedData = this.getSelector(reason);
-        }
-
         _performMultiItemTransferAndCheckBalances(
             items,
             alice,
             inputs.recipients,
-            inputs.useConduit,
-            abi.encodeWithSignature(
-                "ConduitErrorRevertBytes(bytes,bytes32,address)",
-                returnedData,
-                conduitKeyOne,
-                conduit
-            ),
             abi.encodePacked(TransferHelperErrors.InvalidItemType.selector)
         );
     }
@@ -1109,7 +1029,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             item,
             alice,
             inputs.recipients,
-            true,
             true,
             abi.encodePacked(
                 TokenTransferrerErrors.InvalidERC721TransferAmount.selector
@@ -1152,7 +1071,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             alice,
             inputs.recipients,
             true,
-            true,
             abi.encodePacked(
                 TokenTransferrerErrors.InvalidERC721TransferAmount.selector
             )
@@ -1182,7 +1100,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            true,
             true,
             abi.encodeWithSignature(
                 "ConduitErrorRevertBytes(bytes,bytes32,address)",
@@ -1255,7 +1172,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             alice,
             invalidReceivers,
             false,
-            false,
             abi.encodeWithSignature(
                 "ERC721ReceiverErrorRevertString(string,address,address,uint256)",
                 "ERC721ReceiverMock: reverting",
@@ -1283,7 +1199,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             item,
             bob,
             inputs.recipients,
-            true,
             true,
             abi.encodeWithSignature(
                 "ConduitErrorRevertString(string,bytes32,address)",
@@ -1322,7 +1237,6 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
             items,
             alice,
             inputs.recipients,
-            true,
             true,
             abi.encodeWithSignature(
                 "ConduitErrorRevertBytes(bytes,bytes32,address)",

--- a/test/transferhelper.spec.ts
+++ b/test/transferhelper.spec.ts
@@ -247,11 +247,8 @@ describe(`TransferHelper tests (Seaport v${VERSION})`, function () {
       // Loop through all transfer to do ownership/balance checks
       for (let i = 0; i < transfersWithRecipients[0].items.length; i++) {
         // Get Itemtype, token, amount, identifier
-        const {
-          itemType,
-          amount,
-          identifier,
-        } = transfersWithRecipients[0].items[i];
+        const { itemType, amount, identifier } =
+          transfersWithRecipients[0].items[i];
         const token = contracts[i];
 
         switch (itemType) {


### PR DESCRIPTION
Main change is to remove "direct" / no-conduit bulk transfer support, as it adds unnecessary surface area — a standalone contract that implements direct transfers should be deployed if and when that functionality is desired (unlike Seaport, there's no composability benefit to colocation of those transfer methods on the same contract).