### PR TITLE
fix abi encoding/decoding of bytes

### DIFF
--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -110,7 +110,7 @@ uint256 constant FourWords = 0x80;
 uint256 constant FiveWords = 0xa0;
 
 uint256 constant AlmostTwoWords = 0x3f;
-uint256 constant OnlyFullWordMask = 0xffffe0;
+uint256 constant OnlyFullWordMask = 0xffffffe0;
 
 uint256 constant FreeMemoryPointerSlot = 0x40;
 uint256 constant ZeroSlot = 0x60;

--- a/contracts/lib/ConsiderationDecoder.sol
+++ b/contracts/lib/ConsiderationDecoder.sol
@@ -64,13 +64,14 @@ contract ConsiderationDecoder {
             // Get the current free memory pointer.
             mPtrLength := mload(FreeMemoryPointerSlot)
 
-            // Derive the size of the bytes array, rounding up to nearest word.
-            let size := and(
-                add(
-                    and(calldataload(cdPtrLength), OffsetOrLengthMask),
-                    AlmostTwoWords
+            // Derive the size of the bytes array, rounding up to nearest word
+            // and adding a word for the length field.
+            let size := add(
+                and(
+                    add(calldataload(cdPtrLength), AlmostOneWord),
+                    OnlyFullWordMask
                 ),
-                OnlyFullWordMask
+                OneWord
             )
 
             // Copy bytes from calldata into memory based on pointers and size.

--- a/contracts/lib/ConsiderationEncoder.sol
+++ b/contracts/lib/ConsiderationEncoder.sol
@@ -70,9 +70,7 @@ contract ConsiderationEncoder {
         unchecked {
             // Mask the length of the bytes array to protect against overflow
             // and round up to the nearest word.
-            size =
-                ((src.readUint256() & OffsetOrLengthMask) + AlmostTwoWords) &
-                OnlyFullWordMask;
+            size = (src.readUint256() + AlmostTwoWords) & OnlyFullWordMask;
 
             // Copy the bytes array to the new memory location.
             src.copy(dst, size);


### PR DESCRIPTION
Fix issues identified by Spearbit with abi encoding/decoding of `bytes`:
- `OnlyFullWordMask` was set to 3 bytes prior to max dynamic value size being set to 4 bytes but was not updated. Modify it to use 4 bytes.
- Decoder used redundant masks and had overflow potential due to a word being added to length prior to applying the mask. Remove redundant mask and round up to nearest word before adding a word for length field.
- Encoder used redundant mask - remove it.