### PR TITLE
Code4rena gas finding: Shift left by 5 instead of multiplying by 32

### DIFF
--- a/contracts/lib/ConsiderationDecoder.sol
+++ b/contracts/lib/ConsiderationDecoder.sol
@@ -381,7 +381,7 @@ contract ConsiderationDecoder {
 
         unchecked {
             // Derive offset to the tail based on one word per array element.
-            uint256 tailOffset = arrLength * OneWord;
+            uint256 tailOffset = arrLength << OneWordShift;
 
             // Add one additional word for the length and allocate memory.
             mPtrLength = malloc(tailOffset + OneWord);
@@ -422,7 +422,7 @@ contract ConsiderationDecoder {
 
         unchecked {
             // Derive array size based on one word per array element and length.
-            uint256 arrSize = (arrLength + 1) * OneWord;
+            uint256 arrSize = (arrLength + 1) << OneWordShift;
 
             // Allocate memory equal to the array size.
             mPtrLength = malloc(arrSize);
@@ -480,7 +480,7 @@ contract ConsiderationDecoder {
 
         unchecked {
             // Derive offset to the tail based on one word per array element.
-            uint256 tailOffset = arrLength * OneWord;
+            uint256 tailOffset = arrLength << OneWordShift;
 
             // Add one additional word for the length and allocate memory.
             mPtrLength = malloc(tailOffset + OneWord);
@@ -520,7 +520,7 @@ contract ConsiderationDecoder {
 
         unchecked {
             // Derive offset to the tail based on one word per array element.
-            uint256 tailOffset = arrLength * OneWord;
+            uint256 tailOffset = arrLength << OneWordShift;
 
             // Add one additional word for the length and allocate memory.
             mPtrLength = malloc(tailOffset + OneWord);
@@ -612,7 +612,7 @@ contract ConsiderationDecoder {
 
         unchecked {
             // Derive offset to the tail based on one word per array element.
-            uint256 tailOffset = arrLength * OneWord;
+            uint256 tailOffset = arrLength << OneWordShift;
 
             // Add one additional word for the length and allocate memory.
             mPtrLength = malloc(tailOffset + OneWord);
@@ -655,7 +655,7 @@ contract ConsiderationDecoder {
 
         unchecked {
             // Derive offset to the tail based on one word per array element.
-            uint256 tailOffset = arrLength * OneWord;
+            uint256 tailOffset = arrLength << OneWordShift;
 
             // Add one additional word for the length and allocate memory.
             mPtrLength = malloc(tailOffset + OneWord);
@@ -726,7 +726,7 @@ contract ConsiderationDecoder {
 
         unchecked {
             // Derive offset to the tail based on one word per array element.
-            uint256 tailOffset = arrLength * OneWord;
+            uint256 tailOffset = arrLength << OneWordShift;
 
             // Add one additional word for the length and allocate memory.
             mPtrLength = malloc(tailOffset + OneWord);

--- a/contracts/lib/ConsiderationEncoder.sol
+++ b/contracts/lib/ConsiderationEncoder.sol
@@ -559,7 +559,7 @@ contract ConsiderationEncoder {
 
         unchecked {
             // Determine head & tail size as one word per element in the array.
-            uint256 headAndTailSize = length * OneWord;
+            uint256 headAndTailSize = length << OneWordShift;
 
             // Copy the tail starting from the next element of the source to the
             // next element of the destination.
@@ -670,7 +670,7 @@ contract ConsiderationEncoder {
             // incremented until it reaches the tail position (start of the
             // array data).
             MemoryPointer srcHead = srcLength.next();
-            MemoryPointer srcHeadEnd = srcHead.offset(length * OneWord);
+            MemoryPointer srcHeadEnd = srcHead.offset(length << OneWordShift);
 
             // Position in memory to write next item for calldata. Since
             // ReceivedItem has a fixed length, the array elements do not

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -217,7 +217,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
             orderHashes = new bytes32[](totalOrders);
 
             // Determine the memory offset to terminate on during loops.
-            terminalMemoryOffset = (totalOrders + 1) * 32;
+            terminalMemoryOffset = (totalOrders + 1) << OneWordShift;
         }
 
         // Skip overflow checks as all for loops are indexed starting at zero.


### PR DESCRIPTION
This is from my code4rena finding (+ I now saw the `OneWordShift` constant).
I'll add that, as all of those are in `unchecked` block, they are assumed to be safe enough to not overflow, therefore I don't believe we're introducing a bug with `<< 5` vs `* 32` here

## 2. Shift left by 5 instead of multiplying by 32

*Estimated savings: 22 gas*
*Max savings according to `yarn profile`: 98 gas*

The equivalent of multiplying by 32 is shifting left by 5. On Remix, a simple POC shows some by replacing one with the other (Optimizer at 10k runs):

```solidity
    function shiftLeft5(uint256 a) public pure returns (uint256) {
        //unchecked { return a * 32; } //346
        //unchecked { return a << 5; } //344
    }
```

This is due to the fact that the MUL opcode costs 5 gas and the SHL opcode costs 3 gas. Therefore, saving those 2 units of gas is expected.

Places where this optimization can be applied are as such:

- A simple multiplication by 32:

```diff
File: OrderCombiner.sol
- 220:             terminalMemoryOffset = (totalOrders + 1) * 32; //@audit-issue << 5
+ 220:             terminalMemoryOffset = (totalOrders + 1) << 5;
```

- Multiplying by the constant `OneWord == 0x20`, as `0x20` in hex is actually `32` in decimals:

```diff
seaport/contracts/lib/ConsiderationDecoder.sol:
-  386:             uint256 tailOffset = arrLength * OneWord;
+  386:             uint256 tailOffset = arrLength << 5;
-  427:             uint256 arrSize = (arrLength + 1) * OneWord;
+  427:             uint256 arrSize = (arrLength + 1) << 5;
-  485:             uint256 tailOffset = arrLength * OneWord;
+  485:             uint256 tailOffset = arrLength << 5;
-  525:             uint256 tailOffset = arrLength * OneWord;
+  525:             uint256 tailOffset = arrLength << 5;
-  617:             uint256 tailOffset = arrLength * OneWord;
+  617:             uint256 tailOffset = arrLength << 5;
-  660:             uint256 tailOffset = arrLength * OneWord;
+  660:             uint256 tailOffset = arrLength << 5;
-  731:             uint256 tailOffset = arrLength * OneWord;
+  731:             uint256 tailOffset = arrLength << 5;

seaport/contracts/lib/ConsiderationEncoder.sol:
-  567:             uint256 headAndTailSize = length * OneWord;
+  567:             uint256 headAndTailSize = length << 5;
-  678:             MemoryPointer srcHeadEnd = srcHead.offset(length * OneWord);
+  678:             MemoryPointer srcHeadEnd = srcHead.offset(length << 5);
```

**POC**

- Run `forge test -m test_shl5`:

```solidity
    function test_shl5(uint256 a) public {
        vm.assume(a <= type(uint256).max / 32); // This is to avoid an overflow
        assert((a * 32) == (a << 5)); // always true 
    }
```

Consider also adding a constant so that the code can be maintainable (`OneWordShiftLength`?)

**yarn profile**

```diff
===============================================================================================
| method                         |          min |           max |           avg |       calls |
===============================================================================================
- | matchAdvancedOrders            | +12 (+0.01%) |     -12 (0%) | -471 (-0.19%) | +2 (+2.67%) |
+ | matchAdvancedOrders            | -84 (-0.05%) |     -12 (0%) | -472 (-0.19%) | +2 (+2.67%) |
- | matchOrders                    | -12 (-0.01%) | -24 (-0.01%) | -234 (-0.09%) | +2 (+1.34%) |
+ | matchOrders                    | -12 (-0.01%) | -24 (-0.01%) | -236 (-0.09%) | +2 (+1.34%) |
```

Added together, the max gas saving counted here is 98.