### PR TITLE
1.2 Modifies `NonMatchSelector` constants, comments and adds tests

### DIFF
--- a/contracts/lib/ConsiderationConstants.sol
+++ b/contracts/lib/ConsiderationConstants.sol
@@ -426,13 +426,13 @@ uint256 constant Signature_lower_v = 27;
 
 // Bitmask that only gives a non-zero value if masked with a non-match selector.
 uint256 constant NonMatchSelector_MagicMask = (
-    0x0100000000000000000000000000000000000000000000000000000000000000
+    0x4000000000000000000000000000000000000000000000000000000000
 );
 
-// First bit indicates that a NATIVE offer items has been used and the 248th bit
+// First bit indicates that a NATIVE offer items has been used and the 231th bit
 // indicates that a non match selector has been called.
 uint256 constant NonMatchSelector_InvalidErrorValue = (
-    0x0100000000000000000000000000000000000000000000000000000000000001
+    0x4000000000000000000000000000000000000000000000000000000001
 );
 
 uint256 constant IsValidOrder_signature = (

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -185,16 +185,16 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
         // Use assembly to set the value for the second bit of the error buffer.
         assembly {
             /**
-             * Use the 248th bit of the error buffer to indicate whether the
+             * Use the 231st bit of the error buffer to indicate whether the
              * current function is not matchAdvancedOrders or matchOrders.
              *
              * sig                                func
              * -----------------------------------------------------------------
-             * 10101000000101110100010 00 0000100 matchOrders
-             * 01010101100101000100101 00 1000010 matchAdvancedOrders
-             * 11101101100110001010010 10 1110100 fulfillAvailableOrders
-             * 10000111001000000001101 10 1000001 fulfillAvailableAdvancedOrders
-             *                         ^ 9th bit
+             * 1010100000010111010001000 0 000100 matchOrders
+             * 1111001011010001001010110 0 010010 matchAdvancedOrders
+             * 1110110110011000101001010 1 110100 fulfillAvailableOrders
+             * 1000011100100000000110110 1 000001 fulfillAvailableAdvancedOrders
+             *                           ^ 7th bit
              */
             invalidNativeOfferItemErrorBuffer := and(
                 NonMatchSelector_MagicMask,

--- a/test/foundry/NonMatchSelectorTest.t.sol
+++ b/test/foundry/NonMatchSelectorTest.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+//Author: Saw-mon and Natalie
+
+pragma solidity ^0.8.17;
+
+import {
+    ConsiderationInterface
+} from "../../contracts/interfaces/ConsiderationInterface.sol";
+
+import {
+    NonMatchSelector_MagicMask,
+    NonMatchSelector_InvalidErrorValue
+} from "../../contracts/lib/ConsiderationConstants.sol";
+
+import { Test } from "forge-std/Test.sol";
+contract NonMatchSelectorTest is Test {
+
+    function testNonMatchSelectorMagicMaskAndInvalidErrorValue() public {
+        assertEq(
+            NonMatchSelector_MagicMask + 1,
+            NonMatchSelector_InvalidErrorValue
+        );
+    }
+    
+    function testSelectorMatchOrders() public {
+        _testSelector(
+            ConsiderationInterface.matchOrders.selector,
+            false
+        );
+    }
+
+    function testSelectorMatchAdvancedOrders() public {
+        _testSelector(
+            ConsiderationInterface.matchAdvancedOrders.selector,
+            false
+        );
+    }
+
+    function testSelectorFulfillAvailableOrders() public {
+        _testSelector(
+            ConsiderationInterface.fulfillAvailableOrders.selector,
+            true
+        );
+    }
+
+    function testSelectorFulfillAvailableAdvancedOrders() public {
+        _testSelector(
+            ConsiderationInterface.fulfillAvailableAdvancedOrders.selector,
+            true
+        );
+    }
+
+    function _testSelector(bytes4 selector, bool shouldBeSelected) internal {
+        bool isSelected;
+
+        assembly {
+            isSelected := eq(
+                NonMatchSelector_MagicMask,
+                and(
+                    NonMatchSelector_MagicMask,
+                    selector
+                )
+            )
+        }
+
+        assertEq(isSelected, shouldBeSelected);
+    }
+}


### PR DESCRIPTION
`NonMatchSelector_...` constants have been updated to select a lower bit which would also reduce the deployment size.

Comments have been updated and new tests have been added.