### PR TITLE
conform reference signature verification to optimized implementation

### DIFF
--- a/reference/lib/ReferenceSignatureVerification.sol
+++ b/reference/lib/ReferenceSignatureVerification.sol
@@ -107,7 +107,7 @@ contract ReferenceSignatureVerification is SignatureVerificationErrors {
             EIP1271Interface(signer).isValidSignature(digest, signature) !=
             EIP1271Interface.isValidSignature.selector
         ) {
-            revert InvalidSigner();
+            revert BadContractSignature();
         }
     }
 }

--- a/test/foundry/SignatureVerification.t.sol
+++ b/test/foundry/SignatureVerification.t.sol
@@ -501,9 +501,6 @@ contract SignatureVerificationTest is BaseOrderTest {
                 address(conduitController),
                 consideration
             );
-        // Inconsistency between the reference and the implementation.
-        // vm.expectRevert(abi.encodeWithSignature("InvalidSigner()"));
-        // Might be better to have reference do `BadContractSignature()`, too.
         vm.expectRevert(abi.encodeWithSignature("BadContractSignature()"));
         logicWith1271Override.signatureVerification1271Invalid();
 
@@ -527,7 +524,7 @@ contract SignatureVerificationTest is BaseOrderTest {
                 address(referenceConduitController),
                 referenceConsideration
             );
-        vm.expectRevert(abi.encodeWithSignature("InvalidSigner()"));
+        vm.expectRevert(abi.encodeWithSignature("BadContractSignature()"));
         referenceLogicWith1271Override.referenceSignatureVerification1271Invalid();
     }
 }


### PR DESCRIPTION
## Motivation

In the case where we we don't get back the magic 1271 value for a 1271 signature, we were giving a `BadContractSignature` revert in the optimized implementation and an `InvalidSigner` revert in the reference implementation.

## Solution

This PR changes the behavior of the reference implementation to be consistent with the optimized implementation and updates the tests accordingly.
