### PR TITLE
Send forge coverage to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Seaport Test CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, 1.*, 2.*]
+    tags: ["*"]
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,8 +167,13 @@ jobs:
       - name: Install forge dependencies
         run: forge install
 
-      - name: Run coverage summary
-        run: SEAPORT_COVERAGE=true forge coverage
+      - name: Run coverage with lcov output
+        run: SEAPORT_COVERAGE=true forge coverage --report lcov
+
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./lcov.info
+          flags: foundry
 
   coverage:
     name: Run Coverage Tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,7 +12,6 @@ coverage:
 
 flag_management:
   default_rules: # the rules that will be followed for any flag added, generally
-    carryforward: true
     statuses:
       - type: project
         target: 100%
@@ -22,10 +21,6 @@ flag_management:
         threshold: 0%
   individual_flags: # exceptions to the default rules above, stated flag by flag
     - name: foundry
-      paths:
-        - contracts
-        - reference
-      carryforward: true
       statuses:
         - type: project
           target: 100%
@@ -34,7 +29,9 @@ flag_management:
           target: 100%
           threshold: 0%
 
+# Ignore folders that forge coverage is reporting on
 ignore:
   - offerers
   - script
   - test
+  - contracts/test

--- a/codecov.yml
+++ b/codecov.yml
@@ -33,3 +33,8 @@ flag_management:
         - type: patch
           target: 100%
           threshold: 0%
+
+ignore:
+  - offerers
+  - script
+  - test

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,27 @@ coverage:
         threshold: 0%
         base: auto
         if_ci_failed: error
+
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    carryforward: true
+    statuses:
+      - type: project
+        target: 100%
+        threshold: 0%
+      - type: patch
+        target: 100%
+        threshold: 0%
+  individual_flags: # exceptions to the default rules above, stated flag by flag
+    - name: foundry
+      paths:
+        - contracts
+        - reference
+      carryforward: true
+      statuses:
+        - type: project
+          target: 100%
+          threshold: 0%
+        - type: patch
+          target: 100%
+          threshold: 0%


### PR DESCRIPTION
Sends forge coverage lcov to codecov under the flag `foundry`

https://app.codecov.io/github/ProjectOpenSea/seaport/flags