### PR TITLE
1.2 reuse `currentAmount` in `OrderCombiner`

### DIFF
--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -400,12 +400,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                         // track received amounts.
                         mstore(
                             considerationItemRecipient,
-                            mload(
-                                add(
-                                    considerationItem,
-                                    ReceivedItem_amount_offset
-                                )
-                            )
+                            currentAmount
                         )
                     }
                 }


### PR DESCRIPTION
addresses:
- https://github.com/spearbit-audits/review-seaport-1.2/issues/91