### PR TITLE
Code4rena gas finding: Pre-decrements cost less than post-decrements

### DIFF
--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -269,7 +269,7 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
                 // Decrement the number of fulfilled orders.
                 // Skip underflow check as the condition before
                 // implies that maximumFulfilled > 0.
-                maximumFulfilled--;
+                --maximumFulfilled;
 
                 // Place the start time for the order on the stack.
                 uint256 startTime = advancedOrder.parameters.startTime;


### PR DESCRIPTION
## 6. Pre-decrements cost less than post-decrements

*Estimated savings: 5 gas per iteration*
*Max savings according to `yarn profile`: 61 gas*

For a `uint256 maximumFulfilled` variable, the following is true with the Optimizer enabled at 10k:

- `--maximumFulfilled` costs 5 gas less than `maximumFulfilled--`

Affected code:  

```diff
File: OrderCombiner.sol
- 272:                 maximumFulfilled--;
+ 272:                 --maximumFulfilled;
```

**yarn profile**

```diff
==============================================================================================
| method                         |          min |          max |           avg |       calls |
==============================================================================================
- | matchAdvancedOrders            | +12 (+0.01%) |     -12 (0%) | -471 (-0.19%) | +2 (+2.67%) |
+ | matchAdvancedOrders            | -36 (-0.02%) |     -12 (0%) | -472 (-0.19%) | +2 (+2.67%) |
- | matchOrders                    | -12 (-0.01%) | -24 (-0.01%) | -234 (-0.09%) | +2 (+1.34%) |
+ | matchOrders                    | -12 (-0.01%) | -24 (-0.01%) | -235 (-0.09%) | +2 (+1.34%) |
- | validate                       |        53206 |        83915 |       -1 (0%) |          27 |
+ | validate                       |        53206 | -12 (-0.01%) |   -4 (-0.01%) |          27 |
```

Added together, the max gas saving counted here is 61.