### PR TITLE
Hardhat tests for bad contract offerer

### DIFF
--- a/config/.solcover-reference.js
+++ b/config/.solcover-reference.js
@@ -32,6 +32,7 @@ module.exports = {
     "test/TestContractOfferer.sol",
     "test/TestInvalidContractOfferer.sol",
     "test/TestInvalidContractOffererRatifyOrder.sol",
+    "test/TestBadContractOfferer.sol",
     "test/TestZone.sol",
     "test/TestPostExecution.sol",
     "test/TestERC20Panic.sol",

--- a/config/.solcover.js
+++ b/config/.solcover.js
@@ -26,6 +26,7 @@ module.exports = {
     "test/TestContractOfferer.sol",
     "test/TestInvalidContractOfferer.sol",
     "test/TestInvalidContractOffererRatifyOrder.sol",
+    "test/TestBadContractOfferer.sol",
     "test/TestPostExecution.sol",
     "test/TestZone.sol",
     "test/TestERC20Panic.sol",

--- a/contracts/test/TestBadContractOfferer.sol
+++ b/contracts/test/TestBadContractOfferer.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {
+    ERC721Interface,
+    ERC1155Interface
+} from "../interfaces/AbridgedTokenInterfaces.sol";
+
+import {
+    ContractOffererInterface
+} from "../interfaces/ContractOffererInterface.sol";
+
+import { ItemType, Side } from "../lib/ConsiderationEnums.sol";
+
+import { SpentItem, ReceivedItem } from "../lib/ConsiderationStructs.sol";
+
+contract TestBadContractOfferer is ContractOffererInterface {
+    error IntentionalRevert();
+
+    ERC721Interface token;
+
+    constructor(ERC721Interface _token) {
+        token = _token;
+    }
+
+    /**
+     * @dev Generates an order with the specified minimum and maximum spent items,
+     * and the optional extra data.
+     *
+     * @param a               Fulfiller, unused here.
+     * @param b               The minimum items that the caller is willing to
+     *                        receive.
+     * @param c               maximumSent, unused here.
+     * @param d               context, unused here.
+     *
+     * @return offer         A tuple containing the offer items.
+     * @return consideration A tuple containing the consideration items.
+     */
+    function generateOrder(
+        address a,
+        SpentItem[] calldata b,
+        SpentItem[] calldata c,
+        bytes calldata d
+    )
+        external
+        virtual
+        override
+        returns (SpentItem[] memory offer, ReceivedItem[] memory consideration)
+    {
+        return previewOrder(a, a, b, c, d);
+    }
+
+    /**
+     * @dev Generates an order in response to a minimum received set of items.
+     *
+     * @param -               caller, unused here.
+     * @param -               fulfiller, unused here.
+     * @param minimumReceived The minimum received set.
+     * @param -               maximumSpent, unused here.
+     * @param -               context, unused here.
+     *
+     * @return offer         The offer for the order.
+     * @return consideration The consideration for the order.
+     */
+    function previewOrder(
+        address,
+        address,
+        SpentItem[] calldata minimumReceived,
+        SpentItem[] calldata maximumSpent,
+        bytes calldata
+    )
+        public
+        view
+        override
+        returns (SpentItem[] memory offer, ReceivedItem[] memory consideration)
+    {
+        if (maximumSpent[0].identifier == 1) {
+            offer = minimumReceived;
+            consideration = new ReceivedItem[](1);
+            consideration[0] = ReceivedItem({
+                itemType: ItemType.ERC721,
+                token: address(token),
+                identifier: 1,
+                amount: 1,
+                recipient: payable(address(this))
+            });
+            return (offer, consideration);
+        } else if (maximumSpent[0].identifier == 2) {
+            // return nothing
+            assembly {
+                return(0, 0)
+            }
+        } else if (maximumSpent[0].identifier == 3) {
+            revert IntentionalRevert();
+        } else {
+            // return garbage
+            bytes32 h1 = keccak256(abi.encode(minimumReceived));
+            bytes32 h2 = keccak256(abi.encode(maximumSpent));
+            assembly {
+                mstore(0x00, h1)
+                mstore(0x20, h2)
+                return(0, 0x100)
+            }
+        }
+    }
+
+    function ratifyOrder(
+        SpentItem[] calldata /* offer */,
+        ReceivedItem[] calldata /* consideration */,
+        bytes calldata /* context */,
+        bytes32[] calldata /* orderHashes */,
+        uint256 /* contractNonce */
+    ) external pure override returns (bytes4 /* ratifyOrderMagicValue */) {
+        return TestBadContractOfferer.ratifyOrder.selector;
+    }
+
+    /** @dev Returns the metadata for this contract offerer.
+     */
+    function getMetadata()
+        external
+        pure
+        override
+        returns (
+            uint256 schemaID, // maps to a Seaport standard's ID
+            string memory name,
+            bytes memory metadata // decoded based on the schemaID
+        )
+    {
+        return (1337, "TestBadContractOfferer", "");
+    }
+}

--- a/contracts/test/TestBadContractOfferer.sol
+++ b/contracts/test/TestBadContractOfferer.sol
@@ -17,11 +17,16 @@ import { SpentItem, ReceivedItem } from "../lib/ConsiderationStructs.sol";
 contract TestBadContractOfferer is ContractOffererInterface {
     error IntentionalRevert();
 
+    address private immutable seaport;
     ERC721Interface token;
 
-    constructor(ERC721Interface _token) {
+    constructor(address _seaport, ERC721Interface _token) {
+        seaport = _seaport;
         token = _token;
+        ERC721Interface(token).setApprovalForAll(seaport, true);
     }
+
+    receive() external payable {}
 
     /**
      * @dev Generates an order with the specified minimum and maximum spent items,
@@ -74,23 +79,23 @@ contract TestBadContractOfferer is ContractOffererInterface {
         override
         returns (SpentItem[] memory offer, ReceivedItem[] memory consideration)
     {
-        if (maximumSpent[0].identifier == 1) {
+        if (minimumReceived[0].identifier == 1) {
             offer = minimumReceived;
             consideration = new ReceivedItem[](1);
             consideration[0] = ReceivedItem({
-                itemType: ItemType.ERC721,
-                token: address(token),
-                identifier: 1,
-                amount: 1,
+                itemType: ItemType.NATIVE,
+                token: address(0),
+                identifier: 0,
+                amount: 100,
                 recipient: payable(address(this))
             });
             return (offer, consideration);
-        } else if (maximumSpent[0].identifier == 2) {
+        } else if (minimumReceived[0].identifier == 2) {
             // return nothing
             assembly {
                 return(0, 0)
             }
-        } else if (maximumSpent[0].identifier == 3) {
+        } else if (minimumReceived[0].identifier == 3) {
             revert IntentionalRevert();
         } else {
             // return garbage

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "build": "yarn clean; hardhat compile --config ./hardhat.config.ts; yarn show:headroom;",
     "build:ref": "hardhat compile --config ./hardhat-reference.config.ts",
     "build:nospec": "yarn clean; NO_SPECIALIZER=true hardhat compile --config ./hardhat.config.ts; yarn show:headroom;",
-    "clean": "hardhat clean; hardhat clean --config ./hardhat-reference.config.ts; forge clean; rm -rf {coverage,coverage.json}; rm -rf hh-cache hh-cache-ref;",
+    "clean": "hardhat clean; hardhat clean --config ./hardhat-reference.config.ts; forge clean; rm -rf coverage coverage.json hh-cache hh-cache-ref",
     "test": "yarn clean; hardhat test --config ./hardhat.config.ts",
     "test:nospec": "NO_SPECIALIZER=true hardhat test --config ./hardhat.config.ts",
     "test:ref": "REFERENCE=true hardhat test --config ./hardhat-reference.config.ts",

--- a/reference/shim/Shim.sol
+++ b/reference/shim/Shim.sol
@@ -17,6 +17,9 @@ import {
     TestContractOfferer
 } from "../../contracts/test/TestContractOfferer.sol";
 import {
+    TestBadContractOfferer
+} from "../../contracts/test/TestBadContractOfferer.sol";
+import {
     TestInvalidContractOfferer
 } from "../../contracts/test/TestInvalidContractOfferer.sol";
 import {


### PR DESCRIPTION
Adds the tests:
 1. Fulfillment reverts if contract offerer is an EOA
 1. Fulfillment does not revert when valid
    1. fixed! ~~Having trouble using `TestBadContractOfferer` here with id=1 which should ideally pass, it passes when swapped out for `TestContractOfferer`. Unsure if the contract has an issue or if it was my setup. I made a todo note.~~
 1. Fulfillment reverts if contract offerer returns no data
 1. Fulfillment reverts if contract offerer reverts
 1. Fulfillment reverts if contract offerer returns with garbage data
 1. Fulfillment does not revert when valid order included with invalid contract offerer order
    1. this is working now with fixes from `1.2-validateorder-tests` ~~Was having trouble with `fulfillAvailableAdvancedOrders` to ignore the bad contract offerer order and just process the second valid order. Unsure if this is my setup or the expected behavior. Swapping `TestBadContractOfferer` for `TestContractOfferer` as a test made it pass fine (meaning both orders were successfully executed), but the tx runs out of gas when using an invalid order via `TestBadContractOfferer` along with a second valid order.~~ 
 
Thanks @jameswenzel for the `BadContractOfferer` contract.