### PR TITLE
Use 4 byte error selectors

### DIFF
--- a/contracts/lib/AmountDeriver.sol
+++ b/contracts/lib/AmountDeriver.sol
@@ -122,8 +122,10 @@ contract AmountDeriver is AmountDerivationErrors {
             // Ensure new value contains no remainder via mulmod operator.
             // Credit to @hrkrshnn + @axic for proposing this optimal solution.
             if mulmod(value, numerator, denominator) {
-                mstore(0, InexactFraction_error_signature)
-                revert(0, InexactFraction_error_len)
+                // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                mstore(0, InexactFraction_error_selector)
+                // revert(abi.encodeWithSignature("InexactFraction()"))
+                revert(0x1c, InexactFraction_error_length)
             }
         }
 

--- a/contracts/lib/Assertions.sol
+++ b/contracts/lib/Assertions.sol
@@ -11,7 +11,7 @@ import {
 
 import { CounterManager } from "./CounterManager.sol";
 
-import "./ConsiderationConstants.sol";
+import "./ConsiderationErrors.sol";
 
 /**
  * @title Assertions
@@ -80,7 +80,7 @@ contract Assertions is
     ) internal pure {
         // Ensure supplied consideration array length is not less than original.
         if (suppliedConsiderationItemTotal < originalConsiderationItemTotal) {
-            revert MissingOriginalConsiderationItems();
+            _revertMissingOriginalConsiderationItems();
         }
     }
 
@@ -91,9 +91,13 @@ contract Assertions is
      * @param amount The amount to check.
      */
     function _assertNonZeroAmount(uint256 amount) internal pure {
-        // Revert if the supplied amount is equal to zero.
-        if (amount == 0) {
-            revert MissingItemAmount();
+        assembly {
+            if iszero(amount) {
+                // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                mstore(0, MissingItemAmount_error_selector)
+                // revert(abi.encodeWithSignature("MissingItemAmount()"))
+                revert(0x1c, MissingItemAmount_error_length)
+            }
         }
     }
 
@@ -165,7 +169,7 @@ contract Assertions is
 
         // Revert with an error if basic order parameter offsets are invalid.
         if (!validOffsets) {
-            revert InvalidBasicOrderParameterEncoding();
+            _revertInvalidBasicOrderParameterEncoding();
         }
     }
 }

--- a/contracts/lib/BasicOrderFulfiller.sol
+++ b/contracts/lib/BasicOrderFulfiller.sol
@@ -20,7 +20,7 @@ import {
 
 import { OrderValidator } from "./OrderValidator.sol";
 
-import "./ConsiderationConstants.sol";
+import "./ConsiderationErrors.sol";
 
 /**
  * @title BasicOrderFulfiller
@@ -106,7 +106,7 @@ contract BasicOrderFulfiller is OrderValidator {
             // Revert if msg.value has not been supplied as part of payable
             // routes or has been supplied as part of non-payable routes.
             if (!correctPayableStatus) {
-                revert InvalidMsgValue(msg.value);
+                _revertInvalidMsgValue(msg.value);
             }
         }
 
@@ -185,7 +185,7 @@ contract BasicOrderFulfiller is OrderValidator {
                 (uint160(parameters.considerationToken) |
                     parameters.considerationIdentifier) != 0
             ) {
-                revert UnusedItemParameters();
+                _revertUnusedItemParameters();
             }
 
             // Transfer the ERC721 or ERC1155 item, bypassing the accumulator.
@@ -945,7 +945,7 @@ contract BasicOrderFulfiller is OrderValidator {
 
                 // Ensure that sufficient Ether is available.
                 if (additionalRecipientAmount > etherRemaining) {
-                    revert InsufficientEtherSupplied();
+                    _revertInsufficientEtherSupplied();
                 }
 
                 // Transfer Ether to the additional recipient.
@@ -962,7 +962,7 @@ contract BasicOrderFulfiller is OrderValidator {
 
         // Ensure that sufficient Ether is still available.
         if (amount > etherRemaining) {
-            revert InsufficientEtherSupplied();
+            _revertInsufficientEtherSupplied();
         }
 
         // Transfer Ether to the offerer.
@@ -1031,7 +1031,7 @@ contract BasicOrderFulfiller is OrderValidator {
 
             // Ensure that no identifier is supplied.
             if (identifier != 0) {
-                revert UnusedItemParameters();
+                _revertUnusedItemParameters();
             }
         }
 

--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -69,22 +69,7 @@ uint256 constant ConsiderItem_recipient_offset = 0xa0;
 uint256 constant Execution_offerer_offset = 0x20;
 uint256 constant Execution_conduit_offset = 0x40;
 
-uint256 constant InvalidFulfillmentComponentData_error_signature = (
-    0x7fda727900000000000000000000000000000000000000000000000000000000
-);
-uint256 constant InvalidFulfillmentComponentData_error_len = 0x04;
-
-uint256 constant Panic_error_signature = (
-    0x4e487b7100000000000000000000000000000000000000000000000000000000
-);
-uint256 constant Panic_error_offset = 0x04;
-uint256 constant Panic_error_length = 0x24;
 uint256 constant Panic_arithmetic = 0x11;
-
-uint256 constant MissingItemAmount_error_signature = (
-    0x91b3e51400000000000000000000000000000000000000000000000000000000
-);
-uint256 constant MissingItemAmount_error_len = 0x04;
 
 uint256 constant OrderParameters_offer_head_offset = 0x40;
 uint256 constant OrderParameters_consideration_head_offset = 0x60;
@@ -294,14 +279,6 @@ uint256 constant EIP1271_isValidSignature_calldata_baseLength = 0x64;
 
 uint256 constant EIP1271_isValidSignature_signature_head_offset = 0x40;
 
-// abi.encodeWithSignature("NoContract(address)")
-uint256 constant NoContract_error_signature = (
-    0x5f15d67200000000000000000000000000000000000000000000000000000000
-);
-uint256 constant NoContract_error_sig_ptr = 0x0;
-uint256 constant NoContract_error_token_ptr = 0x4;
-uint256 constant NoContract_error_length = 0x24; // 4 + 32 == 36
-
 uint256 constant EIP_712_PREFIX = (
     0x1901000000000000000000000000000000000000000000000000000000000000
 );
@@ -364,42 +341,9 @@ uint256 constant Conduit_transferItem_to_ptr = 0x60;
 uint256 constant Conduit_transferItem_identifier_ptr = 0x80;
 uint256 constant Conduit_transferItem_amount_ptr = 0xa0;
 
-// Declare constant for errors related to amount derivation.
-// error InexactFraction() @ AmountDerivationErrors.sol
-uint256 constant InexactFraction_error_signature = (
-    0xc63cf08900000000000000000000000000000000000000000000000000000000
-);
-uint256 constant InexactFraction_error_len = 0x04;
-
-// Declare constant for errors related to signature verification.
 uint256 constant Ecrecover_precompile = 1;
 uint256 constant Ecrecover_args_size = 0x80;
 uint256 constant Signature_lower_v = 27;
-
-// error BadSignatureV(uint8) @ SignatureVerificationErrors.sol
-uint256 constant BadSignatureV_error_signature = (
-    0x1f003d0a00000000000000000000000000000000000000000000000000000000
-);
-uint256 constant BadSignatureV_error_offset = 0x04;
-uint256 constant BadSignatureV_error_length = 0x24;
-
-// error InvalidSigner() @ SignatureVerificationErrors.sol
-uint256 constant InvalidSigner_error_signature = (
-    0x815e1d6400000000000000000000000000000000000000000000000000000000
-);
-uint256 constant InvalidSigner_error_length = 0x04;
-
-// error InvalidSignature() @ SignatureVerificationErrors.sol
-uint256 constant InvalidSignature_error_signature = (
-    0x8baa579f00000000000000000000000000000000000000000000000000000000
-);
-uint256 constant InvalidSignature_error_length = 0x04;
-
-// error BadContractSignature() @ SignatureVerificationErrors.sol
-uint256 constant BadContractSignature_error_signature = (
-    0x4f7fb80d00000000000000000000000000000000000000000000000000000000
-);
-uint256 constant BadContractSignature_error_length = 0x04;
 
 uint256 constant NumBitsAfterSelector = 0xe0;
 
@@ -420,3 +364,465 @@ uint256 constant IsValidOrder_caller_ptr = 0x24;
 uint256 constant IsValidOrder_offerer_ptr = 0x44;
 uint256 constant IsValidOrder_zoneHash_ptr = 0x64;
 uint256 constant IsValidOrder_length = 0x84; // 4 + 32 * 4 == 132
+
+/*
+ *  error MissingFulfillmentComponentOnAggregation(uint8 side)
+ *    - Defined in FulfillmentApplicationErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: side
+ * Revert buffer is memory[0x1c:0x40]
+ */
+uint256 constant MissingFulfillmentComponentOnAggregation_error_selector = 0x375c24c1;
+uint256 constant MissingFulfillmentComponentOnAggregation_error_side_ptr = 0x20;
+uint256 constant MissingFulfillmentComponentOnAggregation_error_length = 0x24;
+
+/*
+ *  error OfferAndConsiderationRequiredOnFulfillment()
+ *    - Defined in FulfillmentApplicationErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant OfferAndConsiderationRequiredOnFulfillment_error_selector = 0x98e9db6e;
+uint256 constant OfferAndConsiderationRequiredOnFulfillment_error_length = 0x04;
+
+/*
+ *  error MismatchedFulfillmentOfferAndConsiderationComponents()
+ *    - Defined in FulfillmentApplicationErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant MismatchedFulfillmentOfferAndConsiderationComponents_error_selector = 0x09cfb455;
+uint256 constant MismatchedFulfillmentOfferAndConsiderationComponents_error_length = 0x04;
+
+/*
+ *  error InvalidFulfillmentComponentData()
+ *    - Defined in FulfillmentApplicationErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant InvalidFulfillmentComponentData_error_selector = 0x7fda7279;
+uint256 constant InvalidFulfillmentComponentData_error_length = 0x04;
+
+/*
+ *  error InexactFraction()
+ *    - Defined in AmountDerivationErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant InexactFraction_error_selector = 0xc63cf089;
+uint256 constant InexactFraction_error_length = 0x04;
+
+/*
+ *  error OrderCriteriaResolverOutOfRange()
+ *    - Defined in CriteriaResolutionErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant OrderCriteriaResolverOutOfRange_error_selector = 0x869586c4;
+uint256 constant OrderCriteriaResolverOutOfRange_error_length = 0x04;
+
+/*
+ *  error UnresolvedOfferCriteria()
+ *    - Defined in CriteriaResolutionErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant UnresolvedOfferCriteria_error_selector = 0xa6cfc673;
+uint256 constant UnresolvedOfferCriteria_error_length = 0x04;
+
+/*
+ *  error UnresolvedConsiderationCriteria()
+ *    - Defined in CriteriaResolutionErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant UnresolvedConsiderationCriteria_error_selector = 0xff75a340;
+uint256 constant UnresolvedConsiderationCriteria_error_length = 0x04;
+
+/*
+ *  error OfferCriteriaResolverOutOfRange()
+ *    - Defined in CriteriaResolutionErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant OfferCriteriaResolverOutOfRange_error_selector = 0xbfb3f8ce;
+uint256 constant OfferCriteriaResolverOutOfRange_error_length = 0x04;
+
+/*
+ *  error ConsiderationCriteriaResolverOutOfRange()
+ *    - Defined in CriteriaResolutionErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant ConsiderationCriteriaResolverOutOfRange_error_selector = 0x6088d7de;
+uint256 constant ConsiderationCriteriaResolverOutOfRange_error_length = 0x04;
+
+/*
+ *  error CriteriaNotEnabledForItem()
+ *    - Defined in CriteriaResolutionErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant CriteriaNotEnabledForItem_error_selector = 0x94eb6af6;
+uint256 constant CriteriaNotEnabledForItem_error_length = 0x04;
+
+/*
+ *  error InvalidProof()
+ *    - Defined in CriteriaResolutionErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant InvalidProof_error_selector = 0x09bde339;
+uint256 constant InvalidProof_error_length = 0x04;
+
+/*
+ *  error InvalidRestrictedOrder(bytes32 orderHash)
+ *    - Defined in ZoneInteractionErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: orderHash
+ * Revert buffer is memory[0x1c:0x40]
+ */
+uint256 constant InvalidRestrictedOrder_error_selector = 0xfb5014fc;
+uint256 constant InvalidRestrictedOrder_error_orderHash_ptr = 0x20;
+uint256 constant InvalidRestrictedOrder_error_length = 0x24;
+
+/*
+ *  error BadSignatureV(uint8 v)
+ *    - Defined in SignatureVerificationErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: v
+ * Revert buffer is memory[0x1c:0x40]
+ */
+uint256 constant BadSignatureV_error_selector = 0x1f003d0a;
+uint256 constant BadSignatureV_error_v_ptr = 0x20;
+uint256 constant BadSignatureV_error_length = 0x24;
+
+/*
+ *  error InvalidSigner()
+ *    - Defined in SignatureVerificationErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant InvalidSigner_error_selector = 0x815e1d64;
+uint256 constant InvalidSigner_error_length = 0x04;
+
+/*
+ *  error InvalidSignature()
+ *    - Defined in SignatureVerificationErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant InvalidSignature_error_selector = 0x8baa579f;
+uint256 constant InvalidSignature_error_length = 0x04;
+
+/*
+ *  error BadContractSignature()
+ *    - Defined in SignatureVerificationErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant BadContractSignature_error_selector = 0x4f7fb80d;
+uint256 constant BadContractSignature_error_length = 0x04;
+
+/*
+ *  error InvalidERC721TransferAmount()
+ *    - Defined in TokenTransferrerErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant InvalidERC721TransferAmount_error_selector = 0xefcc00b1;
+uint256 constant InvalidERC721TransferAmount_error_length = 0x04;
+
+/*
+ *  error MissingItemAmount()
+ *    - Defined in TokenTransferrerErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant MissingItemAmount_error_selector = 0x91b3e514;
+uint256 constant MissingItemAmount_error_length = 0x04;
+
+/*
+ *  error UnusedItemParameters()
+ *    - Defined in TokenTransferrerErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant UnusedItemParameters_error_selector = 0x6ab37ce7;
+uint256 constant UnusedItemParameters_error_length = 0x04;
+
+/*
+ *  error BadReturnValueFromERC20OnTransfer(address token, address from, address to, uint256 amount)
+ *    - Defined in TokenTransferrerErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: token
+ *    - 0x40: from
+ *    - 0x60: to
+ *    - 0x80: amount
+ * Revert buffer is memory[0x1c:0xa0]
+ */
+uint256 constant BadReturnValueFromERC20OnTransfer_error_selector = 0x98891923;
+uint256 constant BadReturnValueFromERC20OnTransfer_error_token_ptr = 0x20;
+uint256 constant BadReturnValueFromERC20OnTransfer_error_from_ptr = 0x40;
+uint256 constant BadReturnValueFromERC20OnTransfer_error_to_ptr = 0x60;
+uint256 constant BadReturnValueFromERC20OnTransfer_error_amount_ptr = 0x80;
+uint256 constant BadReturnValueFromERC20OnTransfer_error_length = 0x84;
+
+/*
+ *  error NoContract(address account)
+ *    - Defined in TokenTransferrerErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: account
+ * Revert buffer is memory[0x1c:0x40]
+ */
+uint256 constant NoContract_error_selector = 0x5f15d672;
+uint256 constant NoContract_error_account_ptr = 0x20;
+uint256 constant NoContract_error_length = 0x24;
+
+/*
+ *  error Invalid1155BatchTransferEncoding()
+ *    - Defined in TokenTransferrerErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant Invalid1155BatchTransferEncoding_error_selector = 0xeba2084c;
+uint256 constant Invalid1155BatchTransferEncoding_error_length = 0x04;
+
+/*
+ *  error NoReentrantCalls()
+ *    - Defined in ReentrancyErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant NoReentrantCalls_error_selector = 0x7fa8a987;
+uint256 constant NoReentrantCalls_error_length = 0x04;
+
+/*
+ *  error OrderAlreadyFilled(bytes32 orderHash)
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: orderHash
+ * Revert buffer is memory[0x1c:0x40]
+ */
+uint256 constant OrderAlreadyFilled_error_selector = 0x10fda3e1;
+uint256 constant OrderAlreadyFilled_error_orderHash_ptr = 0x20;
+uint256 constant OrderAlreadyFilled_error_length = 0x24;
+
+/*
+ *  error InvalidTime()
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant InvalidTime_error_selector = 0x6f7eac26;
+uint256 constant InvalidTime_error_length = 0x04;
+
+/*
+ *  error InvalidConduit(bytes32 conduitKey, address conduit)
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: conduitKey
+ *    - 0x40: conduit
+ * Revert buffer is memory[0x1c:0x60]
+ */
+uint256 constant InvalidConduit_error_selector = 0x1cf99b26;
+uint256 constant InvalidConduit_error_conduitKey_ptr = 0x20;
+uint256 constant InvalidConduit_error_conduit_ptr = 0x40;
+uint256 constant InvalidConduit_error_length = 0x44;
+
+/*
+ *  error MissingOriginalConsiderationItems()
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant MissingOriginalConsiderationItems_error_selector = 0x466aa616;
+uint256 constant MissingOriginalConsiderationItems_error_length = 0x04;
+
+/*
+ *  error InvalidCallToConduit(address conduit)
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: conduit
+ * Revert buffer is memory[0x1c:0x40]
+ */
+uint256 constant InvalidCallToConduit_error_selector = 0xd13d53d4;
+uint256 constant InvalidCallToConduit_error_conduit_ptr = 0x20;
+uint256 constant InvalidCallToConduit_error_length = 0x24;
+
+/*
+ *  error ConsiderationNotMet(uint256 orderIndex, uint256 considerationIndex, uint256 shortfallAmount)
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: orderIndex
+ *    - 0x40: considerationIndex
+ *    - 0x60: shortfallAmount
+ * Revert buffer is memory[0x1c:0x80]
+ */
+uint256 constant ConsiderationNotMet_error_selector = 0xa5f54208;
+uint256 constant ConsiderationNotMet_error_orderIndex_ptr = 0x20;
+uint256 constant ConsiderationNotMet_error_considerationIndex_ptr = 0x40;
+uint256 constant ConsiderationNotMet_error_shortfallAmount_ptr = 0x60;
+uint256 constant ConsiderationNotMet_error_length = 0x64;
+
+/*
+ *  error InsufficientEtherSupplied()
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant InsufficientEtherSupplied_error_selector = 0x1a783b8d;
+uint256 constant InsufficientEtherSupplied_error_length = 0x04;
+
+/*
+ *  error EtherTransferGenericFailure(address account, uint256 amount)
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: account
+ *    - 0x40: amount
+ * Revert buffer is memory[0x1c:0x60]
+ */
+uint256 constant EtherTransferGenericFailure_error_selector = 0x470c7c1d;
+uint256 constant EtherTransferGenericFailure_error_account_ptr = 0x20;
+uint256 constant EtherTransferGenericFailure_error_amount_ptr = 0x40;
+uint256 constant EtherTransferGenericFailure_error_length = 0x44;
+
+/*
+ *  error PartialFillsNotEnabledForOrder()
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant PartialFillsNotEnabledForOrder_error_selector = 0xa11b63ff;
+uint256 constant PartialFillsNotEnabledForOrder_error_length = 0x04;
+
+/*
+ *  error OrderIsCancelled(bytes32 orderHash)
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: orderHash
+ * Revert buffer is memory[0x1c:0x40]
+ */
+uint256 constant OrderIsCancelled_error_selector = 0x1a515574;
+uint256 constant OrderIsCancelled_error_orderHash_ptr = 0x20;
+uint256 constant OrderIsCancelled_error_length = 0x24;
+
+/*
+ *  error OrderPartiallyFilled(bytes32 orderHash)
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: orderHash
+ * Revert buffer is memory[0x1c:0x40]
+ */
+uint256 constant OrderPartiallyFilled_error_selector = 0xee9e0e63;
+uint256 constant OrderPartiallyFilled_error_orderHash_ptr = 0x20;
+uint256 constant OrderPartiallyFilled_error_length = 0x24;
+
+/*
+ *  error InvalidCanceller()
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant InvalidCanceller_error_selector = 0x80ec7374;
+uint256 constant InvalidCanceller_error_length = 0x04;
+
+/*
+ *  error BadFraction()
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant BadFraction_error_selector = 0x5a052b32;
+uint256 constant BadFraction_error_length = 0x04;
+
+/*
+ *  error InvalidMsgValue(uint256 value)
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: value
+ * Revert buffer is memory[0x1c:0x40]
+ */
+uint256 constant InvalidMsgValue_error_selector = 0xa61be9f0;
+uint256 constant InvalidMsgValue_error_value_ptr = 0x20;
+uint256 constant InvalidMsgValue_error_length = 0x24;
+
+/*
+ *  error InvalidBasicOrderParameterEncoding()
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant InvalidBasicOrderParameterEncoding_error_selector = 0x39f3e3fd;
+uint256 constant InvalidBasicOrderParameterEncoding_error_length = 0x04;
+
+/*
+ *  error NoSpecifiedOrdersAvailable()
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant NoSpecifiedOrdersAvailable_error_selector = 0xd5da9a1b;
+uint256 constant NoSpecifiedOrdersAvailable_error_length = 0x04;
+
+/*
+ *  error InvalidNativeOfferItem()
+ *    - Defined in ConsiderationEventsAndErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ * Revert buffer is memory[0x1c:0x20]
+ */
+uint256 constant InvalidNativeOfferItem_error_selector = 0x12d3f5a3;
+uint256 constant InvalidNativeOfferItem_error_length = 0x04;
+
+/*
+ *  error Panic(uint256 code)
+ *    - Built-in Solidity error
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: code
+ * Revert buffer is memory[0x1c:0x40]
+ */
+uint256 constant Panic_error_selector = 0x4e487b71;
+uint256 constant Panic_error_code_ptr = 0x20;
+uint256 constant Panic_error_length = 0x24;

--- a/contracts/lib/ConsiderationErrors.sol
+++ b/contracts/lib/ConsiderationErrors.sol
@@ -147,15 +147,6 @@ function _revertInvalidERC721TransferAmount() pure {
 	}
 }
 
-function _revertInvalidFulfillmentComponentData() pure {
-	assembly {
-		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
-		mstore(0,  InvalidFulfillmentComponentData_error_selector)
-		// revert(abi.encodeWithSignature("InvalidFulfillmentComponentData()"))
-		revert(0x1c, InvalidFulfillmentComponentData_error_length)
-	}
-}
-
 function _revertInvalidMsgValue(uint256 value) pure {
 	assembly {
 		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
@@ -203,15 +194,6 @@ function _revertInvalidSignature() pure {
 	}
 }
 
-function _revertInvalidSigner() pure {
-	assembly {
-		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
-		mstore(0,  InvalidSigner_error_selector)
-		// revert(abi.encodeWithSignature("InvalidSigner()"))
-		revert(0x1c, InvalidSigner_error_length)
-	}
-}
-
 function _revertInvalidTime() pure {
 	assembly {
 		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
@@ -237,15 +219,6 @@ function _revertMissingFulfillmentComponentOnAggregation(uint8 side) pure {
 		mstore(MissingFulfillmentComponentOnAggregation_error_side_ptr, side)
 		// revert(abi.encodeWithSignature("MissingFulfillmentComponentOnAggregation(uint8)", side))
 		revert(0x1c, MissingFulfillmentComponentOnAggregation_error_length)
-	}
-}
-
-function _revertMissingItemAmount() pure {
-	assembly {
-		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
-		mstore(0,  MissingItemAmount_error_selector)
-		// revert(abi.encodeWithSignature("MissingItemAmount()"))
-		revert(0x1c, MissingItemAmount_error_length)
 	}
 }
 
@@ -366,15 +339,5 @@ function _revertUnusedItemParameters() pure {
 		mstore(0,  UnusedItemParameters_error_selector)
 		// revert(abi.encodeWithSignature("UnusedItemParameters()"))
 		revert(0x1c, UnusedItemParameters_error_length)
-	}
-}
-
-function _revertPanic(uint256 code) pure {
-	assembly {
-		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
-		mstore(0,  Panic_error_selector)
-		mstore(Panic_error_code_ptr, code)
-		// revert(abi.encodeWithSignature("Panic(uint256)", code))
-		revert(0x1c, Panic_error_length)
 	}
 }

--- a/contracts/lib/ConsiderationErrors.sol
+++ b/contracts/lib/ConsiderationErrors.sol
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import "./ConsiderationConstants.sol";
+
+function _revertBadContractSignature() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  BadContractSignature_error_selector)
+		// revert(abi.encodeWithSignature("BadContractSignature()"))
+		revert(0x1c, BadContractSignature_error_length)
+	}
+}
+
+function _revertBadFraction() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  BadFraction_error_selector)
+		// revert(abi.encodeWithSignature("BadFraction()"))
+		revert(0x1c, BadFraction_error_length)
+	}
+}
+
+function _revertBadSignatureV(uint8 v) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  BadSignatureV_error_selector)
+		mstore(BadSignatureV_error_v_ptr, v)
+		// revert(abi.encodeWithSignature("BadSignatureV(uint8)", v))
+		revert(0x1c, BadSignatureV_error_length)
+	}
+}
+
+function _revertConsiderationCriteriaResolverOutOfRange() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  ConsiderationCriteriaResolverOutOfRange_error_selector)
+		// revert(abi.encodeWithSignature("ConsiderationCriteriaResolverOutOfRange()"))
+		revert(0x1c, ConsiderationCriteriaResolverOutOfRange_error_length)
+	}
+}
+
+function _revertConsiderationNotMet(uint256 orderIndex, uint256 considerationIndex, uint256 shortfallAmount) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  ConsiderationNotMet_error_selector)
+		mstore(ConsiderationNotMet_error_orderIndex_ptr, orderIndex)
+		mstore(ConsiderationNotMet_error_considerationIndex_ptr, considerationIndex)
+		mstore(ConsiderationNotMet_error_shortfallAmount_ptr, shortfallAmount)
+		// revert(abi.encodeWithSignature("ConsiderationNotMet(uint256,uint256,uint256)", orderIndex, considerationIndex, shortfallAmount))
+		revert(0x1c, ConsiderationNotMet_error_length)
+	}
+}
+
+function _revertCriteriaNotEnabledForItem() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  CriteriaNotEnabledForItem_error_selector)
+		// revert(abi.encodeWithSignature("CriteriaNotEnabledForItem()"))
+		revert(0x1c, CriteriaNotEnabledForItem_error_length)
+	}
+}
+
+function _revertEtherTransferGenericFailure(address account, uint256 amount) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  EtherTransferGenericFailure_error_selector)
+		mstore(EtherTransferGenericFailure_error_account_ptr, account)
+		mstore(EtherTransferGenericFailure_error_amount_ptr, amount)
+		// revert(abi.encodeWithSignature("EtherTransferGenericFailure(address,uint256)", account, amount))
+		revert(0x1c, EtherTransferGenericFailure_error_length)
+	}
+}
+
+function _revertInexactFraction() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InexactFraction_error_selector)
+		// revert(abi.encodeWithSignature("InexactFraction()"))
+		revert(0x1c, InexactFraction_error_length)
+	}
+}
+
+function _revertInsufficientEtherSupplied() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InsufficientEtherSupplied_error_selector)
+		// revert(abi.encodeWithSignature("InsufficientEtherSupplied()"))
+		revert(0x1c, InsufficientEtherSupplied_error_length)
+	}
+}
+
+function _revertInvalid1155BatchTransferEncoding() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  Invalid1155BatchTransferEncoding_error_selector)
+		// revert(abi.encodeWithSignature("Invalid1155BatchTransferEncoding()"))
+		revert(0x1c, Invalid1155BatchTransferEncoding_error_length)
+	}
+}
+
+function _revertInvalidBasicOrderParameterEncoding() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidBasicOrderParameterEncoding_error_selector)
+		// revert(abi.encodeWithSignature("InvalidBasicOrderParameterEncoding()"))
+		revert(0x1c, InvalidBasicOrderParameterEncoding_error_length)
+	}
+}
+
+function _revertInvalidCallToConduit(address conduit) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidCallToConduit_error_selector)
+		mstore(InvalidCallToConduit_error_conduit_ptr, conduit)
+		// revert(abi.encodeWithSignature("InvalidCallToConduit(address)", conduit))
+		revert(0x1c, InvalidCallToConduit_error_length)
+	}
+}
+
+function _revertInvalidCanceller() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidCanceller_error_selector)
+		// revert(abi.encodeWithSignature("InvalidCanceller()"))
+		revert(0x1c, InvalidCanceller_error_length)
+	}
+}
+
+function _revertInvalidConduit(bytes32 conduitKey, address conduit) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidConduit_error_selector)
+		mstore(InvalidConduit_error_conduitKey_ptr, conduitKey)
+		mstore(InvalidConduit_error_conduit_ptr, conduit)
+		// revert(abi.encodeWithSignature("InvalidConduit(bytes32,address)", conduitKey, conduit))
+		revert(0x1c, InvalidConduit_error_length)
+	}
+}
+
+function _revertInvalidERC721TransferAmount() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidERC721TransferAmount_error_selector)
+		// revert(abi.encodeWithSignature("InvalidERC721TransferAmount()"))
+		revert(0x1c, InvalidERC721TransferAmount_error_length)
+	}
+}
+
+function _revertInvalidFulfillmentComponentData() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidFulfillmentComponentData_error_selector)
+		// revert(abi.encodeWithSignature("InvalidFulfillmentComponentData()"))
+		revert(0x1c, InvalidFulfillmentComponentData_error_length)
+	}
+}
+
+function _revertInvalidMsgValue(uint256 value) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidMsgValue_error_selector)
+		mstore(InvalidMsgValue_error_value_ptr, value)
+		// revert(abi.encodeWithSignature("InvalidMsgValue(uint256)", value))
+		revert(0x1c, InvalidMsgValue_error_length)
+	}
+}
+
+function _revertInvalidNativeOfferItem() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidNativeOfferItem_error_selector)
+		// revert(abi.encodeWithSignature("InvalidNativeOfferItem()"))
+		revert(0x1c, InvalidNativeOfferItem_error_length)
+	}
+}
+
+function _revertInvalidProof() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidProof_error_selector)
+		// revert(abi.encodeWithSignature("InvalidProof()"))
+		revert(0x1c, InvalidProof_error_length)
+	}
+}
+
+function _revertInvalidRestrictedOrder(bytes32 orderHash) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidRestrictedOrder_error_selector)
+		mstore(InvalidRestrictedOrder_error_orderHash_ptr, orderHash)
+		// revert(abi.encodeWithSignature("InvalidRestrictedOrder(bytes32)", orderHash))
+		revert(0x1c, InvalidRestrictedOrder_error_length)
+	}
+}
+
+function _revertInvalidSignature() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidSignature_error_selector)
+		// revert(abi.encodeWithSignature("InvalidSignature()"))
+		revert(0x1c, InvalidSignature_error_length)
+	}
+}
+
+function _revertInvalidSigner() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidSigner_error_selector)
+		// revert(abi.encodeWithSignature("InvalidSigner()"))
+		revert(0x1c, InvalidSigner_error_length)
+	}
+}
+
+function _revertInvalidTime() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  InvalidTime_error_selector)
+		// revert(abi.encodeWithSignature("InvalidTime()"))
+		revert(0x1c, InvalidTime_error_length)
+	}
+}
+
+function _revertMismatchedFulfillmentOfferAndConsiderationComponents() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  MismatchedFulfillmentOfferAndConsiderationComponents_error_selector)
+		// revert(abi.encodeWithSignature("MismatchedFulfillmentOfferAndConsiderationComponents()"))
+		revert(0x1c, MismatchedFulfillmentOfferAndConsiderationComponents_error_length)
+	}
+}
+
+function _revertMissingFulfillmentComponentOnAggregation(uint8 side) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  MissingFulfillmentComponentOnAggregation_error_selector)
+		mstore(MissingFulfillmentComponentOnAggregation_error_side_ptr, side)
+		// revert(abi.encodeWithSignature("MissingFulfillmentComponentOnAggregation(uint8)", side))
+		revert(0x1c, MissingFulfillmentComponentOnAggregation_error_length)
+	}
+}
+
+function _revertMissingItemAmount() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  MissingItemAmount_error_selector)
+		// revert(abi.encodeWithSignature("MissingItemAmount()"))
+		revert(0x1c, MissingItemAmount_error_length)
+	}
+}
+
+function _revertMissingOriginalConsiderationItems() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  MissingOriginalConsiderationItems_error_selector)
+		// revert(abi.encodeWithSignature("MissingOriginalConsiderationItems()"))
+		revert(0x1c, MissingOriginalConsiderationItems_error_length)
+	}
+}
+
+function _revertNoReentrantCalls() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  NoReentrantCalls_error_selector)
+		// revert(abi.encodeWithSignature("NoReentrantCalls()"))
+		revert(0x1c, NoReentrantCalls_error_length)
+	}
+}
+
+function _revertNoSpecifiedOrdersAvailable() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  NoSpecifiedOrdersAvailable_error_selector)
+		// revert(abi.encodeWithSignature("NoSpecifiedOrdersAvailable()"))
+		revert(0x1c, NoSpecifiedOrdersAvailable_error_length)
+	}
+}
+
+function _revertOfferAndConsiderationRequiredOnFulfillment() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  OfferAndConsiderationRequiredOnFulfillment_error_selector)
+		// revert(abi.encodeWithSignature("OfferAndConsiderationRequiredOnFulfillment()"))
+		revert(0x1c, OfferAndConsiderationRequiredOnFulfillment_error_length)
+	}
+}
+
+function _revertOfferCriteriaResolverOutOfRange() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  OfferCriteriaResolverOutOfRange_error_selector)
+		// revert(abi.encodeWithSignature("OfferCriteriaResolverOutOfRange()"))
+		revert(0x1c, OfferCriteriaResolverOutOfRange_error_length)
+	}
+}
+
+function _revertOrderAlreadyFilled(bytes32 orderHash) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  OrderAlreadyFilled_error_selector)
+		mstore(OrderAlreadyFilled_error_orderHash_ptr, orderHash)
+		// revert(abi.encodeWithSignature("OrderAlreadyFilled(bytes32)", orderHash))
+		revert(0x1c, OrderAlreadyFilled_error_length)
+	}
+}
+
+function _revertOrderCriteriaResolverOutOfRange() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  OrderCriteriaResolverOutOfRange_error_selector)
+		// revert(abi.encodeWithSignature("OrderCriteriaResolverOutOfRange()"))
+		revert(0x1c, OrderCriteriaResolverOutOfRange_error_length)
+	}
+}
+
+function _revertOrderIsCancelled(bytes32 orderHash) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  OrderIsCancelled_error_selector)
+		mstore(OrderIsCancelled_error_orderHash_ptr, orderHash)
+		// revert(abi.encodeWithSignature("OrderIsCancelled(bytes32)", orderHash))
+		revert(0x1c, OrderIsCancelled_error_length)
+	}
+}
+
+function _revertOrderPartiallyFilled(bytes32 orderHash) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  OrderPartiallyFilled_error_selector)
+		mstore(OrderPartiallyFilled_error_orderHash_ptr, orderHash)
+		// revert(abi.encodeWithSignature("OrderPartiallyFilled(bytes32)", orderHash))
+		revert(0x1c, OrderPartiallyFilled_error_length)
+	}
+}
+
+function _revertPartialFillsNotEnabledForOrder() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  PartialFillsNotEnabledForOrder_error_selector)
+		// revert(abi.encodeWithSignature("PartialFillsNotEnabledForOrder()"))
+		revert(0x1c, PartialFillsNotEnabledForOrder_error_length)
+	}
+}
+
+function _revertUnresolvedConsiderationCriteria() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  UnresolvedConsiderationCriteria_error_selector)
+		// revert(abi.encodeWithSignature("UnresolvedConsiderationCriteria()"))
+		revert(0x1c, UnresolvedConsiderationCriteria_error_length)
+	}
+}
+
+function _revertUnresolvedOfferCriteria() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  UnresolvedOfferCriteria_error_selector)
+		// revert(abi.encodeWithSignature("UnresolvedOfferCriteria()"))
+		revert(0x1c, UnresolvedOfferCriteria_error_length)
+	}
+}
+
+function _revertUnusedItemParameters() pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  UnusedItemParameters_error_selector)
+		// revert(abi.encodeWithSignature("UnusedItemParameters()"))
+		revert(0x1c, UnusedItemParameters_error_length)
+	}
+}
+
+function _revertPanic(uint256 code) pure {
+	assembly {
+		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+		mstore(0,  Panic_error_selector)
+		mstore(Panic_error_code_ptr, code)
+		// revert(abi.encodeWithSignature("Panic(uint256)", code))
+		revert(0x1c, Panic_error_length)
+	}
+}

--- a/contracts/lib/ConsiderationErrors.sol
+++ b/contracts/lib/ConsiderationErrors.sol
@@ -3,31 +3,12 @@ pragma solidity >=0.8.13;
 
 import "./ConsiderationConstants.sol";
 
-function _revertBadContractSignature() pure {
-	assembly {
-		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
-		mstore(0,  BadContractSignature_error_selector)
-		// revert(abi.encodeWithSignature("BadContractSignature()"))
-		revert(0x1c, BadContractSignature_error_length)
-	}
-}
-
 function _revertBadFraction() pure {
 	assembly {
 		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
 		mstore(0,  BadFraction_error_selector)
 		// revert(abi.encodeWithSignature("BadFraction()"))
 		revert(0x1c, BadFraction_error_length)
-	}
-}
-
-function _revertBadSignatureV(uint8 v) pure {
-	assembly {
-		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
-		mstore(0,  BadSignatureV_error_selector)
-		mstore(BadSignatureV_error_v_ptr, v)
-		// revert(abi.encodeWithSignature("BadSignatureV(uint8)", v))
-		revert(0x1c, BadSignatureV_error_length)
 	}
 }
 
@@ -72,30 +53,12 @@ function _revertEtherTransferGenericFailure(address account, uint256 amount) pur
 	}
 }
 
-function _revertInexactFraction() pure {
-	assembly {
-		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
-		mstore(0,  InexactFraction_error_selector)
-		// revert(abi.encodeWithSignature("InexactFraction()"))
-		revert(0x1c, InexactFraction_error_length)
-	}
-}
-
 function _revertInsufficientEtherSupplied() pure {
 	assembly {
 		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
 		mstore(0,  InsufficientEtherSupplied_error_selector)
 		// revert(abi.encodeWithSignature("InsufficientEtherSupplied()"))
 		revert(0x1c, InsufficientEtherSupplied_error_length)
-	}
-}
-
-function _revertInvalid1155BatchTransferEncoding() pure {
-	assembly {
-		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
-		mstore(0,  Invalid1155BatchTransferEncoding_error_selector)
-		// revert(abi.encodeWithSignature("Invalid1155BatchTransferEncoding()"))
-		revert(0x1c, Invalid1155BatchTransferEncoding_error_length)
 	}
 }
 
@@ -182,15 +145,6 @@ function _revertInvalidRestrictedOrder(bytes32 orderHash) pure {
 		mstore(InvalidRestrictedOrder_error_orderHash_ptr, orderHash)
 		// revert(abi.encodeWithSignature("InvalidRestrictedOrder(bytes32)", orderHash))
 		revert(0x1c, InvalidRestrictedOrder_error_length)
-	}
-}
-
-function _revertInvalidSignature() pure {
-	assembly {
-		// Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
-		mstore(0,  InvalidSignature_error_selector)
-		// revert(abi.encodeWithSignature("InvalidSignature()"))
-		revert(0x1c, InvalidSignature_error_length)
 	}
 }
 

--- a/contracts/lib/CriteriaResolution.sol
+++ b/contracts/lib/CriteriaResolution.sol
@@ -11,7 +11,7 @@ import {
     CriteriaResolver
 } from "./ConsiderationStructs.sol";
 
-import "./ConsiderationConstants.sol";
+import "./ConsiderationErrors.sol";
 
 import {
     CriteriaResolutionErrors
@@ -62,7 +62,7 @@ contract CriteriaResolution is CriteriaResolutionErrors {
 
                 // Ensure that the order index is in range.
                 if (orderIndex >= totalAdvancedOrders) {
-                    revert OrderCriteriaResolverOutOfRange();
+                    _revertOrderCriteriaResolverOutOfRange();
                 }
 
                 // Skip criteria resolution for order if not fulfilled.
@@ -89,7 +89,7 @@ contract CriteriaResolution is CriteriaResolutionErrors {
 
                     // Ensure that the component index is in range.
                     if (componentIndex >= offer.length) {
-                        revert OfferCriteriaResolverOutOfRange();
+                        _revertOfferCriteriaResolverOutOfRange();
                     }
 
                     // Retrieve relevant item using the component index.
@@ -119,7 +119,7 @@ contract CriteriaResolution is CriteriaResolutionErrors {
 
                     // Ensure that the component index is in range.
                     if (componentIndex >= consideration.length) {
-                        revert ConsiderationCriteriaResolverOutOfRange();
+                        _revertConsiderationCriteriaResolverOutOfRange();
                     }
 
                     // Retrieve relevant item using order and component index.
@@ -150,7 +150,7 @@ contract CriteriaResolution is CriteriaResolutionErrors {
 
                 // Ensure the specified item type indicates criteria usage.
                 if (!_isItemWithCriteria(itemType)) {
-                    revert CriteriaNotEnabledForItem();
+                    _revertCriteriaNotEnabledForItem();
                 }
 
                 // If criteria is not 0 (i.e. a collection-wide offer)...
@@ -190,7 +190,7 @@ contract CriteriaResolution is CriteriaResolutionErrors {
                             orderParameters.consideration[j].itemType
                         )
                     ) {
-                        revert UnresolvedConsiderationCriteria();
+                        _revertUnresolvedConsiderationCriteria();
                     }
                 }
 
@@ -203,7 +203,7 @@ contract CriteriaResolution is CriteriaResolutionErrors {
                     if (
                         _isItemWithCriteria(orderParameters.offer[j].itemType)
                     ) {
-                        revert UnresolvedOfferCriteria();
+                        _revertUnresolvedOfferCriteria();
                     }
                 }
             }
@@ -291,7 +291,7 @@ contract CriteriaResolution is CriteriaResolutionErrors {
 
         // Revert if computed hash does not equal supplied root.
         if (!isValid) {
-            revert InvalidProof();
+            _revertInvalidProof();
         }
     }
 }

--- a/contracts/lib/Executor.sol
+++ b/contracts/lib/Executor.sol
@@ -13,7 +13,7 @@ import { Verifiers } from "./Verifiers.sol";
 
 import { TokenTransferrer } from "./TokenTransferrer.sol";
 
-import "./ConsiderationConstants.sol";
+import "./ConsiderationErrors.sol";
 
 /**
  * @title Executor
@@ -56,7 +56,7 @@ contract Executor is Verifiers, TokenTransferrer {
         if (item.itemType == ItemType.NATIVE) {
             // Ensure neither the token nor the identifier parameters are set.
             if ((uint160(item.token) | item.identifier) != 0) {
-                revert UnusedItemParameters();
+                _revertUnusedItemParameters();
             }
 
             // transfer the native tokens to the recipient.
@@ -64,7 +64,7 @@ contract Executor is Verifiers, TokenTransferrer {
         } else if (item.itemType == ItemType.ERC20) {
             // Ensure that no identifier is supplied.
             if (item.identifier != 0) {
-                revert UnusedItemParameters();
+                _revertUnusedItemParameters();
             }
 
             // Transfer ERC20 tokens from the source to the recipient.
@@ -205,7 +205,7 @@ contract Executor is Verifiers, TokenTransferrer {
             if (itemType == ItemType.ERC721) {
                 // Ensure that exactly one 721 item is being transferred.
                 if (amount != 1) {
-                    revert InvalidERC721TransferAmount();
+                    _revertInvalidERC721TransferAmount();
                 }
 
                 // Perform transfer via the token contract directly.
@@ -242,7 +242,7 @@ contract Executor is Verifiers, TokenTransferrer {
             _revertWithReasonIfOneIsReturned();
 
             // Otherwise, revert with a generic error message.
-            revert EtherTransferGenericFailure(to, amount);
+            _revertEtherTransferGenericFailure(to, amount);
         }
     }
 
@@ -328,7 +328,7 @@ contract Executor is Verifiers, TokenTransferrer {
         if (conduitKey == bytes32(0)) {
             // Ensure that exactly one 721 item is being transferred.
             if (amount != 1) {
-                revert InvalidERC721TransferAmount();
+                _revertInvalidERC721TransferAmount();
             }
 
             // Perform transfer via the token contract directly.
@@ -537,12 +537,12 @@ contract Executor is Verifiers, TokenTransferrer {
             _revertWithReasonIfOneIsReturned();
 
             // Otherwise, revert with a generic error.
-            revert InvalidCallToConduit(conduit);
+            _revertInvalidCallToConduit(conduit);
         }
 
         // Ensure result was extracted and matches EIP-1271 magic value.
         if (result != ConduitInterface.execute.selector) {
-            revert InvalidConduit(conduitKey, conduit);
+            _revertInvalidConduit(conduitKey, conduit);
         }
     }
 

--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -516,7 +516,7 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
                 mstore(0, InvalidFulfillmentComponentData_error_selector)
 
                 // Return, supplying InvalidFulfillmentComponentData signature.
-                revert(0, InvalidFulfillmentComponentData_error_length)
+                revert(0x1c, InvalidFulfillmentComponentData_error_length)
             }
 
             // Declare function for reverts due to arithmetic overflows.

--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -13,7 +13,8 @@ import {
     FulfillmentComponent
 } from "./ConsiderationStructs.sol";
 
-import "./ConsiderationConstants.sol";
+
+import "./ConsiderationErrors.sol";
 
 import {
     FulfillmentApplicationErrors
@@ -52,7 +53,7 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
         if (
             offerComponents.length == 0 || considerationComponents.length == 0
         ) {
-            revert OfferAndConsiderationRequiredOnFulfillment();
+            _revertOfferAndConsiderationRequiredOnFulfillment();
         }
 
         // Declare a new Execution struct.
@@ -83,7 +84,7 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
             execution.item.token != considerationItem.token ||
             execution.item.identifier != considerationItem.identifier
         ) {
-            revert MismatchedFulfillmentOfferAndConsiderationComponents();
+            _revertMismatchedFulfillmentOfferAndConsiderationComponents();
         }
 
         // If total consideration amount exceeds the offer amount...
@@ -164,7 +165,7 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
             // Retrieve fulfillment components array length and place on stack.
             // Ensure at least one fulfillment component has been supplied.
             if (fulfillmentComponents.length == 0) {
-                revert MissingFulfillmentComponentOnAggregation(side);
+                _revertMissingFulfillmentComponentOnAggregation(uint8(side));
             }
 
             // If the fulfillment components are offer components...
@@ -223,23 +224,20 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
         assembly {
             // Declare function for reverts on invalid fulfillment data.
             function throwInvalidFulfillmentComponentData() {
-                // Store the InvalidFulfillmentComponentData error signature.
-                mstore(0, InvalidFulfillmentComponentData_error_signature)
-
-                // Return, supplying InvalidFulfillmentComponentData signature.
-                revert(0, InvalidFulfillmentComponentData_error_len)
+                // Store left-padded selector (uses push4 and reduces code size), mem[28:32] = selector
+                mstore(0, InvalidFulfillmentComponentData_error_selector)
+                // revert(abi.encodeWithSignature("InvalidFulfillmentComponentData()"))
+                revert(0x1c, InvalidFulfillmentComponentData_error_length)
             }
 
             // Declare function for reverts due to arithmetic overflows.
             function throwOverflow() {
                 // Store the Panic error signature.
-                mstore(0, Panic_error_signature)
-
-                // Store the arithmetic (0x11) panic code as initial argument.
-                mstore(Panic_error_offset, Panic_arithmetic)
-
-                // Return, supplying Panic signature and arithmetic code.
-                revert(0, Panic_error_length)
+                mstore(0, Panic_error_selector)
+                // Store the arithmetic (0x11) panic code.
+                mstore(Panic_error_code_ptr, Panic_arithmetic)
+                // revert(abi.encodeWithSignature("Panic(uint256)", 0x11))
+                revert(0x1c, Panic_error_length)
             }
 
             // Get position in offerComponents head.
@@ -479,11 +477,10 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
             if errorBuffer {
                 // If errorBuffer is 1, an item had an amount of zero.
                 if eq(errorBuffer, 1) {
-                    // Store the MissingItemAmount error signature.
-                    mstore(0, MissingItemAmount_error_signature)
-
-                    // Return, supplying MissingItemAmount signature.
-                    revert(0, MissingItemAmount_error_len)
+                    // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                    mstore(0, MissingItemAmount_error_selector)
+                    // revert(abi.encodeWithSignature("MissingItemAmount()"))
+                    revert(0x1c, MissingItemAmount_error_length)
                 }
 
                 // If errorBuffer is not 1 or 0, the sum overflowed.
@@ -516,22 +513,20 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
             // Declare function for reverts on invalid fulfillment data.
             function throwInvalidFulfillmentComponentData() {
                 // Store the InvalidFulfillmentComponentData error signature.
-                mstore(0, InvalidFulfillmentComponentData_error_signature)
+                mstore(0, InvalidFulfillmentComponentData_error_selector)
 
                 // Return, supplying InvalidFulfillmentComponentData signature.
-                revert(0, InvalidFulfillmentComponentData_error_len)
+                revert(0, InvalidFulfillmentComponentData_error_length)
             }
 
             // Declare function for reverts due to arithmetic overflows.
             function throwOverflow() {
                 // Store the Panic error signature.
-                mstore(0, Panic_error_signature)
-
-                // Store the arithmetic (0x11) panic code as initial argument.
-                mstore(Panic_error_offset, Panic_arithmetic)
-
-                // Return, supplying Panic signature and arithmetic code.
-                revert(0, Panic_error_length)
+                mstore(0, Panic_error_selector)
+                // Store the arithmetic (0x11) panic code.
+                mstore(Panic_error_code_ptr, Panic_arithmetic)
+                // revert(abi.encodeWithSignature("Panic(uint256)", 0x11))
+                revert(0x1c, Panic_error_length)
             }
 
             // Get position in considerationComponents head.
@@ -762,11 +757,10 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
             if errorBuffer {
                 // If errorBuffer is 1, an item had an amount of zero.
                 if eq(errorBuffer, 1) {
-                    // Store the MissingItemAmount error signature.
-                    mstore(0, MissingItemAmount_error_signature)
-
-                    // Return, supplying MissingItemAmount signature.
-                    revert(0, MissingItemAmount_error_len)
+                    // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                    mstore(0, MissingItemAmount_error_selector)
+                    // revert(abi.encodeWithSignature("MissingItemAmount()"))
+                    revert(0x1c, MissingItemAmount_error_length)
                 }
 
                 // If errorBuffer is not 1 or 0, the sum overflowed.

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -20,7 +20,7 @@ import { OrderFulfiller } from "./OrderFulfiller.sol";
 
 import { FulfillmentApplier } from "./FulfillmentApplier.sol";
 
-import "./ConsiderationConstants.sol";
+import "./ConsiderationErrors.sol";
 
 /**
  * @title OrderCombiner
@@ -398,7 +398,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
         // matchOrders or matchAdvancedOrders. If the value is three, both the
         // first and second bits were set; in that case, revert with an error.
         if (invalidNativeOfferItemErrorBuffer == 3) {
-            revert InvalidNativeOfferItem();
+            _revertInvalidNativeOfferItem();
         }
 
         // Apply criteria resolvers to each order as applicable.
@@ -578,7 +578,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
 
         // Revert if no orders are available.
         if (executions.length == 0) {
-            revert NoSpecifiedOrdersAvailable();
+            _revertNoSpecifiedOrdersAvailable();
         }
 
         // Perform final checks and return.
@@ -647,7 +647,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
 
                     // Revert if the remaining amount is not zero.
                     if (unmetAmount != 0) {
-                        revert ConsiderationNotMet(i, j, unmetAmount);
+                        _revertConsiderationNotMet(i, j, unmetAmount);
                     }
                 }
             }
@@ -676,7 +676,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
             if (item.itemType == ItemType.NATIVE) {
                 // Ensure that sufficient native tokens are still available.
                 if (item.amount > etherRemaining) {
-                    revert InsufficientEtherSupplied();
+                    _revertInsufficientEtherSupplied();
                 }
 
                 // Skip underflow check as amount is less than ether remaining.

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -20,7 +20,7 @@ import { CriteriaResolution } from "./CriteriaResolution.sol";
 
 import { AmountDeriver } from "./AmountDeriver.sol";
 
-import "./ConsiderationConstants.sol";
+import "./ConsiderationErrors.sol";
 
 /**
  * @title OrderFulfiller
@@ -218,7 +218,7 @@ contract OrderFulfiller is
                 // Offer items for the native token can not be received
                 // outside of a match order function.
                 if (offerItem.itemType == ItemType.NATIVE) {
-                    revert InvalidNativeOfferItem();
+                    _revertInvalidNativeOfferItem();
                 }
 
                 // Declare an additional nested scope to minimize stack depth.
@@ -344,7 +344,7 @@ contract OrderFulfiller is
                 if (considerationItem.itemType == ItemType.NATIVE) {
                     // Ensure that sufficient native tokens are still available.
                     if (amount > etherRemaining) {
-                        revert InsufficientEtherSupplied();
+                        _revertInsufficientEtherSupplied();
                     }
 
                     // Skip underflow check as a comparison has just been made.

--- a/contracts/lib/ReentrancyGuard.sol
+++ b/contracts/lib/ReentrancyGuard.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import { ReentrancyErrors } from "../interfaces/ReentrancyErrors.sol";
 
-import "./ConsiderationConstants.sol";
+import "./ConsiderationErrors.sol";
 
 /**
  * @title ReentrancyGuard
@@ -51,7 +51,7 @@ contract ReentrancyGuard is ReentrancyErrors {
     function _assertNonReentrant() internal view {
         // Ensure that the reentrancy guard is not currently set.
         if (_reentrancyGuard != _NOT_ENTERED) {
-            revert NoReentrantCalls();
+            _revertNoReentrantCalls();
         }
     }
 }

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -9,7 +9,7 @@ import {
 
 import { LowLevelHelpers } from "./LowLevelHelpers.sol";
 
-import "./ConsiderationConstants.sol";
+import "./ConsiderationErrors.sol";
 
 /**
  * @title SignatureVerification
@@ -203,15 +203,19 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
                         // Revert with bad 1271 signature if signer has code.
                         if extcodesize(signer) {
                             // Bad contract signature.
-                            mstore(0, BadContractSignature_error_signature)
-                            revert(0, BadContractSignature_error_length)
+                            // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                            mstore(0, BadContractSignature_error_selector)
+                            // revert(abi.encodeWithSignature("BadContractSignature()"))
+                            revert(0x1c, BadContractSignature_error_length)
                         }
 
                         // Check if signature length was invalid.
                         if gt(sub(ECDSA_MaxLength, signatureLength), 1) {
                             // Revert with generic invalid signature error.
-                            mstore(0, InvalidSignature_error_signature)
-                            revert(0, InvalidSignature_error_length)
+                            // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                            mstore(0, InvalidSignature_error_selector)
+                            // revert(abi.encodeWithSignature("InvalidSignature()"))
+                            revert(0x1c, InvalidSignature_error_length)
                         }
 
                         // Check if v was invalid.
@@ -219,14 +223,18 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
                             byte(v, ECDSA_twentySeventhAndTwentyEighthBytesSet)
                         ) {
                             // Revert with invalid v value.
-                            mstore(0, BadSignatureV_error_signature)
-                            mstore(BadSignatureV_error_offset, v)
-                            revert(0, BadSignatureV_error_length)
+                            // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                            mstore(0, BadSignatureV_error_selector)
+                            mstore(BadSignatureV_error_v_ptr, v)
+                            // revert(abi.encodeWithSignature("BadSignatureV(uint8)", v))
+                            revert(0x1c, BadSignatureV_error_length)
                         }
 
                         // Revert with generic invalid signer error message.
-                        mstore(0, InvalidSigner_error_signature)
-                        revert(0, InvalidSigner_error_length)
+                        // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                        mstore(0, InvalidSigner_error_selector)
+                        // revert(abi.encodeWithSignature("InvalidSigner()"))
+                        revert(0x1c, InvalidSigner_error_length)
                     }
                 }
 
@@ -245,8 +253,10 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
 
             // Otherwise, revert with error indicating bad contract signature.
             assembly {
-                mstore(0, BadContractSignature_error_signature)
-                revert(0, BadContractSignature_error_length)
+                // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                mstore(0, BadContractSignature_error_selector)
+                // revert(abi.encodeWithSignature("BadContractSignature()"))
+                revert(0x1c, BadContractSignature_error_length)
             }
         }
     }

--- a/contracts/lib/TokenTransferrer.sol
+++ b/contracts/lib/TokenTransferrer.sol
@@ -153,10 +153,10 @@ contract TokenTransferrer is TokenTransferrerErrors {
                                 }
                             }
 
-                            // Otherwise revert with a generic error message.
+                            // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
                             mstore(
-                                TokenTransferGenericFailure_error_sig_ptr,
-                                TokenTransferGenericFailure_error_signature
+                                0,
+                                TokenTransferGenericFailure_error_selector
                             )
                             mstore(
                                 TokenTransferGenericFailure_error_token_ptr,
@@ -167,22 +167,28 @@ contract TokenTransferrer is TokenTransferrerErrors {
                                 from
                             )
                             mstore(TokenTransferGenericFailure_error_to_ptr, to)
-                            mstore(TokenTransferGenericFailure_error_id_ptr, 0)
+                            mstore(
+                                TokenTransferGenericFailure_error_identifier_ptr,
+                                0
+                            )
                             mstore(
                                 TokenTransferGenericFailure_error_amount_ptr,
                                 amount
                             )
+                            // revert(abi.encodeWithSignature("TokenTransferGenericFailure(address,address,address,uint256,uint256)", token, from, to, identifier, amount))
                             revert(
-                                TokenTransferGenericFailure_error_sig_ptr,
+                                0x1c,
                                 TokenTransferGenericFailure_error_length
                             )
                         }
 
                         // Otherwise revert with a message about the token
                         // returning false or non-compliant return values.
+
+                        // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
                         mstore(
-                            BadReturnValueFromERC20OnTransfer_error_sig_ptr,
-                            BadReturnValueFromERC20OnTransfer_error_signature
+                            0,
+                            BadReturnValueFromERC20OnTransfer_error_selector
                         )
                         mstore(
                             BadReturnValueFromERC20OnTransfer_error_token_ptr,
@@ -200,16 +206,19 @@ contract TokenTransferrer is TokenTransferrerErrors {
                             BadReturnValueFromERC20OnTransfer_error_amount_ptr,
                             amount
                         )
+                        // revert(abi.encodeWithSignature("BadReturnValueFromERC20OnTransfer(address,address,address,uint256)", token, from, to, amount))
                         revert(
-                            BadReturnValueFromERC20OnTransfer_error_sig_ptr,
+                            0x1c,
                             BadReturnValueFromERC20OnTransfer_error_length
                         )
                     }
 
                     // Otherwise, revert with error about token not having code:
-                    mstore(NoContract_error_sig_ptr, NoContract_error_signature)
-                    mstore(NoContract_error_token_ptr, token)
-                    revert(NoContract_error_sig_ptr, NoContract_error_length)
+                    // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                    mstore(0, NoContract_error_selector)
+                    mstore(NoContract_error_account_ptr, token)
+                    // revert(abi.encodeWithSignature("NoContract(address)", account))
+                    revert(0x1c, NoContract_error_length)
                 }
 
                 // Otherwise, the token just returned no data despite the call
@@ -247,9 +256,11 @@ contract TokenTransferrer is TokenTransferrerErrors {
         assembly {
             // If the token has no code, revert.
             if iszero(extcodesize(token)) {
-                mstore(NoContract_error_sig_ptr, NoContract_error_signature)
-                mstore(NoContract_error_token_ptr, token)
-                revert(NoContract_error_sig_ptr, NoContract_error_length)
+                // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                mstore(0, NoContract_error_selector)
+                mstore(NoContract_error_account_ptr, token)
+                // revert(abi.encodeWithSignature("NoContract(address)", account))
+                revert(0x1c, NoContract_error_length)
             }
 
             // The free memory pointer memory slot will be used when populating
@@ -328,19 +339,18 @@ contract TokenTransferrer is TokenTransferrerErrors {
                 }
 
                 // Otherwise revert with a generic error message.
-                mstore(
-                    TokenTransferGenericFailure_error_sig_ptr,
-                    TokenTransferGenericFailure_error_signature
-                )
+                // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                mstore(0, TokenTransferGenericFailure_error_selector)
                 mstore(TokenTransferGenericFailure_error_token_ptr, token)
                 mstore(TokenTransferGenericFailure_error_from_ptr, from)
                 mstore(TokenTransferGenericFailure_error_to_ptr, to)
-                mstore(TokenTransferGenericFailure_error_id_ptr, identifier)
-                mstore(TokenTransferGenericFailure_error_amount_ptr, 1)
-                revert(
-                    TokenTransferGenericFailure_error_sig_ptr,
-                    TokenTransferGenericFailure_error_length
+                mstore(
+                    TokenTransferGenericFailure_error_identifier_ptr,
+                    identifier
                 )
+                mstore(TokenTransferGenericFailure_error_amount_ptr, 1)
+                // revert(abi.encodeWithSignature("TokenTransferGenericFailure(address,address,address,uint256,uint256)", token, from, to, identifier, amount))
+                revert(0x1c, TokenTransferGenericFailure_error_length)
             }
 
             // Restore the original free memory pointer.
@@ -375,9 +385,11 @@ contract TokenTransferrer is TokenTransferrerErrors {
         assembly {
             // If the token has no code, revert.
             if iszero(extcodesize(token)) {
-                mstore(NoContract_error_sig_ptr, NoContract_error_signature)
-                mstore(NoContract_error_token_ptr, token)
-                revert(NoContract_error_sig_ptr, NoContract_error_length)
+                // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                mstore(0, NoContract_error_selector)
+                mstore(NoContract_error_account_ptr, token)
+                // revert(abi.encodeWithSignature("NoContract(address)", account))
+                revert(0x1c, NoContract_error_length)
             }
 
             // The following memory slots will be used when populating call data
@@ -468,19 +480,19 @@ contract TokenTransferrer is TokenTransferrerErrors {
                 }
 
                 // Otherwise revert with a generic error message.
-                mstore(
-                    TokenTransferGenericFailure_error_sig_ptr,
-                    TokenTransferGenericFailure_error_signature
-                )
+
+                // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                mstore(0, TokenTransferGenericFailure_error_selector)
                 mstore(TokenTransferGenericFailure_error_token_ptr, token)
                 mstore(TokenTransferGenericFailure_error_from_ptr, from)
                 mstore(TokenTransferGenericFailure_error_to_ptr, to)
-                mstore(TokenTransferGenericFailure_error_id_ptr, identifier)
-                mstore(TokenTransferGenericFailure_error_amount_ptr, amount)
-                revert(
-                    TokenTransferGenericFailure_error_sig_ptr,
-                    TokenTransferGenericFailure_error_length
+                mstore(
+                    TokenTransferGenericFailure_error_identifier_ptr,
+                    identifier
                 )
+                mstore(TokenTransferGenericFailure_error_amount_ptr, amount)
+                // revert(abi.encodeWithSignature("TokenTransferGenericFailure(address,address,address,uint256,uint256)", token, from, to, identifier, amount))
+                revert(0x1c, TokenTransferGenericFailure_error_length)
             }
 
             mstore(Slot0x80, slot0x80) // Restore slot 0x80.
@@ -552,9 +564,11 @@ contract TokenTransferrer is TokenTransferrerErrors {
 
                 // If the token has no code, revert.
                 if iszero(extcodesize(token)) {
-                    mstore(NoContract_error_sig_ptr, NoContract_error_signature)
-                    mstore(NoContract_error_token_ptr, token)
-                    revert(NoContract_error_sig_ptr, NoContract_error_length)
+                    // Store left-padded selector with push4 (reduces bytecode), mem[28:32] = selector
+                    mstore(0, NoContract_error_selector)
+                    mstore(NoContract_error_account_ptr, token)
+                    // revert(abi.encodeWithSignature("NoContract(address)", account))
+                    revert(0x1c, NoContract_error_length)
                 }
 
                 // Get the total number of supplied ids.

--- a/contracts/lib/TokenTransferrerConstants.sol
+++ b/contracts/lib/TokenTransferrerConstants.sol
@@ -90,44 +90,37 @@ uint256 constant ERC721_transferFrom_to_ptr = 0x24;
 uint256 constant ERC721_transferFrom_id_ptr = 0x44;
 uint256 constant ERC721_transferFrom_length = 0x64; // 4 + 32 * 3 == 100
 
-// abi.encodeWithSignature("NoContract(address)")
-uint256 constant NoContract_error_signature = (
-    0x5f15d67200000000000000000000000000000000000000000000000000000000
-);
-uint256 constant NoContract_error_sig_ptr = 0x0;
-uint256 constant NoContract_error_token_ptr = 0x4;
-uint256 constant NoContract_error_length = 0x24; // 4 + 32 == 36
+/*
+ *  error NoContract(address account)
+ *    - Defined in TokenTransferrerErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x00: account
+ * Revert buffer is memory[0x1c:0x40]
+ */
+uint256 constant NoContract_error_selector = 0x5f15d672;
+uint256 constant NoContract_error_account_ptr = 0x20;
+uint256 constant NoContract_error_length = 0x24;
 
-// abi.encodeWithSignature(
-//     "TokenTransferGenericFailure(address,address,address,uint256,uint256)"
-// )
-uint256 constant TokenTransferGenericFailure_error_signature = (
-    0xf486bc8700000000000000000000000000000000000000000000000000000000
-);
-uint256 constant TokenTransferGenericFailure_error_sig_ptr = 0x0;
-uint256 constant TokenTransferGenericFailure_error_token_ptr = 0x4;
-uint256 constant TokenTransferGenericFailure_error_from_ptr = 0x24;
-uint256 constant TokenTransferGenericFailure_error_to_ptr = 0x44;
-uint256 constant TokenTransferGenericFailure_error_id_ptr = 0x64;
-uint256 constant TokenTransferGenericFailure_error_amount_ptr = 0x84;
-
-// 4 + 32 * 5 == 164
+/*
+ *  error TokenTransferGenericFailure(address token, address from, address to, uint256 identifier, uint256 amount)
+ *    - Defined in TokenTransferrerErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x20: token
+ *    - 0x40: from
+ *    - 0x60: to
+ *    - 0x80: identifier
+ *    - 0xa0: amount
+ * Revert buffer is memory[0x1c:0xc0]
+ */
+uint256 constant TokenTransferGenericFailure_error_selector = 0xf486bc87;
+uint256 constant TokenTransferGenericFailure_error_token_ptr = 0x20;
+uint256 constant TokenTransferGenericFailure_error_from_ptr = 0x40;
+uint256 constant TokenTransferGenericFailure_error_to_ptr = 0x60;
+uint256 constant TokenTransferGenericFailure_error_identifier_ptr = 0x80;
+uint256 constant TokenTransferGenericFailure_error_amount_ptr = 0xa0;
 uint256 constant TokenTransferGenericFailure_error_length = 0xa4;
-
-// abi.encodeWithSignature(
-//     "BadReturnValueFromERC20OnTransfer(address,address,address,uint256)"
-// )
-uint256 constant BadReturnValueFromERC20OnTransfer_error_signature = (
-    0x9889192300000000000000000000000000000000000000000000000000000000
-);
-uint256 constant BadReturnValueFromERC20OnTransfer_error_sig_ptr = 0x0;
-uint256 constant BadReturnValueFromERC20OnTransfer_error_token_ptr = 0x4;
-uint256 constant BadReturnValueFromERC20OnTransfer_error_from_ptr = 0x24;
-uint256 constant BadReturnValueFromERC20OnTransfer_error_to_ptr = 0x44;
-uint256 constant BadReturnValueFromERC20OnTransfer_error_amount_ptr = 0x64;
-
-// 4 + 32 * 4 == 132
-uint256 constant BadReturnValueFromERC20OnTransfer_error_length = 0x84;
 
 uint256 constant ExtraGasBuffer = 0x20;
 uint256 constant CostPerWord = 3;
@@ -171,3 +164,21 @@ uint256 constant ERC1155BatchTransferGenericFailure_error_signature = (
 );
 uint256 constant ERC1155BatchTransferGenericFailure_token_ptr = 0x04;
 uint256 constant ERC1155BatchTransferGenericFailure_ids_offset = 0xc0;
+
+/*
+ *  error BadReturnValueFromERC20OnTransfer(address token, address from, address to, uint256 amount)
+ *    - Defined in TokenTransferrerErrors.sol
+ *  Memory layout:
+ *    - 0x00: Left-padded selector (data begins at 0x1c)
+ *    - 0x00: token
+ *    - 0x20: from
+ *    - 0x40: to
+ *    - 0x60: amount
+ * Revert buffer is memory[0x1c:0xa0]
+ */
+uint256 constant BadReturnValueFromERC20OnTransfer_error_selector = 0x98891923;
+uint256 constant BadReturnValueFromERC20OnTransfer_error_token_ptr = 0x20;
+uint256 constant BadReturnValueFromERC20OnTransfer_error_from_ptr = 0x40;
+uint256 constant BadReturnValueFromERC20OnTransfer_error_to_ptr = 0x60;
+uint256 constant BadReturnValueFromERC20OnTransfer_error_amount_ptr = 0x80;
+uint256 constant BadReturnValueFromERC20OnTransfer_error_length = 0x84;

--- a/contracts/lib/Verifiers.sol
+++ b/contracts/lib/Verifiers.sol
@@ -7,6 +7,8 @@ import { Assertions } from "./Assertions.sol";
 
 import { SignatureVerification } from "./SignatureVerification.sol";
 
+import "./ConsiderationErrors.sol";
+
 /**
  * @title Verifiers
  * @author 0age
@@ -43,7 +45,7 @@ contract Verifiers is Assertions, SignatureVerification {
         if (startTime > block.timestamp || endTime <= block.timestamp) {
             // Only revert if revertOnInvalid has been supplied as true.
             if (revertOnInvalid) {
-                revert InvalidTime();
+                _revertInvalidTime();
             }
 
             // Return false as the order is invalid.
@@ -109,7 +111,7 @@ contract Verifiers is Assertions, SignatureVerification {
         if (orderStatus.isCancelled) {
             // Only revert if revertOnInvalid has been supplied as true.
             if (revertOnInvalid) {
-                revert OrderIsCancelled(orderHash);
+                _revertOrderIsCancelled(orderHash);
             }
 
             // Return false as the order status is invalid.
@@ -124,13 +126,13 @@ contract Verifiers is Assertions, SignatureVerification {
             // ensure the order has not been partially filled when not allowed.
             if (onlyAllowUnused) {
                 // Always revert on partial fills when onlyAllowUnused is true.
-                revert OrderPartiallyFilled(orderHash);
+                _revertOrderPartiallyFilled(orderHash);
             }
             // Otherwise, ensure that order has not been entirely filled.
             else if (orderStatusNumerator >= orderStatus.denominator) {
                 // Only revert if revertOnInvalid has been supplied as true.
                 if (revertOnInvalid) {
-                    revert OrderAlreadyFilled(orderHash);
+                    _revertOrderAlreadyFilled(orderHash);
                 }
 
                 // Return false as the order status is invalid.

--- a/contracts/lib/ZoneInteraction.sol
+++ b/contracts/lib/ZoneInteraction.sol
@@ -7,11 +7,12 @@ import { OrderType } from "./ConsiderationEnums.sol";
 
 import { AdvancedOrder, CriteriaResolver } from "./ConsiderationStructs.sol";
 
-import "./ConsiderationConstants.sol";
 
 import { ZoneInteractionErrors } from "../interfaces/ZoneInteractionErrors.sol";
 
 import { LowLevelHelpers } from "./LowLevelHelpers.sol";
+
+import "./ConsiderationErrors.sol";
 
 /**
  * @title ZoneInteraction
@@ -200,12 +201,12 @@ contract ZoneInteraction is ZoneInteractionErrors, LowLevelHelpers {
             _revertWithReasonIfOneIsReturned();
 
             // Otherwise, revert with a generic error message.
-            revert InvalidRestrictedOrder(orderHash);
+            _revertInvalidRestrictedOrder(orderHash);
         }
 
         // Ensure result was extracted and matches isValidOrder magic value.
         if (_doesNotMatchMagic(ZoneInterface.isValidOrder.selector)) {
-            revert InvalidRestrictedOrder(orderHash);
+            _revertInvalidRestrictedOrder(orderHash);
         }
     }
 }


### PR DESCRIPTION
Modify constants for error encoding to use left-padded uints so they are compiled to push4. Reduces contract size by ~0.5kb