### PR TITLE
remove unused imports

### DIFF
--- a/contracts/conduit/Conduit.sol
+++ b/contracts/conduit/Conduit.sol
@@ -8,8 +8,8 @@ import { ConduitItemType } from "./lib/ConduitEnums.sol";
 import { TokenTransferrer } from "../lib/TokenTransferrer.sol";
 
 import {
-    ConduitTransfer,
-    ConduitBatch1155Transfer
+    ConduitBatch1155Transfer,
+    ConduitTransfer
 } from "./lib/ConduitStructs.sol";
 
 import {

--- a/contracts/helpers/TransferHelper.sol
+++ b/contracts/helpers/TransferHelper.sol
@@ -16,8 +16,6 @@ import {
     ConduitControllerInterface
 } from "../interfaces/ConduitControllerInterface.sol";
 
-import { Conduit } from "../conduit/Conduit.sol";
-
 import { ConduitTransfer } from "../conduit/lib/ConduitStructs.sol";
 
 import {

--- a/contracts/interfaces/ConduitInterface.sol
+++ b/contracts/interfaces/ConduitInterface.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.13;
 
 import {
-    ConduitTransfer,
-    ConduitBatch1155Transfer
+    ConduitBatch1155Transfer,
+    ConduitTransfer
 } from "../conduit/lib/ConduitStructs.sol";
 
 /**

--- a/contracts/interfaces/ConsiderationEventsAndErrors.sol
+++ b/contracts/interfaces/ConsiderationEventsAndErrors.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.13;
 
 import {
-    SpentItem,
+    OrderParameters,
     ReceivedItem,
-    OrderParameters
+    SpentItem
 } from "../lib/ConsiderationStructs.sol";
 
 /**

--- a/contracts/interfaces/ConsiderationInterface.sol
+++ b/contracts/interfaces/ConsiderationInterface.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.13;
 
 import {
+    AdvancedOrder,
     BasicOrderParameters,
-    OrderComponents,
+    CriteriaResolver,
+    Execution,
     Fulfillment,
     FulfillmentComponent,
-    Execution,
     Order,
-    AdvancedOrder,
-    CriteriaResolver
+    OrderComponents
 } from "../lib/ConsiderationStructs.sol";
 
 /**

--- a/contracts/interfaces/ContractOffererInterface.sol
+++ b/contracts/interfaces/ContractOffererInterface.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.13;
 
 import {
-    SpentItem,
     ReceivedItem,
-    Schema
+    Schema,
+    SpentItem
 } from "../lib/ConsiderationStructs.sol";
 
 /**

--- a/contracts/interfaces/SeaportInterface.sol
+++ b/contracts/interfaces/SeaportInterface.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.13;
 
 import {
+    AdvancedOrder,
     BasicOrderParameters,
-    OrderComponents,
+    CriteriaResolver,
+    Execution,
     Fulfillment,
     FulfillmentComponent,
-    Execution,
     Order,
-    AdvancedOrder,
-    CriteriaResolver
+    OrderComponents
 } from "../lib/ConsiderationStructs.sol";
 
 /**

--- a/contracts/lib/BasicOrderFulfiller.sol
+++ b/contracts/lib/BasicOrderFulfiller.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.17;
 
 import {
-    OrderType,
+    BasicOrderRouteType,
     ItemType,
-    BasicOrderRouteType
+    OrderType
 } from "./ConsiderationEnums.sol";
 
 import { BasicOrderParameters } from "./ConsiderationStructs.sol";

--- a/contracts/lib/BasicOrderFulfiller.sol
+++ b/contracts/lib/BasicOrderFulfiller.sol
@@ -7,14 +7,7 @@ import {
     BasicOrderRouteType
 } from "./ConsiderationEnums.sol";
 
-import {
-    AdditionalRecipient,
-    BasicOrderParameters,
-    OfferItem,
-    ConsiderationItem,
-    SpentItem,
-    ReceivedItem
-} from "./ConsiderationStructs.sol";
+import { BasicOrderParameters } from "./ConsiderationStructs.sol";
 
 import { OrderValidator } from "./OrderValidator.sol";
 

--- a/contracts/lib/Consideration.sol
+++ b/contracts/lib/Consideration.sol
@@ -6,14 +6,14 @@ import {
 } from "../interfaces/ConsiderationInterface.sol";
 
 import {
-    OrderComponents,
-    BasicOrderParameters,
-    Order,
     AdvancedOrder,
+    BasicOrderParameters,
     CriteriaResolver,
+    Execution,
     Fulfillment,
     FulfillmentComponent,
-    Execution
+    Order,
+    OrderComponents
 } from "./ConsiderationStructs.sol";
 
 import { OrderCombiner } from "./OrderCombiner.sol";

--- a/contracts/lib/Consideration.sol
+++ b/contracts/lib/Consideration.sol
@@ -8,10 +8,8 @@ import {
 import {
     OrderComponents,
     BasicOrderParameters,
-    OrderParameters,
     Order,
     AdvancedOrder,
-    OrderStatus,
     CriteriaResolver,
     Fulfillment,
     FulfillmentComponent,

--- a/contracts/lib/ConsiderationDecoder.sol
+++ b/contracts/lib/ConsiderationDecoder.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.17;
 
 import {
-    Order,
-    CriteriaResolver,
     AdvancedOrder,
-    FulfillmentComponent,
-    Fulfillment,
-    OrderParameters,
-    OfferItem,
     ConsiderationItem,
+    CriteriaResolver,
+    Fulfillment,
+    FulfillmentComponent,
+    OfferItem,
+    Order,
+    OrderParameters,
     ReceivedItem
 } from "./ConsiderationStructs.sol";
 

--- a/contracts/lib/ConsiderationDecoder.sol
+++ b/contracts/lib/ConsiderationDecoder.sol
@@ -7,9 +7,7 @@ import {
     AdvancedOrder,
     FulfillmentComponent,
     Fulfillment,
-    OrderComponents,
     OrderParameters,
-    SpentItem,
     OfferItem,
     ConsiderationItem,
     ReceivedItem

--- a/contracts/lib/ConsiderationEncoder.sol
+++ b/contracts/lib/ConsiderationEncoder.sol
@@ -59,11 +59,7 @@ import {
 
 import {
     BasicOrderParameters,
-    Order,
-    Fulfillment,
-    OrderParameters,
-    SpentItem,
-    ReceivedItem
+    OrderParameters
 } from "./ConsiderationStructs.sol";
 
 import {

--- a/contracts/lib/ConsiderationStructs.sol
+++ b/contracts/lib/ConsiderationStructs.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.13;
 
 import {
-    OrderType,
     BasicOrderType,
     ItemType,
+    OrderType,
     Side
 } from "./ConsiderationEnums.sol";
 

--- a/contracts/lib/CriteriaResolution.sol
+++ b/contracts/lib/CriteriaResolution.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.17;
 import { ItemType, Side } from "./ConsiderationEnums.sol";
 
 import {
-    OfferItem,
-    OrderParameters,
     AdvancedOrder,
     CriteriaResolver,
-    MemoryPointer
+    MemoryPointer,
+    OfferItem,
+    OrderParameters
 } from "./ConsiderationStructs.sol";
 
 import {

--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.17;
 import { Side } from "./ConsiderationEnums.sol";
 
 import {
-    ReceivedItem,
     AdvancedOrder,
     Execution,
-    FulfillmentComponent
+    FulfillmentComponent,
+    ReceivedItem
 } from "./ConsiderationStructs.sol";
 
 import {

--- a/contracts/lib/FulfillmentApplier.sol
+++ b/contracts/lib/FulfillmentApplier.sol
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { ItemType, Side } from "./ConsiderationEnums.sol";
+import { Side } from "./ConsiderationEnums.sol";
 
 import {
-    OfferItem,
-    ConsiderationItem,
     ReceivedItem,
-    OrderParameters,
     AdvancedOrder,
     Execution,
     FulfillmentComponent

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -4,15 +4,15 @@ pragma solidity ^0.8.17;
 import { Side, ItemType, OrderType } from "./ConsiderationEnums.sol";
 
 import {
-    OfferItem,
+    AdvancedOrder,
     ConsiderationItem,
-    ReceivedItem,
-    OrderParameters,
+    CriteriaResolver,
+    Execution,
     Fulfillment,
     FulfillmentComponent,
-    Execution,
-    AdvancedOrder,
-    CriteriaResolver
+    OfferItem,
+    OrderParameters,
+    ReceivedItem
 } from "./ConsiderationStructs.sol";
 
 import { OrderFulfiller } from "./OrderFulfiller.sol";

--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -11,7 +11,6 @@ import {
     Fulfillment,
     FulfillmentComponent,
     Execution,
-    Order,
     AdvancedOrder,
     CriteriaResolver
 } from "./ConsiderationStructs.sol";

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -9,7 +9,6 @@ import {
     SpentItem,
     ReceivedItem,
     OrderParameters,
-    Order,
     AdvancedOrder,
     CriteriaResolver
 } from "./ConsiderationStructs.sol";

--- a/contracts/lib/OrderFulfiller.sol
+++ b/contracts/lib/OrderFulfiller.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.17;
 import { ItemType, OrderType } from "./ConsiderationEnums.sol";
 
 import {
-    OfferItem,
-    ConsiderationItem,
-    SpentItem,
-    ReceivedItem,
-    OrderParameters,
     AdvancedOrder,
-    CriteriaResolver
+    ConsiderationItem,
+    CriteriaResolver,
+    OfferItem,
+    OrderParameters,
+    ReceivedItem,
+    SpentItem
 } from "./ConsiderationStructs.sol";
 
 import { BasicOrderFulfiller } from "./BasicOrderFulfiller.sol";

--- a/contracts/lib/OrderValidator.sol
+++ b/contracts/lib/OrderValidator.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.17;
 import { OrderType } from "./ConsiderationEnums.sol";
 
 import {
-    OrderParameters,
-    Order,
     AdvancedOrder,
-    OrderComponents,
-    OrderStatus,
+    ConsiderationItem,
     OfferItem,
-    ConsiderationItem
+    Order,
+    OrderComponents,
+    OrderParameters,
+    OrderStatus
 } from "./ConsiderationStructs.sol";
 
 import {

--- a/contracts/lib/OrderValidator.sol
+++ b/contracts/lib/OrderValidator.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { OrderType, ItemType } from "./ConsiderationEnums.sol";
+import { OrderType } from "./ConsiderationEnums.sol";
 
 import {
     OrderParameters,
@@ -9,7 +9,6 @@ import {
     AdvancedOrder,
     OrderComponents,
     OrderStatus,
-    CriteriaResolver,
     OfferItem,
     ConsiderationItem
 } from "./ConsiderationStructs.sol";

--- a/contracts/lib/SignatureVerification.sol
+++ b/contracts/lib/SignatureVerification.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { EIP1271Interface } from "../interfaces/EIP1271Interface.sol";
-
 import {
     SignatureVerificationErrors
 } from "../interfaces/SignatureVerificationErrors.sol";

--- a/contracts/lib/ZoneInteraction.sol
+++ b/contracts/lib/ZoneInteraction.sol
@@ -5,8 +5,8 @@ import { OrderType } from "./ConsiderationEnums.sol";
 
 import {
     AdvancedOrder,
-    OrderParameters,
-    BasicOrderParameters
+    BasicOrderParameters,
+    OrderParameters
 } from "./ConsiderationStructs.sol";
 
 import { ZoneInteractionErrors } from "../interfaces/ZoneInteractionErrors.sol";

--- a/contracts/test/ConduitControllerMock.sol
+++ b/contracts/test/ConduitControllerMock.sol
@@ -7,8 +7,6 @@ import {
 
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 
-import { ConduitController } from "../conduit/ConduitController.sol";
-
 import { ConduitMock } from "../test/ConduitMock.sol";
 
 import { ConduitMockInvalidMagic } from "../test/ConduitMockInvalidMagic.sol";

--- a/contracts/test/ConduitMock.sol
+++ b/contracts/test/ConduitMock.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.13;
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 
 import {
-    ConduitTransfer,
-    ConduitBatch1155Transfer
+    ConduitBatch1155Transfer,
+    ConduitTransfer
 } from "../conduit/lib/ConduitStructs.sol";
 
 contract ConduitMock is ConduitInterface {

--- a/contracts/test/ConduitMock.sol
+++ b/contracts/test/ConduitMock.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.13;
 
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 
-import { TokenTransferrer } from "../lib/TokenTransferrer.sol";
-
 import {
     ConduitTransfer,
     ConduitBatch1155Transfer

--- a/contracts/test/ConduitMockInvalidMagic.sol
+++ b/contracts/test/ConduitMockInvalidMagic.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.13;
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 
 import {
-    ConduitTransfer,
-    ConduitBatch1155Transfer
+    ConduitBatch1155Transfer,
+    ConduitTransfer
 } from "../conduit/lib/ConduitStructs.sol";
 
 contract ConduitMockInvalidMagic is ConduitInterface {

--- a/contracts/test/ConduitMockInvalidMagic.sol
+++ b/contracts/test/ConduitMockInvalidMagic.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.13;
 
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 
-import { TokenTransferrer } from "../lib/TokenTransferrer.sol";
-
 import {
     ConduitTransfer,
     ConduitBatch1155Transfer

--- a/contracts/test/ConduitMockRevertBytes.sol
+++ b/contracts/test/ConduitMockRevertBytes.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.13;
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 
 import {
-    ConduitTransfer,
-    ConduitBatch1155Transfer
+    ConduitBatch1155Transfer,
+    ConduitTransfer
 } from "../conduit/lib/ConduitStructs.sol";
 
 contract ConduitMockRevertBytes is ConduitInterface {

--- a/contracts/test/ConduitMockRevertBytes.sol
+++ b/contracts/test/ConduitMockRevertBytes.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.13;
 
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 
-import { TokenTransferrer } from "../lib/TokenTransferrer.sol";
-
 import {
     ConduitTransfer,
     ConduitBatch1155Transfer

--- a/contracts/test/ConduitMockRevertNoReason.sol
+++ b/contracts/test/ConduitMockRevertNoReason.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.13;
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 
 import {
-    ConduitTransfer,
-    ConduitBatch1155Transfer
+    ConduitBatch1155Transfer,
+    ConduitTransfer
 } from "../conduit/lib/ConduitStructs.sol";
 
 contract ConduitMockRevertNoReason is ConduitInterface {

--- a/contracts/test/ConduitMockRevertNoReason.sol
+++ b/contracts/test/ConduitMockRevertNoReason.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.13;
 
 import { ConduitInterface } from "../interfaces/ConduitInterface.sol";
 
-import { TokenTransferrer } from "../lib/TokenTransferrer.sol";
-
 import {
     ConduitTransfer,
     ConduitBatch1155Transfer

--- a/contracts/test/ERC721ReceiverMock.sol
+++ b/contracts/test/ERC721ReceiverMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
+
 import { IERC721Receiver } from "../interfaces/IERC721Receiver.sol";
 
 contract ERC721ReceiverMock is IERC721Receiver {

--- a/contracts/test/TestBadContractOfferer.sol
+++ b/contracts/test/TestBadContractOfferer.sol
@@ -10,9 +10,9 @@ import {
 import { ItemType } from "../lib/ConsiderationEnums.sol";
 
 import {
-    SpentItem,
     ReceivedItem,
-    Schema
+    Schema,
+    SpentItem
 } from "../lib/ConsiderationStructs.sol";
 
 contract TestBadContractOfferer is ContractOffererInterface {

--- a/contracts/test/TestBadContractOfferer.sol
+++ b/contracts/test/TestBadContractOfferer.sol
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {
-    ERC721Interface,
-    ERC1155Interface
-} from "../interfaces/AbridgedTokenInterfaces.sol";
+import { ERC721Interface } from "../interfaces/AbridgedTokenInterfaces.sol";
 
 import {
     ContractOffererInterface
 } from "../interfaces/ContractOffererInterface.sol";
 
-import { ItemType, Side } from "../lib/ConsiderationEnums.sol";
+import { ItemType } from "../lib/ConsiderationEnums.sol";
 
 import {
     SpentItem,

--- a/contracts/test/TestContractOfferer.sol
+++ b/contracts/test/TestContractOfferer.sol
@@ -14,9 +14,9 @@ import {
 import { ItemType } from "../lib/ConsiderationEnums.sol";
 
 import {
-    SpentItem,
     ReceivedItem,
-    Schema
+    Schema,
+    SpentItem
 } from "../lib/ConsiderationStructs.sol";
 
 /**

--- a/contracts/test/TestContractOffererNativeToken.sol
+++ b/contracts/test/TestContractOffererNativeToken.sol
@@ -13,9 +13,9 @@ import {
 import { ItemType } from "../lib/ConsiderationEnums.sol";
 
 import {
-    SpentItem,
     ReceivedItem,
-    Schema
+    Schema,
+    SpentItem
 } from "../lib/ConsiderationStructs.sol";
 
 /**

--- a/contracts/test/TestContractOffererNativeToken.sol
+++ b/contracts/test/TestContractOffererNativeToken.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.13;
 
 import {
-    ERC20Interface,
     ERC721Interface,
     ERC1155Interface
 } from "../interfaces/AbridgedTokenInterfaces.sol";

--- a/contracts/test/TestERC1155.sol
+++ b/contracts/test/TestERC1155.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-import "@rari-capital/solmate/src/tokens/ERC1155.sol";
+import { ERC1155 } from "@rari-capital/solmate/src/tokens/ERC1155.sol";
 
 // Used for minting test ERC1155s in our tests
 contract TestERC1155 is ERC1155 {

--- a/contracts/test/TestERC20.sol
+++ b/contracts/test/TestERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-import "@rari-capital/solmate/src/tokens/ERC20.sol";
+import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 // Used for minting test ERC20s in our tests
 contract TestERC20 is ERC20("Test20", "TST20", 18) {

--- a/contracts/test/TestERC20NotOk.sol
+++ b/contracts/test/TestERC20NotOk.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-import "@rari-capital/solmate/src/tokens/ERC20.sol";
+import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 // Used for minting test ERC20s in our tests.
 contract TestERC20NotOk is ERC20("Test20NotOk", "TST20NO", 18) {

--- a/contracts/test/TestERC20Panic.sol
+++ b/contracts/test/TestERC20Panic.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import "@rari-capital/solmate/src/tokens/ERC20.sol";
+import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 contract TestERC20Panic is ERC20("TestPanic", "PANIC", 18) {
     function mint(address to, uint256 amount) external returns (bool) {

--- a/contracts/test/TestERC20Revert.sol
+++ b/contracts/test/TestERC20Revert.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import "@rari-capital/solmate/src/tokens/ERC20.sol";
+import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 contract TestERC20Revert is ERC20("TestRevert", "REVERT", 18) {
     function mint(address to, uint256 amount) external {

--- a/contracts/test/TestERC721.sol
+++ b/contracts/test/TestERC721.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-import "@rari-capital/solmate/src/tokens/ERC721.sol";
+import { ERC721 } from "@rari-capital/solmate/src/tokens/ERC721.sol";
 
 // Used for minting test ERC721s in our tests
 contract TestERC721 is ERC721("Test721", "TST721") {

--- a/contracts/test/TestInvalidContractOfferer.sol
+++ b/contracts/test/TestInvalidContractOfferer.sol
@@ -1,18 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {
-    ERC20Interface,
-    ERC721Interface,
-    ERC1155Interface
-} from "../interfaces/AbridgedTokenInterfaces.sol";
-
-import {
-    ContractOffererInterface
-} from "../interfaces/ContractOffererInterface.sol";
-
-import { ItemType } from "../lib/ConsiderationEnums.sol";
-
 import { SpentItem, ReceivedItem } from "../lib/ConsiderationStructs.sol";
 
 import { TestContractOfferer } from "./TestContractOfferer.sol";

--- a/contracts/test/TestInvalidContractOfferer.sol
+++ b/contracts/test/TestInvalidContractOfferer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { SpentItem, ReceivedItem } from "../lib/ConsiderationStructs.sol";
+import { ReceivedItem, SpentItem } from "../lib/ConsiderationStructs.sol";
 
 import { TestContractOfferer } from "./TestContractOfferer.sol";
 

--- a/contracts/test/TestInvalidContractOffererRatifyOrder.sol
+++ b/contracts/test/TestInvalidContractOffererRatifyOrder.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { SpentItem, ReceivedItem } from "../lib/ConsiderationStructs.sol";
+import { ReceivedItem, SpentItem } from "../lib/ConsiderationStructs.sol";
 
 import { TestContractOfferer } from "./TestContractOfferer.sol";
 

--- a/contracts/test/TestPostExecution.sol
+++ b/contracts/test/TestPostExecution.sol
@@ -8,8 +8,6 @@ import { ERC721Interface } from "../interfaces/AbridgedTokenInterfaces.sol";
 import { ItemType } from "../lib/ConsiderationEnums.sol";
 
 import {
-    AdvancedOrder,
-    CriteriaResolver,
     ReceivedItem,
     ZoneParameters,
     Schema

--- a/contracts/test/TestPostExecution.sol
+++ b/contracts/test/TestPostExecution.sol
@@ -9,8 +9,8 @@ import { ItemType } from "../lib/ConsiderationEnums.sol";
 
 import {
     ReceivedItem,
-    ZoneParameters,
-    Schema
+    Schema,
+    ZoneParameters
 } from "../lib/ConsiderationStructs.sol";
 
 contract TestPostExecution is ZoneInterface {

--- a/contracts/test/TestZone.sol
+++ b/contracts/test/TestZone.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import { ZoneInterface } from "../interfaces/ZoneInterface.sol";
 
-import { ZoneParameters, Schema } from "../lib/ConsiderationStructs.sol";
+import { Schema, ZoneParameters } from "../lib/ConsiderationStructs.sol";
 
 contract TestZone is ZoneInterface {
     function validateOrder(

--- a/contracts/test/TestZone.sol
+++ b/contracts/test/TestZone.sol
@@ -3,14 +3,7 @@ pragma solidity ^0.8.13;
 
 import { ZoneInterface } from "../interfaces/ZoneInterface.sol";
 
-import {
-    AdvancedOrder,
-    CriteriaResolver,
-    OfferItem,
-    ConsiderationItem,
-    ZoneParameters,
-    Schema
-} from "../lib/ConsiderationStructs.sol";
+import { ZoneParameters, Schema } from "../lib/ConsiderationStructs.sol";
 
 contract TestZone is ZoneInterface {
     function validateOrder(

--- a/contracts/zones/PausableZone.sol
+++ b/contracts/zones/PausableZone.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.13;
 
 import { ZoneInterface } from "../interfaces/ZoneInterface.sol";
-import { ZoneInteractionErrors } from "../interfaces/ZoneInteractionErrors.sol";
 
 import {
     PausableZoneEventsAndErrors
@@ -17,8 +16,6 @@ import {
     OrderComponents,
     Fulfillment,
     Execution,
-    OfferItem,
-    ConsiderationItem,
     ZoneParameters,
     Schema
 } from "../lib/ConsiderationStructs.sol";

--- a/contracts/zones/PausableZone.sol
+++ b/contracts/zones/PausableZone.sol
@@ -12,12 +12,12 @@ import { SeaportInterface } from "../interfaces/SeaportInterface.sol";
 import {
     AdvancedOrder,
     CriteriaResolver,
+    Execution,
+    Fulfillment,
     Order,
     OrderComponents,
-    Fulfillment,
-    Execution,
-    ZoneParameters,
-    Schema
+    Schema,
+    ZoneParameters
 } from "../lib/ConsiderationStructs.sol";
 
 import { PausableZoneInterface } from "./interfaces/PausableZoneInterface.sol";

--- a/contracts/zones/PausableZoneController.sol
+++ b/contracts/zones/PausableZoneController.sol
@@ -12,12 +12,12 @@ import {
 } from "./interfaces/PausableZoneEventsAndErrors.sol";
 
 import {
-    Order,
-    Fulfillment,
-    OrderComponents,
     AdvancedOrder,
     CriteriaResolver,
-    Execution
+    Execution,
+    Fulfillment,
+    Order,
+    OrderComponents
 } from "../lib/ConsiderationStructs.sol";
 
 import { SeaportInterface } from "../interfaces/SeaportInterface.sol";

--- a/contracts/zones/interfaces/PausableZoneControllerInterface.sol
+++ b/contracts/zones/interfaces/PausableZoneControllerInterface.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.13;
 
 import {
-    Order,
-    Fulfillment,
-    OrderComponents,
     AdvancedOrder,
     CriteriaResolver,
-    Execution
+    Execution,
+    Fulfillment,
+    Order,
+    OrderComponents
 } from "../../lib/ConsiderationStructs.sol";
 
 import { SeaportInterface } from "../../interfaces/SeaportInterface.sol";

--- a/contracts/zones/interfaces/PausableZoneInterface.sol
+++ b/contracts/zones/interfaces/PausableZoneInterface.sol
@@ -6,10 +6,10 @@ import { SeaportInterface } from "../../interfaces/SeaportInterface.sol";
 import {
     AdvancedOrder,
     CriteriaResolver,
-    Order,
-    OrderComponents,
+    Execution,
     Fulfillment,
-    Execution
+    Order,
+    OrderComponents
 } from "../../lib/ConsiderationStructs.sol";
 
 /**

--- a/reference/ReferenceConsideration.sol
+++ b/reference/ReferenceConsideration.sol
@@ -8,15 +8,15 @@ import {
 import { OrderType } from "../contracts/lib/ConsiderationEnums.sol";
 
 import {
-    OrderComponents,
-    BasicOrderParameters,
-    OrderParameters,
-    Order,
     AdvancedOrder,
+    BasicOrderParameters,
     CriteriaResolver,
+    Execution,
     Fulfillment,
     FulfillmentComponent,
-    Execution
+    Order,
+    OrderComponents,
+    OrderParameters
 } from "../contracts/lib/ConsiderationStructs.sol";
 
 import { ReferenceOrderCombiner } from "./lib/ReferenceOrderCombiner.sol";

--- a/reference/ReferenceConsideration.sol
+++ b/reference/ReferenceConsideration.sol
@@ -13,7 +13,6 @@ import {
     OrderParameters,
     Order,
     AdvancedOrder,
-    OrderStatus,
     CriteriaResolver,
     Fulfillment,
     FulfillmentComponent,
@@ -22,10 +21,7 @@ import {
 
 import { ReferenceOrderCombiner } from "./lib/ReferenceOrderCombiner.sol";
 
-import {
-    OrderToExecute,
-    AccumulatorStruct
-} from "./lib/ReferenceConsiderationStructs.sol";
+import { OrderToExecute } from "./lib/ReferenceConsiderationStructs.sol";
 
 /**
  * @title ReferenceConsideration

--- a/reference/conduit/ReferenceConduit.sol
+++ b/reference/conduit/ReferenceConduit.sol
@@ -12,8 +12,8 @@ import {
 } from "../lib/ReferenceTokenTransferrer.sol";
 
 import {
-    ConduitTransfer,
-    ConduitBatch1155Transfer
+    ConduitBatch1155Transfer,
+    ConduitTransfer
 } from "../../contracts/conduit/lib/ConduitStructs.sol";
 
 /**

--- a/reference/lib/ReferenceBasicOrderFulfiller.sol
+++ b/reference/lib/ReferenceBasicOrderFulfiller.sol
@@ -2,19 +2,19 @@
 pragma solidity ^0.8.13;
 
 import {
-    OrderType,
+    BasicOrderRouteType,
     BasicOrderType,
     ItemType,
-    BasicOrderRouteType
+    OrderType
 } from "../../contracts/lib/ConsiderationEnums.sol";
 
 import {
     AdditionalRecipient,
     BasicOrderParameters,
-    OfferItem,
     ConsiderationItem,
-    SpentItem,
-    ReceivedItem
+    OfferItem,
+    ReceivedItem,
+    SpentItem
 } from "../../contracts/lib/ConsiderationStructs.sol";
 
 import {

--- a/reference/lib/ReferenceConsiderationBase.sol
+++ b/reference/lib/ReferenceConsiderationBase.sol
@@ -9,8 +9,6 @@ import {
     ConsiderationEventsAndErrors
 } from "../../contracts/interfaces/ConsiderationEventsAndErrors.sol";
 
-import { OrderStatus } from "../../contracts/lib/ConsiderationStructs.sol";
-
 import {
     ReentrancyErrors
 } from "../../contracts/interfaces/ReentrancyErrors.sol";

--- a/reference/lib/ReferenceConsiderationStructs.sol
+++ b/reference/lib/ReferenceConsiderationStructs.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.13;
 
 import {
-    OrderType,
-    ItemType
+    ItemType,
+    OrderType
 } from "../../contracts/lib/ConsiderationEnums.sol";
 
 import {
-    SpentItem,
-    ReceivedItem
+    ReceivedItem,
+    SpentItem
 } from "../../contracts/lib/ConsiderationStructs.sol";
 
 import {

--- a/reference/lib/ReferenceCriteriaResolution.sol
+++ b/reference/lib/ReferenceCriteriaResolution.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.13;
 import { ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 
 import {
-    OfferItem,
-    ConsiderationItem,
-    OrderParameters,
     AdvancedOrder,
+    ConsiderationItem,
     CriteriaResolver,
-    SpentItem,
-    ReceivedItem
+    OfferItem,
+    OrderParameters,
+    ReceivedItem,
+    SpentItem
 } from "../../contracts/lib/ConsiderationStructs.sol";
 
 import { OrderToExecute } from "./ReferenceConsiderationStructs.sol";

--- a/reference/lib/ReferenceExecutor.sol
+++ b/reference/lib/ReferenceExecutor.sol
@@ -1,12 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {
-    ERC20Interface,
-    ERC721Interface,
-    ERC1155Interface
-} from "../../contracts/interfaces/AbridgedTokenInterfaces.sol";
-
 import { ConduitItemType } from "../../contracts/conduit/lib/ConduitEnums.sol";
 
 import {
@@ -14,8 +8,7 @@ import {
 } from "../../contracts/interfaces/ConduitInterface.sol";
 
 import {
-    ConduitTransfer,
-    ConduitBatch1155Transfer
+    ConduitTransfer
 } from "../../contracts/conduit/lib/ConduitStructs.sol";
 
 import { ItemType } from "../../contracts/lib/ConsiderationEnums.sol";

--- a/reference/lib/ReferenceFulfillmentApplier.sol
+++ b/reference/lib/ReferenceFulfillmentApplier.sol
@@ -4,13 +4,9 @@ pragma solidity ^0.8.13;
 import { ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 
 import {
-    OfferItem,
-    ConsiderationItem,
-    ReceivedItem,
-    OrderParameters,
-    AdvancedOrder,
     Execution,
     FulfillmentComponent,
+    ReceivedItem,
     SpentItem
 } from "../../contracts/lib/ConsiderationStructs.sol";
 
@@ -22,6 +18,7 @@ import {
 import {
     FulfillmentApplicationErrors
 } from "../../contracts/interfaces/FulfillmentApplicationErrors.sol";
+
 import {
     TokenTransferrerErrors
 } from "../../contracts/interfaces/TokenTransferrerErrors.sol";

--- a/reference/lib/ReferenceGenerateOrderReturndataDecoder.sol
+++ b/reference/lib/ReferenceGenerateOrderReturndataDecoder.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.13;
 
 import {
-    SpentItem,
-    ReceivedItem
+    ReceivedItem,
+    SpentItem
 } from "../../contracts/lib/ConsiderationStructs.sol";
 
 contract ReferenceGenerateOrderReturndataDecoder {

--- a/reference/lib/ReferenceOrderCombiner.sol
+++ b/reference/lib/ReferenceOrderCombiner.sol
@@ -2,24 +2,22 @@
 pragma solidity ^0.8.13;
 
 import {
-    Side,
     ItemType,
-    OrderType
+    OrderType,
+    Side
 } from "../../contracts/lib/ConsiderationEnums.sol";
 
 import {
-    AdditionalRecipient,
-    OfferItem,
+    AdvancedOrder,
     ConsiderationItem,
-    SpentItem,
-    ReceivedItem,
-    OrderParameters,
+    CriteriaResolver,
+    Execution,
     Fulfillment,
     FulfillmentComponent,
-    Execution,
-    Order,
-    AdvancedOrder,
-    CriteriaResolver
+    OfferItem,
+    OrderParameters,
+    ReceivedItem,
+    SpentItem
 } from "../../contracts/lib/ConsiderationStructs.sol";
 
 import {

--- a/reference/lib/ReferenceOrderFulfiller.sol
+++ b/reference/lib/ReferenceOrderFulfiller.sol
@@ -2,19 +2,19 @@
 pragma solidity ^0.8.13;
 
 import {
-    OrderType,
-    ItemType
+    ItemType,
+    OrderType
 } from "../../contracts/lib/ConsiderationEnums.sol";
 
 import {
-    OfferItem,
-    ConsiderationItem,
-    SpentItem,
-    ReceivedItem,
-    OrderParameters,
-    Order,
     AdvancedOrder,
-    CriteriaResolver
+    ConsiderationItem,
+    CriteriaResolver,
+    OfferItem,
+    Order,
+    OrderParameters,
+    ReceivedItem,
+    SpentItem
 } from "../../contracts/lib/ConsiderationStructs.sol";
 
 import {

--- a/reference/lib/ReferenceOrderValidator.sol
+++ b/reference/lib/ReferenceOrderValidator.sol
@@ -7,16 +7,15 @@ import {
 } from "../../contracts/lib/ConsiderationEnums.sol";
 
 import {
-    OrderParameters,
-    Order,
     AdvancedOrder,
-    OrderComponents,
-    OrderStatus,
-    CriteriaResolver,
-    OfferItem,
     ConsiderationItem,
-    SpentItem,
-    ReceivedItem
+    OfferItem,
+    Order,
+    OrderComponents,
+    OrderParameters,
+    OrderStatus,
+    ReceivedItem,
+    SpentItem
 } from "../../contracts/lib/ConsiderationStructs.sol";
 
 import { ReferenceExecutor } from "./ReferenceExecutor.sol";
@@ -26,6 +25,7 @@ import { ReferenceZoneInteraction } from "./ReferenceZoneInteraction.sol";
 import {
     ContractOffererInterface
 } from "../../contracts/interfaces/ContractOffererInterface.sol";
+
 import {
     ReferenceGenerateOrderReturndataDecoder
 } from "./ReferenceGenerateOrderReturndataDecoder.sol";

--- a/reference/lib/ReferenceReentrancyGuard.sol
+++ b/reference/lib/ReferenceReentrancyGuard.sol
@@ -10,8 +10,8 @@ import {
 } from "../../contracts/interfaces/ReentrancyErrors.sol";
 
 import {
-    _ENTERED,
     _ENTERED_AND_ACCEPTING_NATIVE_TOKENS,
+    _ENTERED,
     _NOT_ENTERED
 } from "../../contracts/lib/ConsiderationConstants.sol";
 

--- a/reference/lib/ReferenceZoneInteraction.sol
+++ b/reference/lib/ReferenceZoneInteraction.sol
@@ -8,20 +8,17 @@ import {
 } from "../../contracts/interfaces/ContractOffererInterface.sol";
 
 import {
-    OrderType,
-    ItemType
+    ItemType,
+    OrderType
 } from "../../contracts/lib/ConsiderationEnums.sol";
 
 import {
+    AdditionalRecipient,
     AdvancedOrder,
-    OrderParameters,
-    CriteriaResolver,
     BasicOrderParameters,
-    OrderParameters,
-    ZoneParameters,
-    SpentItem,
     ReceivedItem,
-    AdditionalRecipient
+    SpentItem,
+    ZoneParameters
 } from "../../contracts/lib/ConsiderationStructs.sol";
 
 import { OrderToExecute } from "./ReferenceConsiderationStructs.sol";

--- a/test/foundry/FulfillAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAdvancedOrder.t.sol
@@ -2,25 +2,28 @@
 
 pragma solidity ^0.8.17;
 
-import { OneWord } from "../../contracts/lib/ConsiderationConstants.sol";
 import {
     OrderType,
     ItemType
 } from "../../contracts/lib/ConsiderationEnums.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     AdvancedOrder,
     OrderParameters,
     OrderComponents,
     CriteriaResolver
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { ERC1155Recipient } from "./utils/ERC1155Recipient.sol";
+
 import {
     ConsiderationEventsAndErrors
 } from "../../contracts/interfaces/ConsiderationEventsAndErrors.sol";
+
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
 
 contract FulfillAdvancedOrder is BaseOrderTest {

--- a/test/foundry/FulfillAdvancedOrderCriteria.t.sol
+++ b/test/foundry/FulfillAdvancedOrderCriteria.t.sol
@@ -3,16 +3,20 @@
 pragma solidity ^0.8.17;
 
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
+
 import { Merkle } from "murky/Merkle.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     CriteriaResolver,
     OfferItem,
     OrderComponents,
     AdvancedOrder
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import { ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 
 contract FulfillAdvancedOrderCriteria is BaseOrderTest {

--- a/test/foundry/FulfillAvailableAdvancedOrder.t.sol
+++ b/test/foundry/FulfillAvailableAdvancedOrder.t.sol
@@ -4,35 +4,27 @@ pragma solidity ^0.8.17;
 
 import {
     OrderType,
-    BasicOrderType,
-    ItemType,
-    Side
+    ItemType
 } from "../../contracts/lib/ConsiderationEnums.sol";
-import {
-    AdditionalRecipient
-} from "../../contracts/lib/ConsiderationStructs.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
-    Order,
     AdvancedOrder,
     OfferItem,
     OrderParameters,
     ConsiderationItem,
     OrderComponents,
-    BasicOrderParameters,
     FulfillmentComponent,
     CriteriaResolver
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { TestERC721 } from "../../contracts/test/TestERC721.sol";
-import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../contracts/test/TestERC20.sol";
-import { ProxyRegistry } from "./interfaces/ProxyRegistry.sol";
-import { OwnableDelegateProxy } from "./interfaces/OwnableDelegateProxy.sol";
-import { ERC1155Recipient } from "./utils/ERC1155Recipient.sol";
+
 import { stdError } from "forge-std/Test.sol";
+
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
 
 contract FulfillAvailableAdvancedOrder is BaseOrderTest {

--- a/test/foundry/FulfillAvailableAdvancedOrderCriteria.t.sol
+++ b/test/foundry/FulfillAvailableAdvancedOrderCriteria.t.sol
@@ -3,10 +3,13 @@
 pragma solidity ^0.8.17;
 
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
+
 import { Merkle } from "murky/Merkle.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     CriteriaResolver,
     OfferItem,
@@ -14,6 +17,7 @@ import {
     AdvancedOrder,
     FulfillmentComponent
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import { ItemType, Side } from "../../contracts/lib/ConsiderationEnums.sol";
 
 contract FulfillAdvancedOrderCriteria is BaseOrderTest {

--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -5,33 +5,24 @@ pragma solidity ^0.8.17;
 
 import {
     OrderType,
-    BasicOrderType,
-    ItemType,
-    Side
+    BasicOrderType
 } from "../../contracts/lib/ConsiderationEnums.sol";
-import {
-    AdditionalRecipient,
-    Order
-} from "../../contracts/lib/ConsiderationStructs.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
-    OfferItem,
-    ConsiderationItem,
+    AdditionalRecipient,
+    Order,
     OrderComponents,
     BasicOrderParameters
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { TestERC721 } from "../../contracts/test/TestERC721.sol";
-import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../contracts/test/TestERC20.sol";
+
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
-import { OrderParameters } from "./utils/reentrancy/ReentrantStructs.sol";
-import {
-    PausableZoneController
-} from "../../contracts/zones/PausableZoneController.sol";
-import { PausableZone } from "../../contracts/zones/PausableZone.sol";
+
 import {
     ConsiderationEventsAndErrors
 } from "../../contracts/interfaces/ConsiderationEventsAndErrors.sol";

--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -4,30 +4,23 @@ pragma solidity ^0.8.17;
 
 import {
     OrderType,
-    BasicOrderType,
-    ItemType,
-    Side
+    ItemType    
 } from "../../contracts/lib/ConsiderationEnums.sol";
-import {
-    AdditionalRecipient
-} from "../../contracts/lib/ConsiderationStructs.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     Order,
     OfferItem,
     OrderParameters,
     ConsiderationItem,
-    OrderComponents,
-    BasicOrderParameters
+    OrderComponents
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { TestERC721 } from "../../contracts/test/TestERC721.sol";
-import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../contracts/test/TestERC20.sol";
-import { ProxyRegistry } from "./interfaces/ProxyRegistry.sol";
-import { OwnableDelegateProxy } from "./interfaces/OwnableDelegateProxy.sol";
+
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
 
 contract FulfillOrderTest is BaseOrderTest {

--- a/test/foundry/FullfillAvailableOrder.t.sol
+++ b/test/foundry/FullfillAvailableOrder.t.sol
@@ -4,27 +4,26 @@ pragma solidity ^0.8.17;
 
 import {
     OrderType,
-    BasicOrderType,
-    ItemType,
-    Side
+    ItemType
 } from "../../contracts/lib/ConsiderationEnums.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     Order,
     OfferItem,
     OrderParameters,
     ConsiderationItem,
     OrderComponents,
-    BasicOrderParameters,
     FulfillmentComponent
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { TestERC721 } from "../../contracts/test/TestERC721.sol";
-import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../contracts/test/TestERC20.sol";
+
 import { stdError } from "forge-std/Test.sol";
+
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
 
 contract FulfillAvailableOrder is BaseOrderTest {

--- a/test/foundry/MatchAdvancedOrder.t.sol
+++ b/test/foundry/MatchAdvancedOrder.t.sol
@@ -6,10 +6,11 @@ import {
     OrderType,
     ItemType
 } from "../../contracts/lib/ConsiderationEnums.sol";
-import { Order } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     AdvancedOrder,
     OfferItem,
@@ -19,8 +20,11 @@ import {
     CriteriaResolver,
     FulfillmentComponent
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
+
 import { stdError } from "forge-std/Test.sol";
+
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
 
 contract MatchAdvancedOrder is BaseOrderTest {

--- a/test/foundry/MatchAdvancedOrderUnspentOffer.t.sol
+++ b/test/foundry/MatchAdvancedOrderUnspentOffer.t.sol
@@ -2,27 +2,24 @@
 
 pragma solidity ^0.8.17;
 
-import {
-    OrderType,
-    ItemType
-} from "../../contracts/lib/ConsiderationEnums.sol";
+import { ItemType } from "../../contracts/lib/ConsiderationEnums.sol";
+
 import { Order } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     AdvancedOrder,
     OfferItem,
-    OrderParameters,
     ConsiderationItem,
-    OrderComponents,
     CriteriaResolver,
-    Fulfillment,
-    FulfillmentComponent
+    Fulfillment  
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { stdError } from "forge-std/Test.sol";
-import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
+
 import { Vm } from "forge-std/Vm.sol";
 
 contract MatchOrderUnspentOfferTest is BaseOrderTest {

--- a/test/foundry/MatchOrders.t.sol
+++ b/test/foundry/MatchOrders.t.sol
@@ -6,26 +6,22 @@ import {
     OrderType,
     ItemType
 } from "../../contracts/lib/ConsiderationEnums.sol";
+
 import {
     Order,
-    Fulfillment,
-    OfferItem,
     OrderParameters,
-    ConsiderationItem,
     OrderComponents,
     FulfillmentComponent
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
-import {
-    ConsiderationEventsAndErrors
-} from "../../contracts/interfaces/ConsiderationEventsAndErrors.sol";
+
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
-import { TestERC721 } from "../../contracts/test/TestERC721.sol";
-import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../contracts/test/TestERC20.sol";
+
 import { ArithmeticUtil } from "./utils/ArithmeticUtil.sol";
+
 import { stdError } from "forge-std/Test.sol";
 
 contract MatchOrders is BaseOrderTest {

--- a/test/foundry/NonReentrant.t.sol
+++ b/test/foundry/NonReentrant.t.sol
@@ -7,9 +7,11 @@ import {
     ItemType,
     Side
 } from "../../contracts/lib/ConsiderationEnums.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     AdditionalRecipient,
     Fulfillment,
@@ -17,17 +19,20 @@ import {
     ConsiderationItem,
     FulfillmentComponent,
     OrderComponents,
+    OrderParameters,
     AdvancedOrder,
     BasicOrderParameters,
     Order
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
+
 import {
     EntryPoint,
     ReentryPoint
 } from "./utils/reentrancy/ReentrantEnums.sol";
+
 import {
-    OrderParameters,
     CriteriaResolver
 } from "./utils/reentrancy/ReentrantStructs.sol";
 

--- a/test/foundry/SignatureVerification.t.sol
+++ b/test/foundry/SignatureVerification.t.sol
@@ -4,9 +4,11 @@ pragma solidity ^0.8.17;
 import {
     SignatureVerification
 } from "../../contracts/lib/SignatureVerification.sol";
+
 import {
     ReferenceSignatureVerification
 } from "../../reference/lib/ReferenceSignatureVerification.sol";
+
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 
 contract SignatureVerifierLogic is BaseOrderTest, SignatureVerification {

--- a/test/foundry/TestNewHelpers.t.sol
+++ b/test/foundry/TestNewHelpers.t.sol
@@ -2,18 +2,20 @@
 pragma solidity ^0.8.17;
 
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
+
 import {
     ConsiderationInterface
 } from "../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     BasicOrderParameters,
     Order,
-    AdvancedOrder,
     CriteriaResolver,
     Fulfillment,
     OrderParameters,
     FulfillmentComponent
 } from "../../contracts/lib/ConsiderationStructs.sol";
+
 import { BasicOrderType } from "../../contracts/lib/ConsiderationEnums.sol";
 
 contract TestNewHelpersTest is BaseOrderTest {

--- a/test/foundry/TokenTransferrer.t.sol
+++ b/test/foundry/TokenTransferrer.t.sol
@@ -1,18 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { BaseConsiderationTest } from "./utils/BaseConsiderationTest.sol";
 import {
     ConduitTransfer,
     ConduitBatch1155Transfer,
     ConduitItemType
 } from "../../contracts/conduit/lib/ConduitStructs.sol";
+
 import { TestERC20Revert } from "../../contracts/test/TestERC20Revert.sol";
+
 import { TestERC20NotOk } from "../../contracts/test/TestERC20NotOk.sol";
+
 import { TestERC721Revert } from "../../contracts/test/TestERC721Revert.sol";
+
 import { TestERC1155Revert } from "../../contracts/test/TestERC1155Revert.sol";
+
 import { BaseConduitTest } from "./conduit/BaseConduitTest.sol";
+
 import { Conduit } from "../../contracts/conduit/Conduit.sol";
+
 import {
     TokenTransferrerErrors
 } from "../../contracts/interfaces/TokenTransferrerErrors.sol";

--- a/test/foundry/TransferHelperMultipleRecipientsTest.sol
+++ b/test/foundry/TransferHelperMultipleRecipientsTest.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { BaseConsiderationTest } from "./utils/BaseConsiderationTest.sol";
-
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 
 import {
@@ -24,8 +22,6 @@ import { TestERC721 } from "../../contracts/test/TestERC721.sol";
 
 import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
 
-import { ConduitMock } from "../../contracts/test/ConduitMock.sol";
-
 import {
     ConduitMockInvalidMagic
 } from "../../contracts/test/ConduitMockInvalidMagic.sol";
@@ -33,6 +29,7 @@ import {
 import {
     ConduitMockRevertNoReason
 } from "../../contracts/test/ConduitMockRevertNoReason.sol";
+
 import {
     ConduitControllerMock
 } from "../../contracts/test/ConduitControllerMock.sol";
@@ -44,10 +41,6 @@ import {
 import {
     TokenTransferrerErrors
 } from "../../contracts/interfaces/TokenTransferrerErrors.sol";
-
-import {
-    TransferHelperInterface
-} from "../../contracts/interfaces/TransferHelperInterface.sol";
 
 import {
     TransferHelperErrors
@@ -62,9 +55,13 @@ import {
 } from "../../contracts/test/ERC721ReceiverMock.sol";
 
 import { TestERC20Panic } from "../../contracts/test/TestERC20Panic.sol";
+
 import { StubERC20 } from "./token/StubERC20.sol";
+
 import { StubERC721 } from "./token/StubERC721.sol";
+
 import { StubERC1155 } from "./token/StubERC1155.sol";
+
 import { Strings } from "openzeppelin-contracts/contracts/utils/Strings.sol";
 
 contract TransferHelperMultipleRecipientsTest is BaseOrderTest {

--- a/test/foundry/TransferHelperSingleRecipientTest.sol
+++ b/test/foundry/TransferHelperSingleRecipientTest.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { BaseConsiderationTest } from "./utils/BaseConsiderationTest.sol";
-
 import { BaseOrderTest } from "./utils/BaseOrderTest.sol";
 
 import {
@@ -24,8 +22,6 @@ import { TestERC721 } from "../../contracts/test/TestERC721.sol";
 
 import { TestERC1155 } from "../../contracts/test/TestERC1155.sol";
 
-import { ConduitMock } from "../../contracts/test/ConduitMock.sol";
-
 import {
     ConduitMockInvalidMagic
 } from "../../contracts/test/ConduitMockInvalidMagic.sol";
@@ -33,6 +29,7 @@ import {
 import {
     ConduitMockRevertNoReason
 } from "../../contracts/test/ConduitMockRevertNoReason.sol";
+
 import {
     ConduitControllerMock
 } from "../../contracts/test/ConduitControllerMock.sol";
@@ -44,10 +41,6 @@ import {
 import {
     TokenTransferrerErrors
 } from "../../contracts/interfaces/TokenTransferrerErrors.sol";
-
-import {
-    TransferHelperInterface
-} from "../../contracts/interfaces/TransferHelperInterface.sol";
 
 import {
     TransferHelperErrors

--- a/test/foundry/conduit/ConduitExecute.t.sol
+++ b/test/foundry/conduit/ConduitExecute.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { BaseConsiderationTest } from "../utils/BaseConsiderationTest.sol";
 import {
     ConduitTransfer,
     ConduitItemType
@@ -9,8 +8,6 @@ import {
 import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
 import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
 import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
-import { ERC721Recipient } from "../utils/ERC721Recipient.sol";
-import { ERC1155Recipient } from "../utils/ERC1155Recipient.sol";
 import { BaseConduitTest } from "./BaseConduitTest.sol";
 import { Conduit } from "../../../contracts/conduit/Conduit.sol";
 

--- a/test/foundry/conduit/ConduitExecuteBatch1155.t.sol
+++ b/test/foundry/conduit/ConduitExecuteBatch1155.t.sol
@@ -1,17 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { BaseConsiderationTest } from "../utils/BaseConsiderationTest.sol";
 import {
-    ConduitTransfer,
-    ConduitBatch1155Transfer,
-    ConduitItemType
+    ConduitBatch1155Transfer
 } from "../../../contracts/conduit/lib/ConduitStructs.sol";
 import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
-import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
-import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
-import { ERC721Recipient } from "../utils/ERC721Recipient.sol";
-import { ERC1155Recipient } from "../utils/ERC1155Recipient.sol";
 import { BaseConduitTest } from "./BaseConduitTest.sol";
 import { Conduit } from "../../../contracts/conduit/Conduit.sol";
 

--- a/test/foundry/conduit/ConduitExecuteWithBatch1155.t.sol
+++ b/test/foundry/conduit/ConduitExecuteWithBatch1155.t.sol
@@ -3,9 +3,6 @@
 pragma solidity ^0.8.17;
 
 import { Conduit } from "../../../contracts/conduit/Conduit.sol";
-import {
-    ConduitController
-} from "../../../contracts/conduit/ConduitController.sol";
 import { BaseConduitTest } from "./BaseConduitTest.sol";
 import {
     ConduitTransfer,
@@ -15,8 +12,6 @@ import {
 import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
 import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
 import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
-import { ERC721Recipient } from "../utils/ERC721Recipient.sol";
-import { ERC1155Recipient } from "../utils/ERC1155Recipient.sol";
 
 contract ConduitExecuteWithBatch1155Test is BaseConduitTest {
     struct FuzzInputs {

--- a/test/foundry/offerers/AdjustedAmountOfferer.t.sol
+++ b/test/foundry/offerers/AdjustedAmountOfferer.t.sol
@@ -2,26 +2,24 @@
 pragma solidity ^0.8.17;
 
 import { BaseOrderTest } from "../utils/BaseOrderTest.sol";
+
 import { AdjustedAmountOfferer } from "./impl/AdjustedAmountOfferer.sol";
-import { Merkle } from "murky/Merkle.sol";
+
 import {
-    ERC20Interface,
-    ERC721Interface
+    ERC20Interface
 } from "../../../contracts/interfaces/AbridgedTokenInterfaces.sol";
+
 import {
     ConsiderationInterface
 } from "../../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     OrderType,
-    ItemType,
-    Side
+    ItemType
 } from "../../../contracts/lib/ConsiderationEnums.sol";
+
 import {
-    Order,
-    SpentItem,
-    OrderParameters,
     ConsiderationItem,
-    OfferItem,
     AdvancedOrder,
     CriteriaResolver
 } from "../../../contracts/lib/ConsiderationStructs.sol";
@@ -29,6 +27,7 @@ import {
 import {
     ConsiderationEventsAndErrors
 } from "../../../contracts/interfaces/ConsiderationEventsAndErrors.sol";
+
 import {
     ZoneInteractionErrors
 } from "../../../contracts/interfaces/ZoneInteractionErrors.sol";

--- a/test/foundry/offerers/BadOfferer.t.sol
+++ b/test/foundry/offerers/BadOfferer.t.sol
@@ -7,9 +7,9 @@ import { BadOfferer } from "./impl/BadOfferer.sol";
 
 import {
     ERC20Interface,
-    ERC721Interface,
-    ERC1155Interface
+    ERC721Interface
 } from "../../../contracts/interfaces/AbridgedTokenInterfaces.sol";
+
 import {
     ConsiderationInterface
 } from "../../../contracts/interfaces/ConsiderationInterface.sol";
@@ -19,12 +19,8 @@ import {
     ConsiderationItem,
     AdvancedOrder,
     CriteriaResolver,
-    SpentItem,
     OrderParameters,
-    OrderComponents,
-    ReceivedItem,
-    FulfillmentComponent,
-    Fulfillment
+    FulfillmentComponent
 } from "../../../contracts/lib/ConsiderationStructs.sol";
 
 import {

--- a/test/foundry/offerers/ContractOffersNativeTokenOfferItems.t.sol
+++ b/test/foundry/offerers/ContractOffersNativeTokenOfferItems.t.sol
@@ -8,17 +8,8 @@ import { BaseOrderTest } from "../utils/BaseOrderTest.sol";
 import { DifferentialTest } from "../utils/DifferentialTest.sol";
 
 import {
-    ERC20Interface,
-    ERC721Interface
-} from "../../../contracts/interfaces/AbridgedTokenInterfaces.sol";
-
-import {
     ConsiderationInterface
 } from "../../../contracts/interfaces/ConsiderationInterface.sol";
-
-import {
-    ContractOffererInterface
-} from "../../../contracts/interfaces/ContractOffererInterface.sol";
 
 import { ItemType } from "../../../contracts/lib/ConsiderationEnums.sol";
 
@@ -30,8 +21,6 @@ import {
 import {
     TestContractOffererNativeToken
 } from "../../../contracts/test/TestContractOffererNativeToken.sol";
-
-import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
 
 import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
 

--- a/test/foundry/offerers/OffererCriteriaAdvanced.t.sol
+++ b/test/foundry/offerers/OffererCriteriaAdvanced.t.sol
@@ -2,24 +2,27 @@
 pragma solidity ^0.8.17;
 
 import { BaseOrderTest } from "../utils/BaseOrderTest.sol";
+
 import { PassthroughOfferer } from "./impl/PassthroughOfferer.sol";
+
 import { Merkle } from "murky/Merkle.sol";
+
 import {
     ERC20Interface,
     ERC721Interface
 } from "../../../contracts/interfaces/AbridgedTokenInterfaces.sol";
+
 import {
     ConsiderationInterface
 } from "../../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     OrderType,
     ItemType,
     Side
 } from "../../../contracts/lib/ConsiderationEnums.sol";
+
 import {
-    Order,
-    SpentItem,
-    OrderParameters,
     ConsiderationItem,
     OfferItem,
     AdvancedOrder,
@@ -29,6 +32,7 @@ import {
 import {
     ConsiderationEventsAndErrors
 } from "../../../contracts/interfaces/ConsiderationEventsAndErrors.sol";
+
 import {
     ZoneInteractionErrors
 } from "../../../contracts/interfaces/ZoneInteractionErrors.sol";

--- a/test/foundry/offerers/StatefulOfferer.t.sol
+++ b/test/foundry/offerers/StatefulOfferer.t.sol
@@ -2,29 +2,28 @@
 pragma solidity ^0.8.17;
 
 import { BaseOrderTest } from "../utils/BaseOrderTest.sol";
+
 import { StatefulRatifierOfferer } from "./impl/StatefulRatifierOfferer.sol";
+
 import {
     ERC20Interface,
-    ERC721Interface,
-    ERC1155Interface
+    ERC721Interface
 } from "../../../contracts/interfaces/AbridgedTokenInterfaces.sol";
+
 import {
     ConsiderationInterface
 } from "../../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
     OfferItem,
     ConsiderationItem,
     AdvancedOrder,
     CriteriaResolver,
-    SpentItem,
-    OrderParameters,
     OrderComponents,
-    ReceivedItem,
-    FulfillmentComponent,
-    Fulfillment
+    FulfillmentComponent
 } from "../../../contracts/lib/ConsiderationStructs.sol";
+
 import {
-    ItemType,
     OrderType
 } from "../../../contracts/lib/ConsiderationEnums.sol";
 

--- a/test/foundry/offerers/TestPoolOffererImpl.t.sol
+++ b/test/foundry/offerers/TestPoolOffererImpl.t.sol
@@ -3,15 +3,6 @@ pragma solidity ^0.8.7;
 
 import { Test } from "forge-std/Test.sol";
 
-import {
-    ERC20Interface,
-    ERC721Interface
-} from "../../../contracts/interfaces/AbridgedTokenInterfaces.sol";
-
-import {
-    ContractOffererInterface
-} from "../../../contracts/interfaces/ContractOffererInterface.sol";
-
 import { ItemType } from "../../../contracts/lib/ConsiderationEnums.sol";
 
 import {
@@ -36,8 +27,6 @@ import { TestERC20 } from "../../../contracts/test/TestERC20.sol";
 import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
 
 import { TestPoolOfferer } from "./impl/TestPoolOfferer.sol";
-
-import { TestPoolFactory } from "./impl/TestPoolFactory.sol";
 
 contract TestPoolFactoryImpl {
     address immutable seaport;

--- a/test/foundry/offerers/TestPoolOffererTest.t.sol
+++ b/test/foundry/offerers/TestPoolOffererTest.t.sol
@@ -2,41 +2,19 @@
 pragma solidity ^0.8.17;
 
 import { Test } from "forge-std/Test.sol";
+
 import { BaseOrderTest } from "../utils/BaseOrderTest.sol";
-import { IERC721 } from "forge-std/interfaces/IERC721.sol";
 
 import { TestPoolFactory, TestPoolOfferer } from "./impl/TestPoolFactory.sol";
+
 import {
     SpentItem,
-    ReceivedItem,
-    OrderComponents,
-    OfferItem,
-    ConsiderationItem,
     AdvancedOrder,
     CriteriaResolver,
     OrderType
 } from "../../../contracts/lib/ConsiderationStructs.sol";
+
 import { ItemType } from "../../../contracts/lib/ConsiderationEnums.sol";
-
-struct TransferHelperItem {
-    uint8 itemType;
-    address token;
-    uint256 identifier;
-    uint256 amount;
-}
-
-struct TransferHelperItemsWithRecipient {
-    TransferHelperItem[] items;
-    address recipient;
-    bool validateERC721Receiver;
-}
-
-interface TransferHelper {
-    function bulkTransfer(
-        TransferHelperItemsWithRecipient[] memory items,
-        bytes32 conduitKey
-    ) external returns (bytes4 magicValue);
-}
 
 contract TestPoolOffererTest is BaseOrderTest {
     TestPoolFactory factory;

--- a/test/foundry/offerers/impl/AdjustedAmountOfferer.sol
+++ b/test/foundry/offerers/impl/AdjustedAmountOfferer.sol
@@ -10,11 +10,6 @@ import {
 } from "../../../../contracts/interfaces/ContractOffererInterface.sol";
 
 import {
-    ItemType,
-    Side
-} from "../../../../contracts/lib/ConsiderationEnums.sol";
-
-import {
     SpentItem,
     ReceivedItem,
     Schema

--- a/test/foundry/offerers/impl/BadOfferer.sol
+++ b/test/foundry/offerers/impl/BadOfferer.sol
@@ -3,8 +3,7 @@ pragma solidity ^0.8.13;
 
 import {
     ERC20Interface,
-    ERC721Interface,
-    ERC1155Interface
+    ERC721Interface
 } from "../../../../contracts/interfaces/AbridgedTokenInterfaces.sol";
 
 import {
@@ -12,8 +11,7 @@ import {
 } from "../../../../contracts/interfaces/ContractOffererInterface.sol";
 
 import {
-    ItemType,
-    Side
+    ItemType
 } from "../../../../contracts/lib/ConsiderationEnums.sol";
 
 import {

--- a/test/foundry/offerers/impl/PassthroughOfferer.sol
+++ b/test/foundry/offerers/impl/PassthroughOfferer.sol
@@ -3,18 +3,12 @@ pragma solidity ^0.8.13;
 
 import {
     ERC20Interface,
-    ERC721Interface,
-    ERC1155Interface
+    ERC721Interface
 } from "../../../../contracts/interfaces/AbridgedTokenInterfaces.sol";
 
 import {
     ContractOffererInterface
 } from "../../../../contracts/interfaces/ContractOffererInterface.sol";
-
-import {
-    ItemType,
-    Side
-} from "../../../../contracts/lib/ConsiderationEnums.sol";
 
 import {
     SpentItem,

--- a/test/foundry/offerers/impl/StatefulRatifierOfferer.sol
+++ b/test/foundry/offerers/impl/StatefulRatifierOfferer.sol
@@ -3,8 +3,7 @@ pragma solidity ^0.8.13;
 
 import {
     ERC20Interface,
-    ERC721Interface,
-    ERC1155Interface
+    ERC721Interface
 } from "../../../../contracts/interfaces/AbridgedTokenInterfaces.sol";
 
 import {

--- a/test/foundry/offerers/impl/TestPoolFactory.sol
+++ b/test/foundry/offerers/impl/TestPoolFactory.sol
@@ -2,14 +2,13 @@
 pragma solidity ^0.8.7;
 
 import {
-    EnumerableSet
-} from "openzeppelin-contracts/contracts/utils/structs/EnumerableSet.sol";
-import {
     IERC721
 } from "openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
+
 import {
     IERC20
 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
 import { TestPoolOfferer } from "./TestPoolOfferer.sol";
 
 contract TestPoolFactory {

--- a/test/foundry/offerers/impl/TestPoolOfferer.sol
+++ b/test/foundry/offerers/impl/TestPoolOfferer.sol
@@ -2,11 +2,6 @@
 pragma solidity ^0.8.7;
 
 import {
-    ERC20Interface,
-    ERC721Interface
-} from "../../../../contracts/interfaces/AbridgedTokenInterfaces.sol";
-
-import {
     ContractOffererInterface
 } from "../../../../contracts/interfaces/ContractOffererInterface.sol";
 

--- a/test/foundry/utils/BaseConsiderationTest.sol
+++ b/test/foundry/utils/BaseConsiderationTest.sol
@@ -17,18 +17,11 @@ import {
     ConsiderationInterface
 } from "../../../contracts/interfaces/ConsiderationInterface.sol";
 
-import {
-    OrderType,
-    BasicOrderType,
-    ItemType,
-    Side
-} from "../../../contracts/lib/ConsiderationEnums.sol";
+import { ItemType } from "../../../contracts/lib/ConsiderationEnums.sol";
 
 import {
     OfferItem,
-    ConsiderationItem,
-    OrderComponents,
-    BasicOrderParameters
+    ConsiderationItem
 } from "../../../contracts/lib/ConsiderationStructs.sol";
 
 import { DifferentialTest } from "./DifferentialTest.sol";

--- a/test/foundry/utils/BaseOrderTest.sol
+++ b/test/foundry/utils/BaseOrderTest.sol
@@ -1,32 +1,29 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { BaseConsiderationTest } from "./BaseConsiderationTest.sol";
 import { stdStorage, StdStorage } from "forge-std/Test.sol";
-import { ProxyRegistry } from "../interfaces/ProxyRegistry.sol";
-import { OwnableDelegateProxy } from "../interfaces/OwnableDelegateProxy.sol";
-import { OneWord } from "../../../contracts/lib/ConsiderationConstants.sol";
+
 import {
     ConsiderationInterface
 } from "../../../contracts/interfaces/ConsiderationInterface.sol";
+
 import {
-    BasicOrderType,
     OrderType
 } from "../../../contracts/lib/ConsiderationEnums.sol";
+
 import {
-    BasicOrderParameters,
-    ConsiderationItem,
     AdditionalRecipient,
-    OfferItem,
     Fulfillment,
     FulfillmentComponent,
-    ItemType,
     Order,
     OrderComponents,
     OrderParameters
 } from "../../../contracts/lib/ConsiderationStructs.sol";
+
 import { ArithmeticUtil } from "./ArithmeticUtil.sol";
+
 import { OrderBuilder } from "./OrderBuilder.sol";
+
 import { AmountDeriver } from "../../../contracts/lib/AmountDeriver.sol";
 
 /// @dev base test class for cases that depend on pre-deployed token contracts

--- a/test/foundry/utils/DifferentialTest.sol
+++ b/test/foundry/utils/DifferentialTest.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
+
 import { Test } from "forge-std/Test.sol";
 
 contract DifferentialTest is Test {

--- a/test/foundry/utils/OfferConsiderationItemAdder.sol
+++ b/test/foundry/utils/OfferConsiderationItemAdder.sol
@@ -7,6 +7,7 @@ import {
     ItemType,
     SpentItem
 } from "../../../contracts/lib/ConsiderationStructs.sol";
+
 import { TestTokenMinter } from "./TestTokenMinter.sol";
 
 contract OfferConsiderationItemAdder is TestTokenMinter {

--- a/test/foundry/utils/OrderBuilder.sol
+++ b/test/foundry/utils/OrderBuilder.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.17;
 
 import { OfferConsiderationItemAdder } from "./OfferConsiderationItemAdder.sol";
+
 import {
     OrderParameters,
     OrderComponents,
     Order,
     BasicOrderParameters,
     SpentItem,
-    ReceivedItem,
     AdditionalRecipient,
     OfferItem,
     ConsiderationItem,
@@ -16,10 +16,12 @@ import {
     FulfillmentComponent,
     AdvancedOrder
 } from "../../../contracts/lib/ConsiderationStructs.sol";
+
 import {
     OrderType,
     BasicOrderType
 } from "../../../contracts/lib/ConsiderationEnums.sol";
+
 import {
     ConsiderationInterface
 } from "../../../contracts/interfaces/ConsiderationInterface.sol";

--- a/test/foundry/utils/StructCopier.sol
+++ b/test/foundry/utils/StructCopier.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
+
 import {
     BasicOrderParameters,
     CriteriaResolver,
@@ -13,9 +14,6 @@ import {
     OrderParameters,
     OrderComponents
 } from "../../../contracts/lib/ConsiderationStructs.sol";
-import {
-    ConsiderationInterface
-} from "../../../contracts/interfaces/ConsiderationInterface.sol";
 
 contract StructCopier {
     Order _tempOrder;

--- a/test/foundry/utils/reentrancy/ReentrantStructs.sol
+++ b/test/foundry/utils/reentrancy/ReentrantStructs.sol
@@ -2,16 +2,11 @@
 pragma solidity ^0.8.17;
 import {
     BasicOrderParameters,
-    OfferItem,
-    ConsiderationItem,
-    OrderParameters,
     OrderComponents,
     Fulfillment,
     FulfillmentComponent,
-    Execution,
     Order,
     AdvancedOrder,
-    OrderStatus,
     CriteriaResolver
 } from "../../../../contracts/lib/ConsiderationStructs.sol";
 

--- a/test/foundry/zone/PostFulfillmentCheck.t.sol
+++ b/test/foundry/zone/PostFulfillmentCheck.t.sol
@@ -2,10 +2,13 @@
 pragma solidity ^0.8.17;
 
 import { BaseOrderTest } from "../utils/BaseOrderTest.sol";
+
 import { TestZone } from "./impl/TestZone.sol";
+
 import {
     PostFulfillmentStatefulTestZone
 } from "./impl/PostFullfillmentStatefulTestZone.sol";
+
 import {
     ConsiderationItem,
     OfferItem,
@@ -13,16 +16,16 @@ import {
     AdvancedOrder,
     CriteriaResolver,
     BasicOrderParameters,
-    Order,
     AdditionalRecipient,
-    FulfillmentComponent,
-    Fulfillment
+    FulfillmentComponent
 } from "../../../contracts/lib/ConsiderationStructs.sol";
+
 import {
     OrderType,
     Side,
     BasicOrderType
 } from "../../../contracts/lib/ConsiderationEnums.sol";
+
 import {
     ConsiderationInterface
 } from "../../../contracts/interfaces/ConsiderationInterface.sol";

--- a/test/foundry/zone/impl/BadZone.sol
+++ b/test/foundry/zone/impl/BadZone.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.17;
 
 import {
-    AdvancedOrder,
-    CriteriaResolver,
     ZoneParameters,
     Schema
 } from "../../../../contracts/lib/ConsiderationStructs.sol";

--- a/test/foundry/zone/impl/PostFullfillmentStatefulTestZone.sol
+++ b/test/foundry/zone/impl/PostFullfillmentStatefulTestZone.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.17;
 
 import {
-    AdvancedOrder,
-    CriteriaResolver,
     ZoneParameters,
     Schema
 } from "../../../../contracts/lib/ConsiderationStructs.sol";

--- a/test/foundry/zone/impl/TestZone.sol
+++ b/test/foundry/zone/impl/TestZone.sol
@@ -2,11 +2,10 @@
 pragma solidity ^0.8.17;
 
 import {
-    AdvancedOrder,
-    CriteriaResolver,
     ZoneParameters,
     Schema
 } from "../../../../contracts/lib/ConsiderationStructs.sol";
+
 import {
     ZoneInterface
 } from "../../../../contracts/interfaces/ZoneInterface.sol";


### PR DESCRIPTION
## Motivation

Hygiene.

## Solution

Remove unused imports.  I think this gets all of them in ./contracts
