### PR TITLE
Code4rena gas finding: Swap conditions for a better happy path

### DIFF
--- a/contracts/helpers/PointerLibraries.sol
+++ b/contracts/helpers/PointerLibraries.sol
@@ -221,7 +221,7 @@ library MemoryPointerLib {
                 dst,
                 size
             )
-            if or(iszero(success), iszero(returndatasize())) {
+            if or(iszero(returndatasize()), iszero(success)) {
                 revert(0, 0)
             }
         }


### PR DESCRIPTION
## 4. Swap conditions for a better happy path

*Estimated savings: 6 gas*
*Max savings according to `yarn profile`: 38 gas*

When a staticcall ends in failure, there will rarely, if ever, be a case of `returndatasize()` being non-zero. However, most often with a staticcall, `success` will be true, while the `returndatasize()` has a higher probability of being 0. The consequence is that, in the current order of conditions, both conditions are more likely to be evaluated. Furthermore, the RETURNDATASIZE opcode costs 2 gas while a MLOAD costs 3 gas. Consider swapping both conditions here for a better happy path:

```diff
File: PointerLibraries.sol
215:         assembly {
216:             let success := staticcall(
217:                 gas(),
218:                 IdentityPrecompileAddress,
219:                 src,
220:                 size,
221:                 dst,
222:                 size
223:             )
- 224:             if or(iszero(success), iszero(returndatasize())) {
+ 224:             if or(iszero(returndatasize()), iszero(success)) {
225:                 revert(0, 0)
226:             }
227:         }
```

**yarn profile**

```diff
==============================================================================================
| method                         |          min |          max |           avg |       calls |
==============================================================================================
- | fulfillAdvancedOrder           | +12 (+0.01%) |       225187 |       -7 (0%) |         182 |
+ | fulfillAdvancedOrder           | +12 (+0.01%) |       225187 |  -31 (-0.02%) |         182 |
- | fulfillAvailableAdvancedOrders |       149965 |       217284 |       +3 (0%) |          22 |
+ | fulfillAvailableAdvancedOrders |       149965 |       217284 |       +2 (0%) |          22 |
- | matchOrders                    | -12 (-0.01%) | -24 (-0.01%) | -234 (-0.09%) | +2 (+1.34%) |
+ | matchOrders                    | -12 (-0.01%) | -24 (-0.01%) | -235 (-0.09%) | +2 (+1.34%) |
- | validate                       |        53206 |        83915 |       -1 (0%) |          27 |
+ | validate                       |        53206 | -12 (-0.01%) |       -1 (0%) |          27 |
```

Added together, the max gas saving counted here is 38.