### PR TITLE
Add branch coverage for deriveDomainSeparator

### DIFF
--- a/test/revert.spec.ts
+++ b/test/revert.spec.ts
@@ -6380,11 +6380,11 @@ describe(`Reverts (Seaport v${VERSION})`, function () {
             }
           }
         };
+        const hreProvider = hre.network.provider as any;
         recurse(
-          (hre.network.provider as any)._wrapped._wrapped._wrapped?._node
-            ?._vm ??
-            (hre.network.provider as any)._wrapped._wrapped._wrapped._wrapped
-              ._node._vm
+          hreProvider._wrapped._wrapped._wrapped?._node?._vm ??
+            // When running coverage, there was an additional layer of wrapping
+            hreProvider._wrapped._wrapped._wrapped._wrapped._node._vm
         );
       };
       changeChainId();

--- a/test/revert.spec.ts
+++ b/test/revert.spec.ts
@@ -6325,4 +6325,78 @@ describe(`Reverts (Seaport v${VERSION})`, function () {
         });
     });
   });
+
+  describe(`Changing chainId`, function () {
+    // Note: Run this test last in this file as it hacks changing the hre
+    it("Reverts on changed chainId", async () => {
+      const nftId = await mintAndApprove721(
+        seller,
+        marketplaceContract.address
+      );
+
+      // Buyer mints ERC20
+      const tokenAmount = minRandom(100);
+      await mintAndApproveERC20(
+        buyer,
+        marketplaceContract.address,
+        tokenAmount
+      );
+
+      const offer = [getTestItem721(nftId)];
+
+      const consideration = [
+        getTestItem20(
+          tokenAmount.sub(100),
+          tokenAmount.sub(100),
+          seller.address
+        ),
+        getTestItem20(50, 50, zone.address),
+        getTestItem20(50, 50, owner.address),
+      ];
+
+      const { order } = await createOrder(
+        seller,
+        zone,
+        offer,
+        consideration,
+        0 // FULL_OPEN
+      );
+
+      const basicOrderParameters = getBasicOrderParameters(
+        2, // ERC20ForERC721
+        order
+      );
+
+      // Change chainId in-flight to test branch coverage for _deriveDomainSeparator()
+      // (hacky way, until https://github.com/NomicFoundation/hardhat/issues/3074 is added)
+      const changeChainId = () => {
+        const recurse = (obj: any) => {
+          for (const [key, value] of Object.entries(obj ?? {})) {
+            if (key === "transactions") continue;
+            if (key === "chainId") {
+              obj[key] = typeof value === "bigint" ? BigInt(1) : 1;
+            } else if (typeof value === "object") {
+              recurse(obj[key]);
+            }
+          }
+        };
+        recurse(
+          (hre.network.provider as any)._wrapped._wrapped._wrapped?._node
+            ?._vm ??
+            (hre.network.provider as any)._wrapped._wrapped._wrapped._wrapped
+              ._node._vm
+        );
+      };
+      changeChainId();
+
+      const expectedRevertReason = getCustomRevertSelector("InvalidSigner()");
+
+      const tx = await marketplaceContract
+        .connect(buyer)
+        .populateTransaction.fulfillBasicOrder(basicOrderParameters);
+      tx.chainId = 1;
+      const returnData = await provider.call(tx);
+      expect(returnData).to.equal(expectedRevertReason);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a test for changing chainId in-flight to add branch coverage for _deriveDomainSeparator