### PR TITLE
Added Arbitrum Nova deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 <tr><td>Optimism</td></tr>
 <tr><td>Optimistic Kovan</td></tr>
 <tr><td>Arbitrum</td></tr>
+<tr><td>Arbitrum Nova</td></tr>
 <tr><td>Arbitrum Rinkeby</td></tr>
 <tr><td>Avalanche Fuji</td></tr>
 <tr><td>Avalanche C-Chain</td></tr>


### PR DESCRIPTION
## Motivation

deployed to arbitrum nova, a separate chain from arbitrum: https://nova.arbiscan.io/address/0x00000000006c3852cbef3e08e8df289169ede581

## Solution

add arbitrum nova as a deployed chain in the readme

