### PR TITLE
Fix Natspec spacing

### DIFF
--- a/contracts/lib/Consideration.sol
+++ b/contracts/lib/Consideration.sol
@@ -42,7 +42,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      * @notice Derive and set hashes, reference chainId, and associated domain
      *         separator during deployment.
      *
-     * @ param conduitController A contract that deploys conduits, or proxies
+     * @param conduitController A contract that deploys conduits, or proxies
      *                          that may optionally be used to transfer approved
      *                          ERC20/721/1155 tokens.
      */
@@ -63,7 +63,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         to the documentation for a more comprehensive summary of how to
      *         utilize this method and what orders are compatible with it.
      *
-     * @ param parameters Additional information on the fulfilled order. Note
+     * @param parameters Additional information on the fulfilled order. Note
      *                   that the offerer and the fulfiller must first approve
      *                   this contract (or their chosen conduit if indicated)
      *                   before any tokens can be transferred. Also note that
@@ -71,7 +71,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                   implement `onERC1155Received` in order to receive those
      *                   items.
      *
-     * @ return fulfilled A boolean indicating whether the order has been
+     * @return fulfilled A boolean indicating whether the order has been
      *                   successfully fulfilled.
      */
     function fulfillBasicOrder(
@@ -87,20 +87,20 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         criteria-based orders or partial filling of orders (though
      *         filling the remainder of a partially-filled order is supported).
      *
-     * @ param order               The order to fulfill. Note that both the
+     * @param order               The order to fulfill. Note that both the
      *                            offerer and the fulfiller must first approve
      *                            this contract (or the corresponding conduit if
      *                            indicated) to transfer any relevant tokens on
      *                            their behalf and that contracts must implement
      *                            `onERC1155Received` to receive ERC1155 tokens
      *                            as consideration.
-     * @ param fulfillerConduitKey A bytes32 value indicating what conduit, if
+     * @param fulfillerConduitKey A bytes32 value indicating what conduit, if
      *                            any, to source the fulfiller's token approvals
      *                            from. The zero hash signifies that no conduit
      *                            should be used (and direct approvals set on
      *                            Consideration).
      *
-     * @ return fulfilled A boolean indicating whether the order has been
+     * @return fulfilled A boolean indicating whether the order has been
      *                   successfully fulfilled.
      */
     function fulfillOrder(
@@ -123,7 +123,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         items for offer and consideration alongside criteria resolvers
      *         containing specific token identifiers and associated proofs.
      *
-     * @ param advancedOrder       The order to fulfill along with the fraction
+     * @param advancedOrder       The order to fulfill along with the fraction
      *                            of the order to attempt to fill. Note that
      *                            both the offerer and the fulfiller must first
      *                            approve this contract (or their conduit if
@@ -136,7 +136,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                            multiplication of the respective amount with
      *                            the supplied fraction for the partial fill to
      *                            be considered valid.
-     * @ param criteriaResolvers   An array where each element contains a
+     * @param criteriaResolvers   An array where each element contains a
      *                            reference to a specific offer or
      *                            consideration, a token identifier, and a proof
      *                            that the supplied token identifier is
@@ -146,16 +146,16 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                            (transferable) token identifier on the token
      *                            in question is valid and that no associated
      *                            proof needs to be supplied.
-     * @ param fulfillerConduitKey A bytes32 value indicating what conduit, if
+     * @param fulfillerConduitKey A bytes32 value indicating what conduit, if
      *                            any, to source the fulfiller's token approvals
      *                            from. The zero hash signifies that no conduit
      *                            should be used (and direct approvals set on
      *                            Consideration).
-     * @ param recipient           The intended recipient for all received items,
+     * @param recipient           The intended recipient for all received items,
      *                            with `address(0)` indicating that the caller
      *                            should receive the items.
      *
-     * @ return fulfilled A boolean indicating whether the order has been
+     * @return fulfilled A boolean indicating whether the order has been
      *                   successfully fulfilled.
      */
     function fulfillAdvancedOrder(
@@ -191,7 +191,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         partial filling of orders (though filling the remainder of a
      *         partially-filled order is supported).
      *
-     * @ param orders                    The orders to fulfill. Note that both
+     * @param orders                    The orders to fulfill. Note that both
      *                                  the offerer and the fulfiller must first
      *                                  approve this contract (or the
      *                                  corresponding conduit if indicated) to
@@ -199,24 +199,24 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                                  behalf and that contracts must implement
      *                                  `onERC1155Received` to receive ERC1155
      *                                  tokens as consideration.
-     * @ param offerFulfillments         An array of FulfillmentComponent arrays
+     * @param offerFulfillments         An array of FulfillmentComponent arrays
      *                                  indicating which offer items to attempt
      *                                  to aggregate when preparing executions.
-     * @ param considerationFulfillments An array of FulfillmentComponent arrays
+     * @param considerationFulfillments An array of FulfillmentComponent arrays
      *                                  indicating which consideration items to
      *                                  attempt to aggregate when preparing
      *                                  executions.
-     * @ param fulfillerConduitKey       A bytes32 value indicating what conduit,
+     * @param fulfillerConduitKey       A bytes32 value indicating what conduit,
      *                                  if any, to source the fulfiller's token
      *                                  approvals from. The zero hash signifies
      *                                  that no conduit should be used (and
      *                                  direct approvals set on Consideration).
-     * @ param maximumFulfilled          The maximum number of orders to fulfill.
+     * @param maximumFulfilled          The maximum number of orders to fulfill.
      *
-     * @ return availableOrders An array of booleans indicating if each order
+     * @return availableOrders An array of booleans indicating if each order
      *                         with an index corresponding to the index of the
      *                         returned boolean was fulfillable or not.
-     * @ return executions      An array of elements indicating the sequence of
+     * @return executions      An array of elements indicating the sequence of
      *                         transfers performed as part of matching the given
      *                         orders.
      */
@@ -267,7 +267,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         recipient, respectively. Note that a failing item transfer or an
      *         issue with order formatting will cause the entire batch to fail.
      *
-     * @ param advancedOrders            The orders to fulfill along with the
+     * @param advancedOrders            The orders to fulfill along with the
      *                                  fraction of those orders to attempt to
      *                                  fill. Note that both the offerer and the
      *                                  fulfiller must first approve this
@@ -283,7 +283,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                                  with the supplied fraction for an
      *                                  order's partial fill amount to be
      *                                  considered valid.
-     * @ param criteriaResolvers         An array where each element contains a
+     * @param criteriaResolvers         An array where each element contains a
      *                                  reference to a specific offer or
      *                                  consideration, a token identifier, and a
      *                                  proof that the supplied token identifier
@@ -294,27 +294,27 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                                  identifier on the token in question is
      *                                  valid and that no associated proof needs
      *                                  to be supplied.
-     * @ param offerFulfillments         An array of FulfillmentComponent arrays
+     * @param offerFulfillments         An array of FulfillmentComponent arrays
      *                                  indicating which offer items to attempt
      *                                  to aggregate when preparing executions.
-     * @ param considerationFulfillments An array of FulfillmentComponent arrays
+     * @param considerationFulfillments An array of FulfillmentComponent arrays
      *                                  indicating which consideration items to
      *                                  attempt to aggregate when preparing
      *                                  executions.
-     * @ param fulfillerConduitKey       A bytes32 value indicating what conduit,
+     * @param fulfillerConduitKey       A bytes32 value indicating what conduit,
      *                                  if any, to source the fulfiller's token
      *                                  approvals from. The zero hash signifies
      *                                  that no conduit should be used (and
      *                                  direct approvals set on Consideration).
-     * @ param recipient                 The intended recipient for all received
+     * @param recipient                 The intended recipient for all received
      *                                  items, with `address(0)` indicating that
      *                                  the caller should receive the items.
-     * @ param maximumFulfilled          The maximum number of orders to fulfill.
+     * @param maximumFulfilled          The maximum number of orders to fulfill.
      *
-     * @ return availableOrders An array of booleans indicating if each order
+     * @return availableOrders An array of booleans indicating if each order
      *                         with an index corresponding to the index of the
      *                         returned boolean was fulfillable or not.
-     * @ return executions      An array of elements indicating the sequence of
+     * @return executions      An array of elements indicating the sequence of
      *                         transfers performed as part of matching the given
      *                         orders.
      */
@@ -366,19 +366,19 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         offer item amounts or native tokens will be transferred to the
      *         caller.
      *
-     * @ param orders       The orders to match. Note that both the offerer and
+     * @param orders       The orders to match. Note that both the offerer and
      *                      fulfiller on each order must first approve this
      *                      contract (or their conduit if indicated by the
      *                      order) to transfer any relevant tokens on their
      *                      behalf and each consideration recipient must
      *                      implement `onERC1155Received` in order to receive
      *                      ERC1155 tokens.
-     * @ param fulfillments An array of elements allocating offer components to
+     * @param fulfillments An array of elements allocating offer components to
      *                      consideration components. Note that each
      *                      consideration component must be fully met in order
      *                      for the match operation to be valid.
      *
-     * @ return executions An array of elements indicating the sequence of
+     * @return executions An array of elements indicating the sequence of
      *                     transfers performed as part of matching the given
      *                     orders. Note that unspent offer item amounts or
      *                     native tokens will not be reflected as part of this
@@ -412,7 +412,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         null address signifying to use the caller) and any unspent native
      *         tokens will be returned to the caller.
      *
-     * @ param advancedOrders    The advanced orders to match. Note that both
+     * @param advancedOrders    The advanced orders to match. Note that both
      *                           the offerer and fulfiller on each order must
      *                           first approve this contract (or their conduit
      *                           if indicated by the order) to transfer any
@@ -425,7 +425,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                           respective amount with the supplied fraction in
      *                           order for the group of partial fills to be
      *                           considered valid.
-     * @ param criteriaResolvers An array where each element contains a
+     * @param criteriaResolvers An array where each element contains a
      *                           reference to a specific order as well as that
      *                           order's offer or consideration, a token
      *                           identifier, and a proof that the supplied token
@@ -434,7 +434,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                           any (transferable) token identifier is valid
      *                           and that no associated proof needs to be
      *                           supplied.
-     * @ param fulfillments      An array of elements allocating offer
+     * @param fulfillments      An array of elements allocating offer
      *                           components to consideration components. Note
      *                           that each consideration component must be fully
      *                           met in order for the match operation to be
@@ -443,7 +443,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                           item amounts, or the caller if the null address
      *                           is supplied.
      *
-     * @ return executions An array of elements indicating the sequence of
+     * @return executions An array of elements indicating the sequence of
      *                     transfers performed as part of matching the given
      *                     orders. Note that unspent offer item amounts or
      *                     native tokens will not be reflected as part of this
@@ -477,9 +477,9 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         that the intended order was cancelled by calling `getOrderStatus`
      *         and confirming that `isCancelled` returns `true`.
      *
-     * @ param orders The orders to cancel.
+     * @param orders The orders to cancel.
      *
-     * @ return cancelled A boolean indicating whether the supplied orders have
+     * @return cancelled A boolean indicating whether the supplied orders have
      *                   been successfully cancelled.
      */
     function cancel(
@@ -499,9 +499,9 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         that anyone can validate a signed order, but only the offerer can
      *         validate an order without supplying a signature.
      *
-     * @ param orders The orders to validate.
+     * @param orders The orders to validate.
      *
-     * @ return validated A boolean indicating whether the supplied orders have
+     * @return validated A boolean indicating whether the supplied orders have
      *                   been successfully validated.
      */
     function validate(
@@ -516,7 +516,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         by incrementing a counter. Note that only the offerer may
      *         increment the counter.
      *
-     * @ return newCounter The new counter.
+     * @return newCounter The new counter.
      */
     function incrementCounter() external override returns (uint256 newCounter) {
         // Increment current counter for the supplied offerer.  Note that the
@@ -527,9 +527,9 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
     /**
      * @notice Retrieve the order hash for a given order.
      *
-     * @ param order The components of the order.
+     * @param order The components of the order.
      *
-     * @ return orderHash The order hash.
+     * @return orderHash The order hash.
      */
     function getOrderHash(
         OrderComponents calldata /* order */
@@ -553,16 +553,16 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         does not get set for contract orders, getOrderStatus will always
      *         return (false, false, 0, 0) for those hashes.
      *
-     * @ param orderHash The order hash in question.
+     * @param orderHash The order hash in question.
      *
-     * @ return isValidated A boolean indicating whether the order in question
+     * @return isValidated A boolean indicating whether the order in question
      *                     has been validated (i.e. previously approved or
      *                     partially filled).
-     * @ return isCancelled A boolean indicating whether the order in question
+     * @return isCancelled A boolean indicating whether the order in question
      *                     has been cancelled.
-     * @ return totalFilled The total portion of the order that has been filled
+     * @return totalFilled The total portion of the order that has been filled
      *                     (i.e. the "numerator").
-     * @ return totalSize   The total size of the order that is either filled or
+     * @return totalSize   The total size of the order that is either filled or
      *                     unfilled (i.e. the "denominator").
      */
     function getOrderStatus(
@@ -585,9 +585,9 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
     /**
      * @notice Retrieve the current counter for a given offerer.
      *
-     * @ param offerer The offerer in question.
+     * @param offerer The offerer in question.
      *
-     * @ return counter The current counter.
+     * @return counter The current counter.
      */
     function getCounter(
         address offerer
@@ -599,9 +599,9 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
     /**
      * @notice Retrieve configuration information for this contract.
      *
-     * @ return version           The contract version.
-     * @ return domainSeparator   The domain separator for this contract.
-     * @ return conduitController The conduit Controller set for this contract.
+     * @return version           The contract version.
+     * @return domainSeparator   The domain separator for this contract.
+     * @return conduitController The conduit Controller set for this contract.
      */
     function information()
         external
@@ -620,9 +620,9 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
     /**
      * @dev Gets the contract offerer nonce for the specified contract offerer.
      *
-     * @ param contractOfferer The contract offerer for which to get the nonce.
+     * @param contractOfferer The contract offerer for which to get the nonce.
      *
-     * @ return nonce The contract offerer nonce.
+     * @return nonce The contract offerer nonce.
      */
     function getContractOffererNonce(
         address contractOfferer
@@ -633,7 +633,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
     /**
      * @notice Retrieve the name of this contract.
      *
-     * @ return contractName The name of this contract.
+     * @return contractName The name of this contract.
      */
     function name()
         external

--- a/contracts/lib/Consideration.sol
+++ b/contracts/lib/Consideration.sol
@@ -366,19 +366,19 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         offer item amounts or native tokens will be transferred to the
      *         caller.
      *
-     * @param orders       The orders to match. Note that both the offerer and
+     * @param orders        The orders to match. Note that both the offerer and
      *                      fulfiller on each order must first approve this
      *                      contract (or their conduit if indicated by the
      *                      order) to transfer any relevant tokens on their
      *                      behalf and each consideration recipient must
      *                      implement `onERC1155Received` in order to receive
      *                      ERC1155 tokens.
-     * @param fulfillments An array of elements allocating offer components to
+     * @param fulfillments  An array of elements allocating offer components to
      *                      consideration components. Note that each
      *                      consideration component must be fully met in order
      *                      for the match operation to be valid.
      *
-     * @return executions An array of elements indicating the sequence of
+     * @return executions  An array of elements indicating the sequence of
      *                     transfers performed as part of matching the given
      *                     orders. Note that unspent offer item amounts or
      *                     native tokens will not be reflected as part of this
@@ -412,7 +412,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         null address signifying to use the caller) and any unspent native
      *         tokens will be returned to the caller.
      *
-     * @param advancedOrders    The advanced orders to match. Note that both
+     * @param advancedOrders     The advanced orders to match. Note that both
      *                           the offerer and fulfiller on each order must
      *                           first approve this contract (or their conduit
      *                           if indicated by the order) to transfer any
@@ -425,7 +425,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                           respective amount with the supplied fraction in
      *                           order for the group of partial fills to be
      *                           considered valid.
-     * @param criteriaResolvers An array where each element contains a
+     * @param criteriaResolvers  An array where each element contains a
      *                           reference to a specific order as well as that
      *                           order's offer or consideration, a token
      *                           identifier, and a proof that the supplied token
@@ -434,7 +434,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                           any (transferable) token identifier is valid
      *                           and that no associated proof needs to be
      *                           supplied.
-     * @param fulfillments      An array of elements allocating offer
+     * @param fulfillments       An array of elements allocating offer
      *                           components to consideration components. Note
      *                           that each consideration component must be fully
      *                           met in order for the match operation to be
@@ -443,7 +443,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                           item amounts, or the caller if the null address
      *                           is supplied.
      *
-     * @return executions An array of elements indicating the sequence of
+     * @return executions  An array of elements indicating the sequence of
      *                     transfers performed as part of matching the given
      *                     orders. Note that unspent offer item amounts or
      *                     native tokens will not be reflected as part of this


### PR DESCRIPTION
Addresses:
> The `@` NatSpec fields have an extra space in `Consideration.sol`:
> ```solidity
> * @ <field>
> ```
> The extra space can be removed.

- https://github.com/spearbit-audits/review-seaport-1.2/issues/47