### PR TITLE
Update function selectors and EIP712 encoding to use push4

### DIFF
--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -103,8 +103,13 @@ uint256 constant EIP712_OfferItem_size = 0xc0;
 uint256 constant EIP712_ConsiderationItem_size = 0xe0;
 uint256 constant AdditionalRecipients_size = 0x40;
 
-uint256 constant EIP712_DomainSeparator_offset = 0x02;
-uint256 constant EIP712_OrderHash_offset = 0x22;
+// Pointers are offset by 30 bytes because the prefix is written to
+// the end of the first word of memory in order to save a shift operation
+// and reduce the bytecode size.
+uint256 constant EIP_712_PREFIX = 0x1901;
+uint256 constant EIP712_DomainSeparator_offset = 0x20;
+uint256 constant EIP712_OrderHash_offset = 0x40;
+uint256 constant EIP712_DigestPayload_ptr = 0x1e;
 uint256 constant EIP712_DigestPayload_size = 0x42;
 
 uint256 constant receivedItemsHash_ptr = 0x60;
@@ -269,19 +274,15 @@ uint256 constant ECDSA_MaxLength = 65;
 uint256 constant ECDSA_signature_s_offset = 0x40;
 uint256 constant ECDSA_signature_v_offset = 0x60;
 
-bytes32 constant EIP1271_isValidSignature_selector = (
-    0x1626ba7e00000000000000000000000000000000000000000000000000000000
-);
+uint256 constant EIP1271_isValidSignature_selector = 0x1626ba7e;
 uint256 constant EIP1271_isValidSignature_signatureHead_negativeOffset = 0x20;
 uint256 constant EIP1271_isValidSignature_digest_negativeOffset = 0x40;
-uint256 constant EIP1271_isValidSignature_selector_negativeOffset = 0x44;
+uint256 constant EIP1271_isValidSignature_selector_negativeOffset = 0x60;
+// Offset from pointer selector is written to to beginning of calldata
+uint256 constant EIP1271_isValidSignature_calldata_offset = 0x1c;
 uint256 constant EIP1271_isValidSignature_calldata_baseLength = 0x64;
 
 uint256 constant EIP1271_isValidSignature_signature_head_offset = 0x40;
-
-uint256 constant EIP_712_PREFIX = (
-    0x1901000000000000000000000000000000000000000000000000000000000000
-);
 
 uint256 constant ExtraGasBuffer = 0x20;
 uint256 constant CostPerWord = 3;
@@ -298,13 +299,7 @@ uint256 constant MaskOverLastTwentyBytes = (
     0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff
 );
 
-uint256 constant MaskOverFirstFourBytes = (
-    0xffffffff00000000000000000000000000000000000000000000000000000000
-);
-
-uint256 constant Conduit_execute_signature = (
-    0x4ce34aa200000000000000000000000000000000000000000000000000000000
-);
+uint256 constant Conduit_execute_signature = 0x4ce34aa2;
 
 uint256 constant MaxUint8 = 0xff;
 uint256 constant MaxUint120 = 0xffffffffffffffffffffffffffffff;
@@ -355,14 +350,13 @@ uint256 constant NonMatchSelector_MagicModulus = 69;
 // remainder modulo 69 is 29.
 uint256 constant NonMatchSelector_MagicRemainder = 0x1d;
 
-uint256 constant IsValidOrder_signature = (
-    0x0e1d31dc00000000000000000000000000000000000000000000000000000000
-);
+uint256 constant IsValidOrder_signature = 0x0e1d31dc;
+uint256 constant IsValidOrder_calldata_ptr = 0x1c;
 uint256 constant IsValidOrder_sig_ptr = 0x0;
-uint256 constant IsValidOrder_orderHash_ptr = 0x04;
-uint256 constant IsValidOrder_caller_ptr = 0x24;
-uint256 constant IsValidOrder_offerer_ptr = 0x44;
-uint256 constant IsValidOrder_zoneHash_ptr = 0x64;
+uint256 constant IsValidOrder_orderHash_ptr = 0x20;
+uint256 constant IsValidOrder_caller_ptr = 0x40;
+uint256 constant IsValidOrder_offerer_ptr = 0x60;
+uint256 constant IsValidOrder_zoneHash_ptr = 0x80;
 uint256 constant IsValidOrder_length = 0x84; // 4 + 32 * 4 == 132
 
 /*

--- a/contracts/lib/Executor.sol
+++ b/contracts/lib/Executor.sol
@@ -139,8 +139,12 @@ contract Executor is Verifiers, TokenTransferrer {
                 // Retrieve the free memory pointer and use it as the offset.
                 callDataOffset := mload(FreeMemoryPointerSlot)
 
-                // Write ConduitInterface.execute.selector to memory.
+                // Write ConduitInterface.execute.selector to memory,
+                // placing selector 28 bytes into free memory
                 mstore(callDataOffset, Conduit_execute_signature)
+
+                // Set pointer to beginning of function selector
+                callDataOffset := add(callDataOffset, 0x1c)
 
                 // Write the offset to the ConduitTransfer array in memory.
                 mstore(
@@ -627,8 +631,8 @@ contract Executor is Verifiers, TokenTransferrer {
         // Insert the item.
         assembly {
             let itemPointer := sub(
-                add(accumulator, mul(elements, Conduit_transferItem_size)),
-                Accumulator_itemSizeOffsetDifference
+              add(accumulator, mul(elements, Conduit_transferItem_size)),
+              Accumulator_itemSizeOffsetDifference
             )
             mstore(itemPointer, itemType)
             mstore(add(itemPointer, Conduit_transferItem_token_ptr), token)

--- a/contracts/lib/GettersAndDerivers.sol
+++ b/contracts/lib/GettersAndDerivers.sol
@@ -349,23 +349,24 @@ contract GettersAndDerivers is ConsiderationBase {
     {
         // Leverage scratch space to perform an efficient hash.
         assembly {
-            // Place the EIP-712 prefix at the start of scratch space.
+            // Place the EIP-712 prefix in scratch space; note that the first 30
+            // bytes will be unused
             mstore(0, EIP_712_PREFIX)
 
             // Place the domain separator in the next region of scratch space.
             mstore(EIP712_DomainSeparator_offset, domainSeparator)
 
-            // Place the order hash in scratch space, spilling into the first
-            // two bytes of the free memory pointer — this should never be set
-            // as memory cannot be expanded to that size, and will be zeroed out
-            // after the hash is performed.
+            // Retrieve the free memory pointer; it will be replaced afterwards.
+            let freeMemoryPointer := mload(FreeMemoryPointerSlot)
+
+            // Place the order hash in the free memory pointer slot
             mstore(EIP712_OrderHash_offset, orderHash)
 
             // Hash the relevant region (65 bytes).
-            value := keccak256(0, EIP712_DigestPayload_size)
+            value := keccak256(EIP712_DigestPayload_ptr, EIP712_DigestPayload_size)
 
-            // Clear out the dirtied bits in the memory pointer.
-            mstore(EIP712_OrderHash_offset, 0)
+            // Replace the free memory pointer
+            mstore(EIP712_OrderHash_offset, freeMemoryPointer)
         }
     }
 }

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -176,7 +176,7 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
                 // Cache the value currently stored at the digest pointer.
                 let cachedWordOverwrittenByDigest := mload(digestPtr)
 
-                // Write the selector first, since it overlaps the digest.
+                // Write the function selector.
                 mstore(selectorPtr, EIP1271_isValidSignature_selector)
 
                 // Next, write the digest.
@@ -186,7 +186,7 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
                 success := staticcall(
                     gas(),
                     signer,
-                    selectorPtr,
+                    add(selectorPtr, EIP1271_isValidSignature_calldata_offset),
                     add(
                         signatureLength,
                         EIP1271_isValidSignature_calldata_baseLength
@@ -199,7 +199,7 @@ contract SignatureVerification is SignatureVerificationErrors, LowLevelHelpers {
                 if success {
                     // If first word of scratch space does not contain EIP-1271
                     // signature selector, revert.
-                    if iszero(eq(mload(0), EIP1271_isValidSignature_selector)) {
+                    if iszero(eq(shr(0xe0, mload(0)), EIP1271_isValidSignature_selector)) {
                         // Revert with bad 1271 signature if signer has code.
                         if extcodesize(signer) {
                             // Bad contract signature.

--- a/contracts/lib/ZoneInteraction.sol
+++ b/contracts/lib/ZoneInteraction.sol
@@ -90,7 +90,7 @@ contract ZoneInteraction is ZoneInteractionErrors, LowLevelHelpers {
             success := staticcall(
                 gas(),
                 zone,
-                IsValidOrder_sig_ptr,
+                IsValidOrder_calldata_ptr,
                 IsValidOrder_length,
                 0,
                 0


### PR DESCRIPTION
Update function selectors and EIP712 encoding to use push4. Update pointers and offsets of other affected values