### PR TITLE
Correct comments about the number of bytes to hash, delete chainId judgement in _domainSeparator function

### DIFF
--- a/contracts/lib/GettersAndDerivers.sol
+++ b/contracts/lib/GettersAndDerivers.sol
@@ -361,7 +361,7 @@ contract GettersAndDerivers is ConsiderationBase {
             // after the hash is performed.
             mstore(EIP712_OrderHash_offset, orderHash)
 
-            // Hash the relevant region (65 bytes).
+            // Hash the relevant region (66 bytes).
             value := keccak256(0, EIP712_DigestPayload_size)
 
             // Clear out the dirtied bits in the memory pointer.

--- a/contracts/lib/GettersAndDerivers.sol
+++ b/contracts/lib/GettersAndDerivers.sol
@@ -295,10 +295,7 @@ contract GettersAndDerivers is ConsiderationBase {
      * @return The domain separator.
      */
     function _domainSeparator() internal view returns (bytes32) {
-        // prettier-ignore
-        return block.chainid == _CHAIN_ID
-            ? _DOMAIN_SEPARATOR
-            : _deriveDomainSeparator();
+        return _DOMAIN_SEPARATOR;
     }
 
     /**


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

### comment 
* the EIP712_DigestPayload_size constant is 0x42 defined in contracts/lib/ConsiderationBase.sol, so the bytes to be hashed is 66 bytes rather than 65 bytes.

### chainId judgement
* chainId is initialized to be block.chainId during contract deployment, there is no need to check block.chainid == _CHAIN_ID in function _domainSeparator



## Solution

### comment 
* modify comment about number of bytes to be hashed to 66 bytes
### chainId judgement
* delete chainId judgement , and return _DOMAIN_SEPARATOR directly





