### PR TITLE
1.2 removes extra MSTOREs and logical operators when applying fulfillments

### DIFF
--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -386,41 +386,38 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
                         )
                         let fulfillmentPtr := mload(fulfillmentHeadPtr)
                         mstore(firstFulfillmentHeadPtr, fulfillmentPtr)
-                        mstore(fulfillmentHeadPtr, firstFulfillmentPtr)
                     }
                 }
                 default {
                     // Compare every subsequent item to the first
-                    if iszero(
-                        and(
-                            and(
-                                // The offerer must match on both items.
-                                eq(
-                                    mload(paramsPtr),
-                                    mload(
-                                        add(execution, Execution_offerer_offset)
-                                    )
-                                ),
-                                // The conduit key must match on both items.
-                                eq(
-                                    mload(
-                                        add(
-                                            paramsPtr,
-                                            OrderParameters_conduit_offset
-                                        )
-                                    ),
-                                    mload(
-                                        add(execution, Execution_conduit_offset)
-                                    )
+                    if or(
+                        or(
+                            // The offerer must match on both items.
+                            xor(
+                                mload(paramsPtr),
+                                mload(
+                                    add(execution, Execution_offerer_offset)
                                 )
                             ),
-                            // The itemType, token, and identifier must match.
-                            eq(
-                                dataHash,
-                                keccak256(
-                                    offerItemPtr,
-                                    ReceivedItem_CommonParams_size
+                            // The conduit key must match on both items.
+                            xor(
+                                mload(
+                                    add(
+                                        paramsPtr,
+                                        OrderParameters_conduit_offset
+                                    )
+                                ),
+                                mload(
+                                    add(execution, Execution_conduit_offset)
                                 )
+                            )
+                        ),
+                        // The itemType, token, and identifier must match.
+                        xor(
+                            dataHash,
+                            keccak256(
+                                offerItemPtr,
+                                ReceivedItem_CommonParams_size
                             )
                         )
                     ) {
@@ -662,7 +659,6 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
                         )
                         let fulfillmentPtr := mload(fulfillmentHeadPtr)
                         mstore(firstFulfillmentHeadPtr, fulfillmentPtr)
-                        mstore(fulfillmentHeadPtr, firstFulfillmentPtr)
                     }
                 }
                 default {


### PR DESCRIPTION
This PR applies two types of changes:

1. It removes the extra writing to memory when swapping the first used fulfillment and the first fulfillment. The first used fulfillment pointer will not be updated as it no longer is needed. So after this stage in the fulfillment data, two head slots would point to the same tail. But we would only care about the first fulfillment slot and only in the case of match orders (perhaps a warning needs to be added for future updates).

2. An `if` statement has been optimized using the following transformation:

```solidity
if iszero(and(eq(x1, x2), and(eq(x3,x4), ...)))
if or(xor(x1, x2), or(xor(x3,x4), ...)) // optimized version
```