### PR TITLE
change SLOAD to MLOAD

### DIFF
--- a/contracts/zones/PausableZone.sol
+++ b/contracts/zones/PausableZone.sol
@@ -127,7 +127,7 @@ contract PausableZone is
         operator = operatorToAssign;
 
         // Emit an event indicating the operator has been updated.
-        emit OperatorUpdated(operator);
+        emit OperatorUpdated(operatorToAssign);
     }
 
     /**

--- a/contracts/zones/PausableZoneController.sol
+++ b/contracts/zones/PausableZoneController.sol
@@ -329,7 +329,7 @@ contract PausableZoneController is
         _pauser = pauserToAssign;
 
         // Emit an event indicating the pauser has been assigned.
-        emit PauserUpdated(_pauser);
+        emit PauserUpdated(pauserToAssign);
     }
 
     /**


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Reading a state variable costs more gas than reading a local variable. In the following example, function assignOperator0 costs 89 more gases than assignOperator.
```
contract LibDemo {
    address public operator;

    event OperatorUpdated(address newOperator);

    function assignOperator0(address operatorToAssign) external {
         // Set the given address as the new operator.
        operator = operatorToAssign;

        // Emit an event indicating the operator has been updated.
        emit OperatorUpdated(operator);
    }

    function assignOperator(address operatorToAssign) external {
         // Set the given address as the new operator.
        operator = operatorToAssign;

        // Emit an event indicating the operator has been updated.
        emit OperatorUpdated(operatorToAssign);
    }
}
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
If a state variable is read immediately after assignment, then replacing this read directly with the previously assigned local variable will change one SLOAD to one MLOAD to save some gases. 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
