### PR TITLE
Complete branch coverage for `ReferenceBasicOrderFulfiller`

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "scripts": {
     "build": "hardhat compile --config ./hardhat.config.ts",
     "build:ref": "hardhat compile --config ./hardhat-reference.config.ts",
+    "clean": "hardhat clean; forge clean; rm -rf coverage; rm coverage.json; rm -rf hh-cache; rm -rf hh-cache-ref",
     "test": "hardhat test --config ./hardhat.config.ts",
     "test:ref": "REFERENCE=true hardhat test --config ./hardhat-reference.config.ts",
     "profile": "REPORT_GAS=true hardhat test --config ./hardhat.config.ts",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "scripts": {
     "build": "hardhat compile --config ./hardhat.config.ts",
     "build:ref": "hardhat compile --config ./hardhat-reference.config.ts",
-    "clean": "hardhat clean; forge clean; rm -rf coverage; rm coverage.json; rm -rf hh-cache; rm -rf hh-cache-ref",
+    "clean": "hardhat clean; hardhat clean --config ./hardhat-reference.config.ts; forge clean; rm -rf {coverage,coverage.json}",
     "test": "hardhat test --config ./hardhat.config.ts",
     "test:ref": "REFERENCE=true hardhat test --config ./hardhat-reference.config.ts",
     "profile": "REPORT_GAS=true hardhat test --config ./hardhat.config.ts",


### PR DESCRIPTION
This PR:

- Completes branch coverage for file `ReferenceBasicOrderFulfiller` by adding branch coverage for error `UnusedItemParameters()` in routes EthForERC721 and ERC721ForERC20
- Adds `yarn clean` cmd