### PR TITLE
Fix compilation errors that occurs using Foundry

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 solc = '0.8.14'
 via_ir = true
 src = 'contracts'
@@ -16,7 +16,7 @@ fuzz_runs = 5000
 fuzz_max_global_rejects = 2_000_000
 optimizer_runs = 19_066
 
-[reference]
+[profile.reference]
 solc = '0.8.7'
 via_ir = false
 src = 'reference'
@@ -24,19 +24,19 @@ out = 'reference-out'
 # specify something so it doesn't try to compile the 0.8.14 files in test/foundry
 test = 'reference'
 
-[optimized]
+[profile.optimized]
 out = 'optimized-out'
 
-[test]
+[profile.test]
 via_ir = false
 src = 'test/foundry'
 
-[lite]
+[profile.lite]
 out = 'optimized-out'
 via_ir = false
 fuzz_runs = 1000
 
-[local]
+[profile.local]
 via_ir = false
 fuzz_runs = 1000
 src = 'reference'

--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,10 @@ remappings = [
 fuzz_runs = 5000
 fuzz_max_global_rejects = 2_000_000
 optimizer_runs = 19_066
-fs_permissions = [{ access = "read", path = "./optimized-out" }, { access = "read", path = "./reference-out" }]
+fs_permissions = [
+    { access = "read", path = "./optimized-out" },
+    { access = "read", path = "./reference-out" },
+]
 
 [profile.reference]
 solc = '0.8.7'
@@ -42,5 +45,4 @@ via_ir = false
 fuzz_runs = 1000
 src = 'reference'
 out = 'reference-out'
-
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/foundry.toml
+++ b/foundry.toml
@@ -15,6 +15,7 @@ remappings = [
 fuzz_runs = 5000
 fuzz_max_global_rejects = 2_000_000
 optimizer_runs = 19_066
+fs_permissions = [{ access = "read", path = "./optimized-out" }, { access = "read", path = "./reference-out" }]
 
 [profile.reference]
 solc = '0.8.7'

--- a/test/foundry/GetterTests.t.sol
+++ b/test/foundry/GetterTests.t.sol
@@ -70,7 +70,7 @@ contract TestGetters is BaseConsiderationTest {
         );
     }
 
-    function testGetCorrectDomainSeparator(uint256 _chainId) public {
+    function testGetCorrectDomainSeparator(uint64 _chainId) public {
         // ignore case where _chainId is the same as block.chainid
         vm.assume(_chainId != block.chainid);
         bytes memory typeName = abi.encodePacked(


### PR DESCRIPTION

## Motivation

`forge test` shows up the following errors because of the Foundry update https://github.com/foundry-rs/foundry/pull/3007
```
Failing tests:
Encountered 1 failing test in test/foundry/FulfillAdvancedOrder.t.sol:FulfillAdvancedOrder
[FAIL. Reason: Setup failed: The path "optimized-out/ConduitController.sol/ConduitController.json" is not allowed to be accessed for read operations.] setUp() (gas: 0)

Encountered 1 failing test in test/foundry/FulfillAdvancedOrderCriteria.t.sol:FulfillAdvancedOrderCriteria
[FAIL. Reason: Setup failed: The path "optimized-out/ConduitController.sol/ConduitController.json" is not allowed to be accessed for read operations.] setUp() (gas: 0)

...
```

It also shows up the following warnings
```
warning: Unknown section [default] found in foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.default] instead or run `forge config --fix`.
warning: Unknown section [lite] found in foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.lite] instead or run `forge config --fix`.

...
```

## Solution
- Add `fs_permission` to allow file access
- Run `forge config --fix`