### PR TITLE
1.2 Changes the arithmetic flow when combining new and current fractions for advanced orders

### DIFF
--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -102,6 +102,10 @@ uint256 constant AdvancedOrder_denominator_offset = 0x40;
 uint256 constant AdvancedOrder_signature_offset = 0x60;
 uint256 constant AdvancedOrder_extraData_offset = 0x80;
 
+uint256 constant OrderStatus_ValidatedAndNotCancelled = 1;
+uint256 constant OrderStatus_filledNumerator_offset = 0x10;
+uint256 constant OrderStatus_filledDenominator_offset = 0x88;
+
 uint256 constant AlmostOneWord = 0x1f;
 uint256 constant OneWord = 0x20;
 uint256 constant TwoWords = 0x40;

--- a/contracts/lib/OrderValidator.sol
+++ b/contracts/lib/OrderValidator.sol
@@ -103,9 +103,9 @@ contract OrderValidator is Executor, ZoneInteraction {
      *                          order is invalid due to the time or status.
      *
      * @return orderHash      The order hash.
-     * @return newNumerator   A value indicating the portion of the order that
+     * @return numerator      A value indicating the portion of the order that
      *                        will be filled.
-     * @return newDenominator A value indicating the total size of the order.
+     * @return denominator    A value indicating the total size of the order.
      */
     function _validateOrderAndUpdateStatus(
         AdvancedOrder memory advancedOrder,
@@ -114,8 +114,8 @@ contract OrderValidator is Executor, ZoneInteraction {
         internal
         returns (
             bytes32 orderHash,
-            uint256 newNumerator,
-            uint256 newDenominator
+            uint256 numerator,
+            uint256 denominator
         )
     {
         // Retrieve the parameters for the order.
@@ -147,8 +147,18 @@ contract OrderValidator is Executor, ZoneInteraction {
         }
 
         // Read numerator and denominator from memory and place on the stack.
-        uint256 numerator = uint256(advancedOrder.numerator);
-        uint256 denominator = uint256(advancedOrder.denominator);
+        // Overflowed values would be masked
+        assembly {
+            numerator := and(
+                mload(add(advancedOrder, AdvancedOrder_numerator_offset)),
+                MaxUint120
+            )
+
+            denominator := and(
+                mload(add(advancedOrder, AdvancedOrder_denominator_offset)),
+                MaxUint120
+            )
+        }
 
         // Ensure that the supplied numerator and denominator are valid.
         if (numerator > denominator || numerator == 0) {
@@ -192,43 +202,85 @@ contract OrderValidator is Executor, ZoneInteraction {
             );
         }
 
-        // Read filled amount as numerator and denominator and put on the stack.
-        uint256 filledNumerator = orderStatus.numerator;
-        uint256 filledDenominator = orderStatus.denominator;
+        assembly {
+            let orderStatusSlot := orderStatus.slot
+            // Read filled amount as numerator and denominator and put on the stack.
+            let filledNumerator := sload(orderStatusSlot)
+            let filledDenominator := shr(
+                OrderStatus_filledDenominator_offset, 
+                filledNumerator
+            )
 
-        // If order (orderStatus) currently has a non-zero denominator it is
-        // partially filled.
-        if (filledDenominator != 0) {
-            // If denominator of 1 supplied, fill all remaining amount on order.
-            if (denominator == 1) {
-                // Scale numerator & denominator to match current denominator.
-                numerator = filledDenominator;
-                denominator = filledDenominator;
-            }
-            // Otherwise, if supplied denominator differs from current one...
-            else if (filledDenominator != denominator) {
-                // scale current numerator by the supplied denominator, then...
-                filledNumerator *= denominator;
+            for {} 1 {} {
+                if iszero(filledDenominator) {
+                    filledNumerator := numerator
 
-                // the supplied numerator & denominator by current denominator.
-                numerator *= filledDenominator;
-                denominator *= filledDenominator;
-            }
-
-            // Once adjusted, if current+supplied numerator exceeds denominator:
-            if (filledNumerator + numerator > denominator) {
-                // Skip underflow check: denominator >= orderStatus.numerator
-                unchecked {
-                    // Reduce current numerator so it + supplied = denominator.
-                    numerator = denominator - filledNumerator;
+                    break
                 }
-            }
 
-            // Increment the filled numerator by the new numerator.
-            filledNumerator += numerator;
+                // shift and mask to calculate the the current filled numerator
+                filledNumerator := and(
+                    shr(OrderStatus_filledNumerator_offset, filledNumerator),
+                    MaxUint120
+                )
 
-            // Use assembly to ensure fractional amounts are below max uint120.
-            assembly {
+                // If denominator of 1 supplied, fill all remaining amount on order.
+                if eq(denominator, 1) {
+                    numerator := sub(filledDenominator, filledNumerator)
+                    denominator := filledDenominator
+                    filledNumerator := filledDenominator
+
+                    break
+                }
+
+                // If supplied denominator equals to the current one
+                if eq(denominator, filledDenominator) {
+                    // Increment the filled numerator by the new numerator.
+                    filledNumerator := add(numerator, filledNumerator)
+
+                    // Once adjusted, if current+supplied numerator exceeds denominator:
+                    let _carry := mul(
+                        sub(filledNumerator, denominator),
+                        gt(filledNumerator, denominator)
+                    )
+
+                    numerator := sub(
+                        numerator,
+                        _carry
+                    )
+
+                    filledNumerator := sub(
+                        filledNumerator,
+                        _carry
+                    )
+
+                    break
+                }
+
+                // Otherwise, if supplied denominator differs from current one...
+                filledNumerator := mul(filledNumerator, denominator)
+                numerator := mul(numerator, filledDenominator)
+                denominator := mul(denominator, filledDenominator)
+
+                // Increment the filled numerator by the new numerator.
+                filledNumerator := add(numerator, filledNumerator)
+
+                // Once adjusted, if current+supplied numerator exceeds denominator:
+                let _carry := mul(
+                    sub(filledNumerator, denominator),
+                    gt(filledNumerator, denominator)
+                )
+
+                numerator := sub(
+                    numerator,
+                    _carry
+                )
+
+                filledNumerator := sub(
+                    filledNumerator,
+                    _carry
+                )
+
                 // Check filledNumerator and denominator for uint120 overflow.
                 if or(
                     gt(filledNumerator, MaxUint120),
@@ -270,28 +322,25 @@ contract OrderValidator is Executor, ZoneInteraction {
                         // Store the arithmetic (0x11) panic code.
                         mstore(Panic_error_code_ptr, Panic_arithmetic)
                         // revert(abi.encodeWithSignature("Panic(uint256)", 0x11))
-                        revert(0x1c, Panic_error_length)
+                        revert(Error_selector_offset, Panic_error_length)
                     }
                 }
-            }
-            // Skip overflow check: checked above unless numerator is reduced.
-            unchecked {
-                // Update order status and fill amount, packing struct values.
-                orderStatus.isValidated = true;
-                orderStatus.isCancelled = false;
-                orderStatus.numerator = uint120(filledNumerator);
-                orderStatus.denominator = uint120(denominator);
-            }
-        } else {
-            // Update order status and fill amount, packing struct values.
-            orderStatus.isValidated = true;
-            orderStatus.isCancelled = false;
-            orderStatus.numerator = uint120(numerator);
-            orderStatus.denominator = uint120(denominator);
-        }
 
-        // Return order hash, a modified numerator, and a modified denominator.
-        return (orderHash, numerator, denominator);
+                break
+            }
+
+            // Update order status and fill amount, packing struct values.
+            // [denominator: 15 bytes] [numerator: 15 bytes] [isCanecelled: 1 byte] [isValidated: 1 byte] 
+            sstore(orderStatusSlot, 
+                or(
+                    OrderStatus_ValidatedAndNotCancelled,
+                    or(
+                        shl(OrderStatus_filledNumerator_offset, filledNumerator),
+                        shl(OrderStatus_filledDenominator_offset, denominator)
+                    )
+                )
+            )
+        }
     }
 
     /**

--- a/contracts/lib/OrderValidator.sol
+++ b/contracts/lib/OrderValidator.sol
@@ -330,7 +330,7 @@ contract OrderValidator is Executor, ZoneInteraction {
             }
 
             // Update order status and fill amount, packing struct values.
-            // [denominator: 15 bytes] [numerator: 15 bytes] [isCanecelled: 1 byte] [isValidated: 1 byte] 
+            // [denominator: 15 bytes] [numerator: 15 bytes] [isCancelled: 1 byte] [isValidated: 1 byte] 
             sstore(orderStatusSlot, 
                 or(
                     OrderStatus_ValidatedAndNotCancelled,


### PR DESCRIPTION
The arithmetic flow in `_validateOrderAndUpdateStatus` has been rewritten mostly in assembly. The new flow avoids unnecessary operations for the special cases:

- `filledDenominator == 0`
- `denominator == 1`
- `denominator == filledDenominator`

The nested `if`/`else` blocks have been untangled.

Reading and writing to `orderStatus` storage slot is also enforced to only once by using `sload`/`sstore` manually in the assembly block.

## Warning

`advancedOrder.numerator` and `advancedOrder.denominator` are being masked before consumption. If there are dirty upper bytes provided by the `msg.sender`, the call will mask and continue.

https://github.com/ProjectOpenSea/seaport/blob/520732187bbe7b9b42968a1aab483d1dff9c62e3/contracts/lib/OrderValidator.sol#L151-L161

## Gas Diff

```gas
=============================================================================================
| method                         |            min |            max |            avg | calls |
=============================================================================================
| cancel                         |   +12 (+0.03%) |          58328 |    +3 (+0.01%) |    16 |
| fulfillAdvancedOrder           | -1092 (-1.12%) |   -676 (-0.3%) |  -612 (-0.38%) |   176 |
| fulfillAvailableAdvancedOrders |  -688 (-0.46%) | -1388 (-0.64%) |  -837 (-0.45%) |    22 |
| fulfillAvailableOrders         |  -700 (-0.42%) |       -12 (0%) |  -765 (-0.33%) |    16 |
| fulfillBasicOrder              |          91390 |       +12 (0%) |        +3 (0%) |   187 |
| fulfillOrder                   |  -700 (-0.58%) |   -676 (-0.3%) |  -689 (-0.39%) |   105 |
| incrementCounter               |           null |           null |          47057 |     6 |
| matchAdvancedOrders            | -1364 (-0.77%) | -1376 (-0.46%) | -1619 (-0.65%) |    74 |
| matchOrders                    |  -1400 (-0.9%) |  -1376 (-0.4%) | -1377 (-0.53%) |   107 |
| validate                       |          53174 |   +24 (+0.03%) |        +3 (0%) |    27 |
=============================================================================================
| runtime size                   |  -973 (-3.99%) |                |                |       |
| init code size                 |  -973 (-3.51%) |                |                |       |
=============================================================================================
Current Report: 520732187bbe7b9b42968a1aab483d1dff9c62e3
Previous Report: 188efe84376b03bf0b26fa63239c0420e7a11ca3
```
