### PR TITLE
Code4rena gas finding: Using XOR (`^`) and OR (`|`) bitwise equivalents

### DIFF
--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -90,10 +90,11 @@ contract FulfillmentApplier is FulfillmentApplicationErrors {
         );
 
         // Ensure offer and consideration share types, tokens and identifiers.
+        // (a != b || c != d || e != f) == (((a ^ b) | (c ^ d) | (e ^ f)) != 0), but the 2nd expression is cheaper
         if (
-            execution.item.itemType != considerationItem.itemType ||
-            execution.item.token != considerationItem.token ||
-            execution.item.identifier != considerationItem.identifier
+            ((uint8(execution.item.itemType) ^ uint8(considerationItem.itemType)) |
+            (uint160(execution.item.token) ^ uint160(considerationItem.token)) |
+            (execution.item.identifier ^ considerationItem.identifier)) != 0
         ) {
             _revertMismatchedFulfillmentOfferAndConsiderationComponents(
                 fulfillmentIndex


### PR DESCRIPTION
From my code4rena gas report:

## 1. Using XOR (`^`) and OR (`|`) bitwise equivalents

*Estimated savings: 73 gas*
*Max savings according to `yarn profile`: 282 gas*

On Remix, given only `uint256` types, the following are logical equivalents, but don't cost the same amount of gas:

- `(a != b || c != d || e != f)` costs 571
- `((a ^ b) | (c ^ d) | (e ^ f)) != 0` costs 498 (saving 73 gas)

Consider rewriting as following to save gas:

```diff
File: FulfillmentApplier.sol
93:         if (
- 94:             execution.item.itemType != considerationItem.itemType ||
- 95:             execution.item.token != considerationItem.token ||
- 96:             execution.item.identifier != considerationItem.identifier
+ 94:             ((uint8(execution.item.itemType) ^ uint8(considerationItem.itemType)) |
+ 95:             (uint160(execution.item.token) ^ uint160(considerationItem.token)) |
+ 96:             (execution.item.identifier ^ considerationItem.identifier)) != 0
97:         ) {
```

**Logic POC**

Given 4 variables `a`, `b`, `c` and `d` represented as such:

```js
0 0 0 0 0 1 1 0 <- a
0 1 1 0 0 1 1 0 <- b
0 0 0 0 0 0 0 0 <- c
1 1 1 1 1 1 1 1 <- d
```

To have `a == b` means that every `0` and `1` match on both variables. Meaning that a XOR (operator `^`) would evaluate to 0 (`(a ^ b) == 0`), as it excludes by definition any equalities.
Now, if `a != b`, this means that there's at least somewhere a `1` and a `0` not matching between `a` and `b`, making `(a ^ b) != 0`.

Both formulas are logically equivalent and using the XOR bitwise operator costs actually the same amount of gas:

```solidity
      function xOrEquivalence(uint a, uint b) external returns (bool) {
        //return a != b; //370
        //return a ^ b != 0; //370
```

However, it is much cheaper to use the bitwise OR operator (`|`) than comparing the truthy or falsy values:

```solidity
    function xOrOrEquivalence(uint a, uint b, uint c, uint d) external returns (bool) {
        //return (a != b || c != d); // 495
        //return (a ^ b | c ^ d) != 0; // 442
    }
```

These are logically equivalent too, as the OR bitwise operator (`|`) would result in a `1` somewhere if any value is not `0` between the XOR (`^`) statements, meaning if any XOR (`^`) statement verifies that its arguments are different.

**Coded POC**

This little POC (use `forge test -m test_XorEq`) also proves that the formulas are equivalent:

```solidity
    function test_XorEq(uint8 a, uint8 b, address c, address d, uint256 e, uint256 f) external {
        assert((a != b || c != d || e != f) == (((a ^ b) | (uint160(c) ^ uint160(d)) | (e ^ f)) != 0));
    }
```

Please keep in mind that Foundry cannot currently fuzz `Enum` types, which is why we're using `uint8` types above, which is [treated the same according to the Solidity documentation](https://docs.soliditylang.org/en/v0.8.17/types.html#enums). However, you can try the following test on Remix to make sure, as it will always pass the asserts:

```solidity
    function test_enum(ItemType a, ItemType b) public {
        assert((a != b) == (uint8(a) != uint8(b)));
        assert((a != b) == ((uint8(a) ^ uint8(b)) != 0));
    }
```

**yarn profile**
This is the diff between the contest repo's `yarn profile` and the added suggestion's `yarn profile`, as `yarn profile` never changes the "Previous Report" it compares the "Current Report" to:

```diff
===============================================================================================
| method                         |          min |           max |           avg |       calls |
===============================================================================================
- | matchAdvancedOrders            | +12 (+0.01%) |     -12 (0%) | -471 (-0.19%) | +2 (+2.67%) |
+ | matchAdvancedOrders            | -40 (-0.02%) |  -92 (-0.03%)| -546 (-0.22%) | +2 (+2.67%) |
- | matchOrders                    | -12 (-0.01%) | -24 (-0.01%) | -234 (-0.09%) | +2 (+1.34%) |
+ | matchOrders                    | -20 (-0.01%) | -176 (-0.05%)| -323 (-0.12%) | +2 (+1.34%) |
- | validate                       |        53206 |        83915 |       -1 (0%) |          27 |
+ | validate                       |        53206 |  -24 (-0.03%)|   -7 (-0.01%) |          27 |
===============================================================================================
- | runtime size                   |        23583 |              |               |             |
+ | runtime size                   | -13 (-0.06%) |              |               |             |
- | init code size                 | +78 (+0.29%) |              |               |             |
+ | init code size                 | +65 (+0.24%) |              |               |             |
===============================================================================================
```

Added together, the max gas saving counted here is 282.

Consider applying the suggested equivalence and **add a comment mentioning what this is equivalent to**, as this is less human-readable, but still understandable once it's been taught.
