### PR TITLE
readme: update deployed addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,44 +80,17 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 [0x00000000F9490004C11Cef243f5400493c00Ad63](https://etherscan.io/address/0x00000000F9490004C11Cef243f5400493c00Ad63#code)
 
 </td></tr>
-
-<tr><td>Rinkeby</td><td>
-
-[0x00000000006c3852cbEf3e08E8dF289169EdE581](https://rinkeby.etherscan.io/address/0x00000000006c3852cbEf3e08E8dF289169EdE581#code)
-
-</td><td>
-
--
-
-</td><td>
-
-[0x00000000F9490004C11Cef243f5400493c00Ad63](https://rinkeby.etherscan.io/address/0x00000000F9490004C11Cef243f5400493c00Ad63#code)
-
-</td></tr>
 <tr><td>Goerli</td><td>
 
 [0x00000000006c3852cbEf3e08E8dF289169EdE581](https://goerli.etherscan.io/address/0x00000000006c3852cbEf3e08E8dF289169EdE581#code)
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://goerli.etherscan.io/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
 [0x00000000F9490004C11Cef243f5400493c00Ad63](https://goerli.etherscan.io/address/0x00000000F9490004C11Cef243f5400493c00Ad63#code)
-
-</td></tr>
-<tr><td>Kovan</td><td>
-
-[0x00000000006c3852cbEf3e08E8dF289169EdE581](https://kovan.etherscan/address/0x00000000006c3852cbEf3e08E8dF289169EdE581#code)
-
-</td><td>
-
--
-
-</td><td>
-
-[0x00000000F9490004C11Cef243f5400493c00Ad63](https://kovan.etherscan.io/address/0x00000000F9490004C11Cef243f5400493c00Ad63#code)
 
 </td></tr>
 <tr><td>Sepolia</td><td>
@@ -126,7 +99,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://sepolia.etherscan.io/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -139,7 +112,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://polygonscan.com/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -152,7 +125,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://mumbai.polygonscan.com/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -165,7 +138,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://scope.klaytn.com/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -178,7 +151,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://baobab.scope.klaytn.com/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -191,7 +164,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://optimistic.etherscan.io/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -204,7 +177,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://goerli-optimism.etherscan.io/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -217,7 +190,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://arbiscan.io/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -230,7 +203,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://goerli.arbiscan.io/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -243,7 +216,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://nova.arbiscan.io/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -256,7 +229,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://snowtrace.io/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -269,7 +242,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://testnet.snowtrace.io/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -282,7 +255,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://gnosisscan.io/address/0x00000000000006c7676171937C444f6BDe3D6282#code)
 
 </td><td>
 
@@ -295,7 +268,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://bscscan.com/address/0x00000000006c3852cbEf3e08E8dF289169EdE581#code)
 
 </td><td>
 
@@ -308,7 +281,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](contracts
 
 </td><td>
 
--
+[0x00000000000006c7676171937C444f6BDe3D6282](https://testnet.bscscan.com/address/0x00000000006c3852cbEf3e08E8dF289169EdE581#code)
 
 </td><td>
 


### PR DESCRIPTION
deployed 1.2 across all chains

removed defunct rinkeby and kovan from the table