### PR TITLE
Code4rena gas finding: Optimized operations

### DIFF
--- a/contracts/lib/ZoneInteraction.sol
+++ b/contracts/lib/ZoneInteraction.sol
@@ -143,7 +143,7 @@ contract ZoneInteraction is
     ) internal view returns (bool mustValidate) {
         assembly {
             mustValidate := and(
-                or(eq(orderType, 2), eq(orderType, 3)),
+                and(lt(orderType, 4),gt(orderType, 1)),
                 iszero(eq(caller(), zone))
             )
         }


### PR DESCRIPTION
This one has some sound logic but the `yarn profile` gas report is a little odd (sometimes saving on the min, but to lose on max and average, or saving the opposites but not the min).

Theory says it's a gas optimization, the analysis should be sound AND by adding together the pluses and minuses: this suggestion is still an overall gas optimization in practice. Therefore I do recommend it.

## 5. Optimized operations

*Estimated savings: 3 gas*
*Max savings according to `yarn profile`: 58 gas*

Tested on Remix: The optimized equivalent of `or(eq(a, 2), eq(a, 3))` is `and(lt(a, 4),gt(a, 1))` (saving 3 gas)

**POC:**
The following opcodes happen for `and(lt(a, 4),gt(a, 1))`:

```
      PUSH 4   4
      DUP2    lt(a, 4)
      LT    lt(a, 4)
      PUSH 1   1
      SWAP1    gt(a, 1)
      SWAP2    gt(a, 1)
      GT    gt(a, 1)
      AND    and(lt(a, 4), gt(a, 1))
      SWAP1    and(lt(a, 4), gt(a, 1))
```

The following opcodes happen for `or(eq(a, 2), eq(a, 3))`:

```
      PUSH 2   2
      DUP2    eq(a, 2)
      EQ    eq(a, 2)
      PUSH 3   3
      SWAP2    eq(a, 3)
      SWAP1    eq(a, 3)
      SWAP2    eq(a, 3)
      EQ    eq(a, 3)
      OR    or(eq(a, 2), eq(a, 3))
      SWAP1    or(eq(a, 2), eq(a, 3))
```

As we can see here, an extra SWAP is costing an extra 3 gas compared to the optimized version.
Consider replacing with the following:

```diff
File: ZoneInteraction.sol
140:     function _isRestrictedAndCallerNotZone(
141:         OrderType orderType,
142:         address zone
143:     ) internal view returns (bool mustValidate) {
144:         assembly {
145:             mustValidate := and(
- 146:                 or(eq(orderType, 2), eq(orderType, 3)),
+ 146:                 and(lt(orderType, 4),gt(orderType, 1)),
147:                 iszero(eq(caller(), zone))
148:             )
149:         }
150:     }
```

**yarn profile**

```diff
==============================================================================================
| method                         |          min |          max |           avg |       calls |
==============================================================================================
- | cancel                         |        41219 |        58403 |         54019 |          16 |
+ | cancel                         | +12 (+0.03%) | -12 (-0.02%) |   -3 (-0.01%) |          16 |
- | fulfillAdvancedOrder           | +12 (+0.01%) |       225187 |       -7 (0%) |         182 |
+ | fulfillAdvancedOrder           |        96287 |       225187 |       +2 (0%) |         182 |
- | fulfillBasicOrder              |        91377 |     -12 (0%) |       -5 (0%) |         187 |
+ | fulfillBasicOrder              | -24 (-0.03%) |      1621539 |       -1 (0%) |         187 |
- | matchOrders                    | -12 (-0.01%) | -24 (-0.01%) | -234 (-0.09%) | +2 (+1.34%) |
+ | matchOrders                    | -12 (-0.01%) | -24 (-0.01%) | -241 (-0.09%) | +2 (+1.34%) |
- | validate                       |        53206 |        83915 |       -1 (0%) |          27 |
+ | validate                       |        53206 |        83915 |   -4 (-0.01%) |          27 |
```

Added together, the max gas saving counted here is 58.