### PR TITLE
Consideration length check

### DIFF
--- a/contracts/interfaces/ConsiderationEventsAndErrors.sol
+++ b/contracts/interfaces/ConsiderationEventsAndErrors.sol
@@ -95,6 +95,12 @@ interface ConsiderationEventsAndErrors {
     error MissingOriginalConsiderationItems();
 
     /**
+     * @dev Revert with an error when an order is validated with a
+     *      consideration array that is larger than the original items.
+     */
+    error ExtraOriginalConsiderationItems();
+
+    /**
      * @dev Revert with an error when a call to a conduit fails with revert data
      *      that is too expensive to return.
      */

--- a/contracts/lib/OrderValidator.sol
+++ b/contracts/lib/OrderValidator.sol
@@ -635,6 +635,12 @@ contract OrderValidator is Executor, ZoneInteraction {
 
                 // If the order has not already been validated...
                 if (!orderStatus.isValidated) {
+
+                    // Validate total original consideration items and consideration length
+                    if (orderParameters.consideration.length != orderParameters.totalOriginalConsiderationItems) {
+                        revert ExtraOriginalConsiderationItems();
+                    }
+
                     // Verify the supplied signature.
                     _verifySignature(offerer, orderHash, order.signature);
 

--- a/reference/lib/ReferenceOrderValidator.sol
+++ b/reference/lib/ReferenceOrderValidator.sol
@@ -582,6 +582,12 @@ contract ReferenceOrderValidator is
 
             // If the order has not already been validated...
             if (!orderStatus.isValidated) {
+
+                // Validate total original consideration items and consideration length
+                if (orderParameters.consideration.length != orderParameters.totalOriginalConsiderationItems) {
+                    revert MissingOriginalConsiderationItems();
+                }
+
                 // Verify the supplied signature.
                 _verifySignature(offerer, orderHash, order.signature);
 

--- a/test/counter.spec.ts
+++ b/test/counter.spec.ts
@@ -520,7 +520,7 @@ describe(`Validate, cancel, and increment counter flows (Seaport v${VERSION})`, 
         getItemETH(parseEther("1"), parseEther("1"), owner.address),
       ];
 
-      const { order, orderHash, value } = await createOrder(
+      const { order } = await createOrder(
         seller,
         zone,
         offer,
@@ -528,13 +528,11 @@ describe(`Validate, cancel, and increment counter flows (Seaport v${VERSION})`, 
         0 // FULL_OPEN
       );
 
-      order.signature = "0x";
-
-      order.parameters.totalOriginalConsiderationItems = 4;
+      order.parameters.totalOriginalConsiderationItems = 2;
 
       // cannot validate when consideration array length is different than total original consideration
         await expect(marketplaceContract.connect(seller).validate([order])).to.be
-          .revertedWith('MissingOriginalConsiderationItems');
+          .revertedWith('ExtraOriginalConsiderationItems');
     });
   });
 


### PR DESCRIPTION
Added a check for extra original consideration items during order validation.

Added a new custom `error ExtraOriginalConsiderationItems()`

Added one additional test to `Validate, cancel, and increment counter flows (Seaport v1.1)` `Reverts if consideration array length doesn't match`
