### PR TITLE
[WIP] 1.2 copy optimizations

### DIFF
--- a/contracts/lib/ConsiderationStructs.sol
+++ b/contracts/lib/ConsiderationStructs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.13;
 
 import {
     OrderType,
@@ -7,6 +7,7 @@ import {
     ItemType,
     Side
 } from "./ConsiderationEnums.sol";
+import { MemoryPointer } from "./PointerLibraries.sol";
 
 /**
  * @dev An order contains eleven components: an offerer, a zone (or account that
@@ -259,4 +260,149 @@ struct ZoneParameters {
     uint256 startTime;
     uint256 endTime;
     bytes32 zoneHash;
+}
+
+using StructPointers for OrderComponents global;
+using StructPointers for OfferItem global;
+using StructPointers for ConsiderationItem global;
+using StructPointers for SpentItem global;
+using StructPointers for ReceivedItem global;
+using StructPointers for BasicOrderParameters global;
+using StructPointers for AdditionalRecipient global;
+using StructPointers for OrderParameters global;
+using StructPointers for Order global;
+using StructPointers for AdvancedOrder global;
+using StructPointers for OrderStatus global;
+using StructPointers for CriteriaResolver global;
+using StructPointers for Fulfillment global;
+using StructPointers for FulfillmentComponent global;
+using StructPointers for Execution global;
+using StructPointers for ZoneParameters global;
+
+library StructPointers {
+    function toPointer(
+        OrderComponents memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        OfferItem memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        ConsiderationItem memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        SpentItem memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        ReceivedItem memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        BasicOrderParameters memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        AdditionalRecipient memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        OrderParameters memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(Order memory obj) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        AdvancedOrder memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        OrderStatus memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        CriteriaResolver memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        Fulfillment memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        FulfillmentComponent memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        Execution memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
+
+    function toPointer(
+        ZoneParameters memory obj
+    ) internal pure returns (MemoryPointer ptr) {
+        assembly {
+            ptr := obj
+        }
+    }
 }

--- a/contracts/lib/OrderValidator.sol
+++ b/contracts/lib/OrderValidator.sol
@@ -382,6 +382,7 @@ contract OrderValidator is Executor, ZoneInteraction {
 
             // add new offer items if there are more than original
             for (uint256 i = originalOfferLength; i < newOfferLength; ++i) {
+              // @todo replace with optimized returndata decoder
               MemoryPointer originalOffer = orderParameters.offer[i].toPointer();
               MemoryPointer newOffer = offer[i].toPointer();
               newOffer.copy(originalOffer, 0x80);

--- a/contracts/lib/PointerLibraries.sol
+++ b/contracts/lib/PointerLibraries.sol
@@ -1,0 +1,2341 @@
+pragma solidity >=0.8.13;
+
+type CalldataPointer is uint256;
+type ReturndataPointer is uint256;
+type MemoryPointer is uint256;
+
+CalldataPointer constant CalldataStart = CalldataPointer.wrap(0x04);
+MemoryPointer constant FreeMemoryPPtr = MemoryPointer.wrap(0x40);
+ReturndataPointer constant NullReturnDataPtr = ReturndataPointer.wrap(0);
+
+uint256 constant PrecompileIdentity = 4;
+
+/// @dev Allocates `size` bytes in memory by increasing the free memory pointer
+///   and returns the memory pointer to the first byte of the allocated region.
+function malloc(uint256 size) pure returns (MemoryPointer mPtr) {
+    assembly {
+        mPtr := mload(0x40)
+        mstore(0x40, add(mPtr, size))
+    }
+}
+
+function getFreeMemoryPointer() pure returns (MemoryPointer mPtr) {
+    mPtr = MemoryPointer.wrap(MemoryPointerLib.read(FreeMemoryPPtr));
+}
+
+function setFreeMemoryPointer(MemoryPointer mPtr) pure {
+    MemoryPointerLib.write(FreeMemoryPPtr, mPtr);
+}
+
+library CalldataPointerLib {
+    function lt(
+        CalldataPointer a,
+        CalldataPointer b
+    ) internal pure returns (bool c) {
+        assembly {
+            c := lt(a, b)
+        }
+    }
+
+    function gt(
+        CalldataPointer a,
+        CalldataPointer b
+    ) internal pure returns (bool c) {
+        assembly {
+            c := gt(a, b)
+        }
+    }
+
+    function eq(
+        CalldataPointer a,
+        CalldataPointer b
+    ) internal pure returns (bool c) {
+        assembly {
+            c := eq(a, b)
+        }
+    }
+
+    /// @dev Resolves an offset stored at `cdPtr + headOffset` to a calldata pointer.
+    ///   `cdPtr` must point to some parent object with a dynamic type's head stored at
+    ///   `cdPtr + headOffset`.
+    function pptr(
+        CalldataPointer cdPtr,
+        uint256 headOffset
+    ) internal pure returns (CalldataPointer cdPtrChild) {
+        assembly {
+            cdPtrChild := add(cdPtr, calldataload(add(cdPtr, headOffset)))
+        }
+    }
+
+    /// @dev Resolves an offset stored at `cdPtr` to a calldata pointer.
+    ///   `cdPtr` must point to some parent object with a dynamic type as its first
+    ///   member, e.g. `struct { bytes data; }`
+    function pptr(
+        CalldataPointer cdPtr
+    ) internal pure returns (CalldataPointer cdPtrChild) {
+        assembly {
+            cdPtrChild := add(cdPtr, calldataload(cdPtr))
+        }
+    }
+
+    /// @dev Returns the calldata pointer one word after `cdPtr`.
+    function next(
+        CalldataPointer cdPtr
+    ) internal pure returns (CalldataPointer cdPtrNext) {
+        assembly {
+            cdPtrNext := add(cdPtr, 32)
+        }
+    }
+
+    /// @dev Returns the calldata pointer `_offset` bytes after `cdPtr`.
+    function offset(
+        CalldataPointer cdPtr,
+        uint256 _offset
+    ) internal pure returns (CalldataPointer cdPtrNext) {
+        assembly {
+            cdPtrNext := add(cdPtr, _offset)
+        }
+    }
+
+    /// @dev Copies `size` bytes from calldata starting at `src` to memory at `dst`.
+    function copy(
+        CalldataPointer src,
+        MemoryPointer dst,
+        uint256 size
+    ) internal pure {
+        assembly {
+            calldatacopy(dst, src, size)
+        }
+    }
+}
+
+library ReturndataPointerLib {
+    using ReturndataPointerLib for ReturndataPointer;
+    using ReturndataReaders for ReturndataPointer;
+
+    function lt(
+        ReturndataPointer a,
+        ReturndataPointer b
+    ) internal pure returns (bool c) {
+        assembly {
+            c := lt(a, b)
+        }
+    }
+
+    function gt(
+        ReturndataPointer a,
+        ReturndataPointer b
+    ) internal pure returns (bool c) {
+        assembly {
+            c := gt(a, b)
+        }
+    }
+
+    function eq(
+        ReturndataPointer a,
+        ReturndataPointer b
+    ) internal pure returns (bool c) {
+        assembly {
+            c := eq(a, b)
+        }
+    }
+
+    /// @dev Resolves an offset stored at `rdPtr + headOffset` to a returndata pointer.
+    ///   `rdPtr` must point to some parent object with a dynamic type's head stored at
+    ///   `rdPtr + headOffset`.
+    function pptr(
+        ReturndataPointer rdPtr,
+        uint256 headOffset
+    ) internal pure returns (ReturndataPointer rdPtrChild) {
+        rdPtrChild = rdPtr.offset(rdPtr.offset(headOffset).readUint256());
+    }
+
+    /// @dev Resolves an offset stored at `rdPtr` to a returndata pointer.
+    ///   `rdPtr` must point to some parent object with a dynamic type as its first
+    ///   member, e.g. `struct { bytes data; }`
+    function pptr(
+        ReturndataPointer rdPtr
+    ) internal pure returns (ReturndataPointer rdPtrChild) {
+        rdPtrChild = rdPtr.offset(rdPtr.readUint256());
+    }
+
+    /// @dev Returns the returndata pointer one word after `cdPtr`.
+    function next(
+        ReturndataPointer rdPtr
+    ) internal pure returns (ReturndataPointer rdPtrNext) {
+        assembly {
+            rdPtrNext := add(rdPtr, 32)
+        }
+    }
+
+    /// @dev Returns the returndata pointer `_offset` bytes after `cdPtr`.
+    function offset(
+        ReturndataPointer rdPtr,
+        uint256 _offset
+    ) internal pure returns (ReturndataPointer rdPtrNext) {
+        assembly {
+            rdPtrNext := add(rdPtr, _offset)
+        }
+    }
+
+    /// @dev Copies `size` bytes from returndata starting at `src` to memory at `dst`.
+    function copy(
+        ReturndataPointer src,
+        MemoryPointer dst,
+        uint256 size
+    ) internal pure {
+        assembly {
+            returndatacopy(dst, src, size)
+        }
+    }
+}
+
+library MemoryPointerLib {
+    function lt(
+        MemoryPointer a,
+        MemoryPointer b
+    ) internal pure returns (bool c) {
+        assembly {
+            c := lt(a, b)
+        }
+    }
+
+    function gt(
+        MemoryPointer a,
+        MemoryPointer b
+    ) internal pure returns (bool c) {
+        assembly {
+            c := gt(a, b)
+        }
+    }
+
+    function eq(
+        MemoryPointer a,
+        MemoryPointer b
+    ) internal pure returns (bool c) {
+        assembly {
+            c := eq(a, b)
+        }
+    }
+
+    function read(MemoryPointer mPtr) internal pure returns (uint256 value) {
+        assembly {
+            value := mload(mPtr)
+        }
+    }
+
+    /// @dev Writes `value` to memory at `mPtr`.
+    function write(MemoryPointer mPtr, uint256 value) internal pure {
+        assembly {
+            mstore(mPtr, value)
+        }
+    }
+
+    /// @dev Writes `valuePtr` to memory at `mPtr`.
+    function write(MemoryPointer mPtr, MemoryPointer valuePtr) internal pure {
+        assembly {
+            mstore(mPtr, valuePtr)
+        }
+    }
+
+    /// @dev Returns the memory pointer one word after `mPtr`.
+    function next(
+        MemoryPointer mPtr
+    ) internal pure returns (MemoryPointer mPtrNext) {
+        assembly {
+            mPtrNext := add(mPtr, 32)
+        }
+    }
+
+    /// @dev Returns the memory pointer `_offset` bytes after `mPtr`.
+    function offset(
+        MemoryPointer mPtr,
+        uint256 _offset
+    ) internal pure returns (MemoryPointer mPtrNext) {
+        assembly {
+            mPtrNext := add(mPtr, _offset)
+        }
+    }
+
+    function copy(
+        MemoryPointer src,
+        MemoryPointer dst,
+        uint256 size
+    ) internal view {
+        assembly {
+            let success := staticcall(
+                gas(),
+                PrecompileIdentity,
+                src,
+                size,
+                dst,
+                size
+            )
+            if or(iszero(success), iszero(returndatasize())) {
+                revert(0, 0)
+            }
+        }
+    }
+}
+
+library CalldataReaders {
+    /// @dev Reads the bool at `cdPtr` in calldata.
+    function readBool(
+        CalldataPointer cdPtr
+    ) internal pure returns (bool value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the address at `cdPtr` in calldata.
+    function readAddress(
+        CalldataPointer cdPtr
+    ) internal pure returns (address value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes1 at `cdPtr` in calldata.
+    function readBytes1(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes1 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes2 at `cdPtr` in calldata.
+    function readBytes2(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes2 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes3 at `cdPtr` in calldata.
+    function readBytes3(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes3 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes4 at `cdPtr` in calldata.
+    function readBytes4(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes4 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes5 at `cdPtr` in calldata.
+    function readBytes5(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes5 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes6 at `cdPtr` in calldata.
+    function readBytes6(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes6 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes7 at `cdPtr` in calldata.
+    function readBytes7(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes7 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes8 at `cdPtr` in calldata.
+    function readBytes8(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes8 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes9 at `cdPtr` in calldata.
+    function readBytes9(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes9 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes10 at `cdPtr` in calldata.
+    function readBytes10(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes10 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes11 at `cdPtr` in calldata.
+    function readBytes11(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes11 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes12 at `cdPtr` in calldata.
+    function readBytes12(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes12 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes13 at `cdPtr` in calldata.
+    function readBytes13(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes13 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes14 at `cdPtr` in calldata.
+    function readBytes14(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes14 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes15 at `cdPtr` in calldata.
+    function readBytes15(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes15 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes16 at `cdPtr` in calldata.
+    function readBytes16(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes16 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes17 at `cdPtr` in calldata.
+    function readBytes17(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes17 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes18 at `cdPtr` in calldata.
+    function readBytes18(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes18 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes19 at `cdPtr` in calldata.
+    function readBytes19(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes19 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes20 at `cdPtr` in calldata.
+    function readBytes20(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes20 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes21 at `cdPtr` in calldata.
+    function readBytes21(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes21 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes22 at `cdPtr` in calldata.
+    function readBytes22(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes22 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes23 at `cdPtr` in calldata.
+    function readBytes23(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes23 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes24 at `cdPtr` in calldata.
+    function readBytes24(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes24 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes25 at `cdPtr` in calldata.
+    function readBytes25(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes25 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes26 at `cdPtr` in calldata.
+    function readBytes26(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes26 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes27 at `cdPtr` in calldata.
+    function readBytes27(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes27 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes28 at `cdPtr` in calldata.
+    function readBytes28(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes28 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes29 at `cdPtr` in calldata.
+    function readBytes29(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes29 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes30 at `cdPtr` in calldata.
+    function readBytes30(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes30 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes31 at `cdPtr` in calldata.
+    function readBytes31(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes31 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the bytes32 at `cdPtr` in calldata.
+    function readBytes32(
+        CalldataPointer cdPtr
+    ) internal pure returns (bytes32 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint8 at `cdPtr` in calldata.
+    function readUint8(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint8 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint16 at `cdPtr` in calldata.
+    function readUint16(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint16 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint24 at `cdPtr` in calldata.
+    function readUint24(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint24 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint32 at `cdPtr` in calldata.
+    function readUint32(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint32 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint40 at `cdPtr` in calldata.
+    function readUint40(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint40 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint48 at `cdPtr` in calldata.
+    function readUint48(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint48 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint56 at `cdPtr` in calldata.
+    function readUint56(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint56 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint64 at `cdPtr` in calldata.
+    function readUint64(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint64 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint72 at `cdPtr` in calldata.
+    function readUint72(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint72 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint80 at `cdPtr` in calldata.
+    function readUint80(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint80 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint88 at `cdPtr` in calldata.
+    function readUint88(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint88 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint96 at `cdPtr` in calldata.
+    function readUint96(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint96 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint104 at `cdPtr` in calldata.
+    function readUint104(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint104 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint112 at `cdPtr` in calldata.
+    function readUint112(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint112 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint120 at `cdPtr` in calldata.
+    function readUint120(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint120 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint128 at `cdPtr` in calldata.
+    function readUint128(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint128 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint136 at `cdPtr` in calldata.
+    function readUint136(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint136 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint144 at `cdPtr` in calldata.
+    function readUint144(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint144 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint152 at `cdPtr` in calldata.
+    function readUint152(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint152 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint160 at `cdPtr` in calldata.
+    function readUint160(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint160 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint168 at `cdPtr` in calldata.
+    function readUint168(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint168 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint176 at `cdPtr` in calldata.
+    function readUint176(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint176 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint184 at `cdPtr` in calldata.
+    function readUint184(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint184 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint192 at `cdPtr` in calldata.
+    function readUint192(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint192 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint200 at `cdPtr` in calldata.
+    function readUint200(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint200 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint208 at `cdPtr` in calldata.
+    function readUint208(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint208 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint216 at `cdPtr` in calldata.
+    function readUint216(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint216 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint224 at `cdPtr` in calldata.
+    function readUint224(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint224 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint232 at `cdPtr` in calldata.
+    function readUint232(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint232 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint240 at `cdPtr` in calldata.
+    function readUint240(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint240 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint248 at `cdPtr` in calldata.
+    function readUint248(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint248 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the uint256 at `cdPtr` in calldata.
+    function readUint256(
+        CalldataPointer cdPtr
+    ) internal pure returns (uint256 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int8 at `cdPtr` in calldata.
+    function readInt8(
+        CalldataPointer cdPtr
+    ) internal pure returns (int8 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int16 at `cdPtr` in calldata.
+    function readInt16(
+        CalldataPointer cdPtr
+    ) internal pure returns (int16 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int24 at `cdPtr` in calldata.
+    function readInt24(
+        CalldataPointer cdPtr
+    ) internal pure returns (int24 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int32 at `cdPtr` in calldata.
+    function readInt32(
+        CalldataPointer cdPtr
+    ) internal pure returns (int32 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int40 at `cdPtr` in calldata.
+    function readInt40(
+        CalldataPointer cdPtr
+    ) internal pure returns (int40 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int48 at `cdPtr` in calldata.
+    function readInt48(
+        CalldataPointer cdPtr
+    ) internal pure returns (int48 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int56 at `cdPtr` in calldata.
+    function readInt56(
+        CalldataPointer cdPtr
+    ) internal pure returns (int56 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int64 at `cdPtr` in calldata.
+    function readInt64(
+        CalldataPointer cdPtr
+    ) internal pure returns (int64 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int72 at `cdPtr` in calldata.
+    function readInt72(
+        CalldataPointer cdPtr
+    ) internal pure returns (int72 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int80 at `cdPtr` in calldata.
+    function readInt80(
+        CalldataPointer cdPtr
+    ) internal pure returns (int80 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int88 at `cdPtr` in calldata.
+    function readInt88(
+        CalldataPointer cdPtr
+    ) internal pure returns (int88 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int96 at `cdPtr` in calldata.
+    function readInt96(
+        CalldataPointer cdPtr
+    ) internal pure returns (int96 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int104 at `cdPtr` in calldata.
+    function readInt104(
+        CalldataPointer cdPtr
+    ) internal pure returns (int104 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int112 at `cdPtr` in calldata.
+    function readInt112(
+        CalldataPointer cdPtr
+    ) internal pure returns (int112 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int120 at `cdPtr` in calldata.
+    function readInt120(
+        CalldataPointer cdPtr
+    ) internal pure returns (int120 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int128 at `cdPtr` in calldata.
+    function readInt128(
+        CalldataPointer cdPtr
+    ) internal pure returns (int128 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int136 at `cdPtr` in calldata.
+    function readInt136(
+        CalldataPointer cdPtr
+    ) internal pure returns (int136 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int144 at `cdPtr` in calldata.
+    function readInt144(
+        CalldataPointer cdPtr
+    ) internal pure returns (int144 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int152 at `cdPtr` in calldata.
+    function readInt152(
+        CalldataPointer cdPtr
+    ) internal pure returns (int152 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int160 at `cdPtr` in calldata.
+    function readInt160(
+        CalldataPointer cdPtr
+    ) internal pure returns (int160 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int168 at `cdPtr` in calldata.
+    function readInt168(
+        CalldataPointer cdPtr
+    ) internal pure returns (int168 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int176 at `cdPtr` in calldata.
+    function readInt176(
+        CalldataPointer cdPtr
+    ) internal pure returns (int176 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int184 at `cdPtr` in calldata.
+    function readInt184(
+        CalldataPointer cdPtr
+    ) internal pure returns (int184 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int192 at `cdPtr` in calldata.
+    function readInt192(
+        CalldataPointer cdPtr
+    ) internal pure returns (int192 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int200 at `cdPtr` in calldata.
+    function readInt200(
+        CalldataPointer cdPtr
+    ) internal pure returns (int200 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int208 at `cdPtr` in calldata.
+    function readInt208(
+        CalldataPointer cdPtr
+    ) internal pure returns (int208 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int216 at `cdPtr` in calldata.
+    function readInt216(
+        CalldataPointer cdPtr
+    ) internal pure returns (int216 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int224 at `cdPtr` in calldata.
+    function readInt224(
+        CalldataPointer cdPtr
+    ) internal pure returns (int224 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int232 at `cdPtr` in calldata.
+    function readInt232(
+        CalldataPointer cdPtr
+    ) internal pure returns (int232 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int240 at `cdPtr` in calldata.
+    function readInt240(
+        CalldataPointer cdPtr
+    ) internal pure returns (int240 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int248 at `cdPtr` in calldata.
+    function readInt248(
+        CalldataPointer cdPtr
+    ) internal pure returns (int248 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+
+    /// @dev Reads the int256 at `cdPtr` in calldata.
+    function readInt256(
+        CalldataPointer cdPtr
+    ) internal pure returns (int256 value) {
+        assembly {
+            value := calldataload(cdPtr)
+        }
+    }
+}
+
+library ReturndataReaders {
+    /**
+     * @dev Reads the bool at `rdPtr` in returndata.
+     */
+    function readBool(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bool value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the address at `rdPtr` in returndata.
+     */
+    function readAddress(
+        ReturndataPointer rdPtr
+    ) internal pure returns (address value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes1 at `rdPtr` in returndata.
+     */
+    function readBytes1(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes1 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes2 at `rdPtr` in returndata.
+     */
+    function readBytes2(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes2 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes3 at `rdPtr` in returndata.
+     */
+    function readBytes3(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes3 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes4 at `rdPtr` in returndata.
+     */
+    function readBytes4(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes4 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes5 at `rdPtr` in returndata.
+     */
+    function readBytes5(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes5 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes6 at `rdPtr` in returndata.
+     */
+    function readBytes6(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes6 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes7 at `rdPtr` in returndata.
+     */
+    function readBytes7(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes7 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes8 at `rdPtr` in returndata.
+     */
+    function readBytes8(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes8 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes9 at `rdPtr` in returndata.
+     */
+    function readBytes9(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes9 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes10 at `rdPtr` in returndata.
+     */
+    function readBytes10(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes10 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes11 at `rdPtr` in returndata.
+     */
+    function readBytes11(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes11 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes12 at `rdPtr` in returndata.
+     */
+    function readBytes12(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes12 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes13 at `rdPtr` in returndata.
+     */
+    function readBytes13(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes13 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes14 at `rdPtr` in returndata.
+     */
+    function readBytes14(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes14 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes15 at `rdPtr` in returndata.
+     */
+    function readBytes15(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes15 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes16 at `rdPtr` in returndata.
+     */
+    function readBytes16(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes16 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes17 at `rdPtr` in returndata.
+     */
+    function readBytes17(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes17 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes18 at `rdPtr` in returndata.
+     */
+    function readBytes18(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes18 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes19 at `rdPtr` in returndata.
+     */
+    function readBytes19(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes19 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes20 at `rdPtr` in returndata.
+     */
+    function readBytes20(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes20 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes21 at `rdPtr` in returndata.
+     */
+    function readBytes21(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes21 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes22 at `rdPtr` in returndata.
+     */
+    function readBytes22(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes22 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes23 at `rdPtr` in returndata.
+     */
+    function readBytes23(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes23 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes24 at `rdPtr` in returndata.
+     */
+    function readBytes24(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes24 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes25 at `rdPtr` in returndata.
+     */
+    function readBytes25(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes25 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes26 at `rdPtr` in returndata.
+     */
+    function readBytes26(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes26 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes27 at `rdPtr` in returndata.
+     */
+    function readBytes27(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes27 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes28 at `rdPtr` in returndata.
+     */
+    function readBytes28(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes28 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes29 at `rdPtr` in returndata.
+     */
+    function readBytes29(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes29 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes30 at `rdPtr` in returndata.
+     */
+    function readBytes30(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes30 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes31 at `rdPtr` in returndata.
+     */
+    function readBytes31(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes31 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the bytes32 at `rdPtr` in returndata.
+     */
+    function readBytes32(
+        ReturndataPointer rdPtr
+    ) internal pure returns (bytes32 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint8 at `rdPtr` in returndata.
+     */
+    function readUint8(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint8 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint16 at `rdPtr` in returndata.
+     */
+    function readUint16(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint16 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint24 at `rdPtr` in returndata.
+     */
+    function readUint24(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint24 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint32 at `rdPtr` in returndata.
+     */
+    function readUint32(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint32 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint40 at `rdPtr` in returndata.
+     */
+    function readUint40(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint40 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint48 at `rdPtr` in returndata.
+     */
+    function readUint48(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint48 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint56 at `rdPtr` in returndata.
+     */
+    function readUint56(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint56 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint64 at `rdPtr` in returndata.
+     */
+    function readUint64(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint64 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint72 at `rdPtr` in returndata.
+     */
+    function readUint72(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint72 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint80 at `rdPtr` in returndata.
+     */
+    function readUint80(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint80 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint88 at `rdPtr` in returndata.
+     */
+    function readUint88(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint88 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint96 at `rdPtr` in returndata.
+     */
+    function readUint96(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint96 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint104 at `rdPtr` in returndata.
+     */
+    function readUint104(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint104 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint112 at `rdPtr` in returndata.
+     */
+    function readUint112(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint112 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint120 at `rdPtr` in returndata.
+     */
+    function readUint120(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint120 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint128 at `rdPtr` in returndata.
+     */
+    function readUint128(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint128 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint136 at `rdPtr` in returndata.
+     */
+    function readUint136(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint136 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint144 at `rdPtr` in returndata.
+     */
+    function readUint144(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint144 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint152 at `rdPtr` in returndata.
+     */
+    function readUint152(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint152 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint160 at `rdPtr` in returndata.
+     */
+    function readUint160(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint160 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint168 at `rdPtr` in returndata.
+     */
+    function readUint168(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint168 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint176 at `rdPtr` in returndata.
+     */
+    function readUint176(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint176 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint184 at `rdPtr` in returndata.
+     */
+    function readUint184(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint184 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint192 at `rdPtr` in returndata.
+     */
+    function readUint192(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint192 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint200 at `rdPtr` in returndata.
+     */
+    function readUint200(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint200 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint208 at `rdPtr` in returndata.
+     */
+    function readUint208(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint208 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint216 at `rdPtr` in returndata.
+     */
+    function readUint216(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint216 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint224 at `rdPtr` in returndata.
+     */
+    function readUint224(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint224 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint232 at `rdPtr` in returndata.
+     */
+    function readUint232(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint232 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint240 at `rdPtr` in returndata.
+     */
+    function readUint240(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint240 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint248 at `rdPtr` in returndata.
+     */
+    function readUint248(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint248 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the uint256 at `rdPtr` in returndata.
+     */
+    function readUint256(
+        ReturndataPointer rdPtr
+    ) internal pure returns (uint256 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int8 at `rdPtr` in returndata.
+     */
+    function readInt8(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int8 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int16 at `rdPtr` in returndata.
+     */
+    function readInt16(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int16 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int24 at `rdPtr` in returndata.
+     */
+    function readInt24(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int24 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int32 at `rdPtr` in returndata.
+     */
+    function readInt32(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int32 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int40 at `rdPtr` in returndata.
+     */
+    function readInt40(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int40 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int48 at `rdPtr` in returndata.
+     */
+    function readInt48(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int48 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int56 at `rdPtr` in returndata.
+     */
+    function readInt56(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int56 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int64 at `rdPtr` in returndata.
+     */
+    function readInt64(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int64 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int72 at `rdPtr` in returndata.
+     */
+    function readInt72(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int72 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int80 at `rdPtr` in returndata.
+     */
+    function readInt80(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int80 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int88 at `rdPtr` in returndata.
+     */
+    function readInt88(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int88 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int96 at `rdPtr` in returndata.
+     */
+    function readInt96(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int96 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int104 at `rdPtr` in returndata.
+     */
+    function readInt104(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int104 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int112 at `rdPtr` in returndata.
+     */
+    function readInt112(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int112 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int120 at `rdPtr` in returndata.
+     */
+    function readInt120(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int120 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int128 at `rdPtr` in returndata.
+     */
+    function readInt128(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int128 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int136 at `rdPtr` in returndata.
+     */
+    function readInt136(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int136 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int144 at `rdPtr` in returndata.
+     */
+    function readInt144(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int144 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int152 at `rdPtr` in returndata.
+     */
+    function readInt152(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int152 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int160 at `rdPtr` in returndata.
+     */
+    function readInt160(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int160 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int168 at `rdPtr` in returndata.
+     */
+    function readInt168(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int168 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int176 at `rdPtr` in returndata.
+     */
+    function readInt176(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int176 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int184 at `rdPtr` in returndata.
+     */
+    function readInt184(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int184 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int192 at `rdPtr` in returndata.
+     */
+    function readInt192(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int192 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int200 at `rdPtr` in returndata.
+     */
+    function readInt200(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int200 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int208 at `rdPtr` in returndata.
+     */
+    function readInt208(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int208 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int216 at `rdPtr` in returndata.
+     */
+    function readInt216(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int216 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int224 at `rdPtr` in returndata.
+     */
+    function readInt224(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int224 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int232 at `rdPtr` in returndata.
+     */
+    function readInt232(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int232 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int240 at `rdPtr` in returndata.
+     */
+    function readInt240(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int240 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int248 at `rdPtr` in returndata.
+     */
+    function readInt248(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int248 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+
+    /**
+     * @dev Reads the int256 at `rdPtr` in returndata.
+     */
+    function readInt256(
+        ReturndataPointer rdPtr
+    ) internal pure returns (int256 value) {
+        assembly {
+            returndatacopy(0, rdPtr, 0x20)
+            value := mload(0)
+        }
+    }
+}


### PR DESCRIPTION
Use pointer libraries from abi-lity to optimize memory copies in any place where >3 sequential values are copied in memory.