### PR TITLE
add a test for index overflow with trees of different heights and refactor a bit

### DIFF
--- a/test/foundry/BulkSignature.t.sol
+++ b/test/foundry/BulkSignature.t.sol
@@ -599,11 +599,11 @@ contract BulkSignatureTest is BaseOrderTest {
         uint24 convertedIndex;
         Order memory order;
 
-        // Iterate over all indexes from the firstExpectedOverflowIndex to the
-        // secondExpectedOverflowIndex, inclusive, and make sure that none of
-        // them work except the expected indexes.
+        // Iterate over all indexes from the firstExpectedOverflowIndex + 1 to
+        // the secondExpectedOverflowIndex, inclusive, and make sure that none
+        // of them work except the expected indexes.
         for (
-            uint256 i = firstExpectedOverflowIndex;
+            uint256 i = firstExpectedOverflowIndex + 1;
             i <= secondExpectedOverflowIndex;
             ++i
         ) {
@@ -624,12 +624,12 @@ contract BulkSignatureTest is BaseOrderTest {
                     0x000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
                 )
                 // 256 - 24 = 232
-                // Create a new value the same as the old value, except that it uses
-                // the fake index.
+                // Create a new value the same as the old value, except that it
+                // uses the fake index.
                 let fakeIndexAndProofData := or(
                     maskedProofData,
-                    // Shift the fake index left by 232 bits to produce a value to
-                    // `or` with the `maskedProofData`.  For example:
+                    // Shift the fake index left by 232 bits to produce a value
+                    // to `or` with the `maskedProofData`.  For example:
                     // `0x000005000...`
                     shl(232, convertedIndex)
                 )
@@ -638,20 +638,19 @@ contract BulkSignatureTest is BaseOrderTest {
                 mstore(indexAndProofDataPointer, fakeIndexAndProofData)
             }
 
-            // Create an order using the `bulkSignature` that was modified in the
-            // assembly block above.
+            // Create an order using the `bulkSignature` that was modified in
+            // the assembly block above.
             order = Order({
                 parameters: baseOrderParameters,
                 signature: bulkSignature
             });
 
-            // We expect a revert for all indexes except the
-            // firstExpectedOverflowIndex and the secondExpectedOverflowIndex.
-            if (
-                i != firstExpectedOverflowIndex &&
-                i != secondExpectedOverflowIndex
-            ) {
-                // We expect InvalidSigner because we're trying to recover the
+            // Expect a revert for all indexes except the
+            // secondExpectedOverflowIndex. The starting range should revert
+            // with `InvalidSigner`, and the secondExpectedOverflowIndex should
+            // fulfill the order.
+            if (i != secondExpectedOverflowIndex) {
+                // Expect InvalidSigner because we're trying to recover the
                 // signer using a signature and proof for one of the dummy
                 // orders that signSparseBulkOrder filled in.
                 vm.expectRevert(abi.encodeWithSignature("InvalidSigner()"));

--- a/test/foundry/BulkSignature.t.sol
+++ b/test/foundry/BulkSignature.t.sol
@@ -100,7 +100,7 @@ contract BulkSignatureTest is BaseOrderTest {
         configureOrderComponents(context.seaport);
         OrderComponents[] memory orderComponents = new OrderComponents[](3);
         orderComponents[0] = baseOrderComponents;
-        // other order components can remain empty
+        // The other order components can remain empty.
 
         EIP712MerkleTree merkleTree = new EIP712MerkleTree();
         bytes memory bulkSignature = merkleTree.signBulkOrder(
@@ -177,7 +177,7 @@ contract BulkSignatureTest is BaseOrderTest {
         configureOrderComponents(context.seaport);
         OrderComponents[] memory orderComponents = new OrderComponents[](3);
         orderComponents[0] = baseOrderComponents;
-        // other order components can remain empty
+        // The other order components can remain empty.
 
         EIP712MerkleTree merkleTree = new EIP712MerkleTree();
         bytes memory bulkSignature = merkleTree.signSparseBulkOrder(
@@ -195,7 +195,7 @@ contract BulkSignatureTest is BaseOrderTest {
         context.seaport.fulfillOrder{ value: 1 }(order, bytes32(0));
     }
 
-    function testSparseBulkSignatureFuzz(SparseArgs memory sparseArgs) public {
+    function testBulkSignatureSparseFuzz(SparseArgs memory sparseArgs) public {
         sparseArgs.height = uint8(bound(sparseArgs.height, 1, 24));
         sparseArgs.orderIndex = uint24(
             bound(sparseArgs.orderIndex, 0, 2 ** uint256(sparseArgs.height) - 1)
@@ -235,6 +235,7 @@ contract BulkSignatureTest is BaseOrderTest {
         );
     }
 
+    // This tests the "targeting" of orders in the out-of-range index case.
     function execBulkSignatureIndexOutOfBounds(
         Context memory context
     ) external stateless {
@@ -269,26 +270,8 @@ contract BulkSignatureTest is BaseOrderTest {
 
         EIP712MerkleTree merkleTree = new EIP712MerkleTree();
 
-        // Get the signature for the second order.
+        // Get the signature for the order at index 0.
         bytes memory bulkSignature = merkleTree.signBulkOrder(
-            context.seaport,
-            key,
-            orderComponents,
-            1,
-            context.useCompact2098
-        );
-
-        Order memory order = Order({
-            parameters: secondOrderParameters,
-            signature: bulkSignature
-        });
-
-        // Fulfill the second order.
-        context.seaport.fulfillOrder{ value: 1 }(order, bytes32(0));
-        assertEq(test721_1.ownerOf(2), address(this));
-
-        // Get the signature for the first order.
-        bulkSignature = merkleTree.signBulkOrder(
             context.seaport,
             key,
             orderComponents,
@@ -296,11 +279,28 @@ contract BulkSignatureTest is BaseOrderTest {
             context.useCompact2098
         );
 
+        Order memory order = Order({
+            parameters: baseOrderParameters,
+            signature: bulkSignature
+        });
+
+        // Fulfill the order at index 0.
+        context.seaport.fulfillOrder{ value: 1 }(order, bytes32(0));
+        assertEq(test721_1.ownerOf(1), address(this));
+
+        // Get the signature for the order at index 1.
+        bulkSignature = merkleTree.signBulkOrder(
+            context.seaport,
+            key,
+            orderComponents,
+            1,
+            context.useCompact2098
+        );
+
         uint256 signatureLength = context.useCompact2098 ? 64 : 65;
 
-        // Swap in a fake index.  Here, we use 4 instead of 0.
+        // Swap in a fake index.  Here, we use 5 instead of 1.
         assembly {
-            // mload(bulkSignature) := signatureLength
             let indexAndProofDataPointer := add(
                 signatureLength,
                 add(bulkSignature, 0x20)
@@ -312,25 +312,27 @@ contract BulkSignatureTest is BaseOrderTest {
             )
             let fakeIndexAndProofData := or(
                 maskedProofData,
-                0x0000040000000000000000000000000000000000000000000000000000000000
+                0x0000050000000000000000000000000000000000000000000000000000000000
             )
             mstore(indexAndProofDataPointer, fakeIndexAndProofData)
         }
 
         order = Order({
-            parameters: baseOrderParameters,
+            parameters: secondOrderParameters,
             signature: bulkSignature
         });
 
-        // Fulfill the first order using th bulk signature with the out of
-        // bounds index..
+        // Fulfill the order order at index 1 using the bulk signature with the
+        // out of bounds index (5).
         context.seaport.fulfillOrder{ value: 1 }(order, bytes32(0));
 
-        // Should wrap around and fulfill the first order, which is for token ID
-        // 1.
-        assertEq(test721_1.ownerOf(1), address(this));
+        // Should wrap around and fulfill the order at index 1, which is for
+        // token ID 2.
+        assertEq(test721_1.ownerOf(2), address(this));
     }
 
+    // Pulled out bc of stacc2dank but can be moved or cleaned up in some better
+    // way.
     function setUpSecondOrder(
         Context memory context,
         address addr
@@ -406,6 +408,138 @@ contract BulkSignatureTest is BaseOrderTest {
             Context({
                 seaport: referenceConsideration,
                 args: _defaultArgs,
+                useCompact2098: true
+            })
+        );
+    }
+
+    // This tests the overflow behavior for trees of different heights.
+    function execBulkSignatureSparseIndexOutOfBounds(
+        Context memory context
+    ) external stateless {
+        // Set up the boilerplate for the offerer.
+        string memory offerer = "offerer";
+        (address addr, uint256 key) = makeAddrAndKey(offerer);
+        addErc721OfferItem(1);
+        test721_1.mint(address(addr), 1);
+        vm.prank(addr);
+        test721_1.setApprovalForAll(address(context.seaport), true);
+        // Set up the order.
+        addConsiderationItem(
+            ConsiderationItem({
+                itemType: ItemType.NATIVE,
+                token: address(0),
+                identifierOrCriteria: 0,
+                startAmount: 1,
+                endAmount: 1,
+                recipient: payable(addr)
+            })
+        );
+        configureOrderParameters(addr);
+        configureOrderComponents(context.seaport);
+        OrderComponents[] memory orderComponents = new OrderComponents[](3);
+        orderComponents[0] = baseOrderComponents;
+        // The other order components can remain empty because
+        // `signSparseBulkOrder` will fill them in with empty orders and we only
+        // care about one order.
+
+        EIP712MerkleTree merkleTree = new EIP712MerkleTree();
+
+        // Get the real signature.
+        bytes memory bulkSignature = merkleTree.signSparseBulkOrder(
+            context.seaport,
+            key,
+            baseOrderComponents,
+            context.args.height,
+            context.args.orderIndex,
+            context.useCompact2098
+        );
+
+        // The memory region that needs to be modified depends on the signature
+        // length.
+        uint256 signatureLength = context.useCompact2098 ? 64 : 65;
+        // Set up an index equal to orderIndex + tree height ** 2.
+        uint256 index = context.args.orderIndex + (context.args.height ** 2);
+        uint24 convertedIndex = uint24(index);
+
+        // Use assembly to swap in a fake index.
+        assembly {
+            // Get the pointer to the index and proof data.
+            let indexAndProofDataPointer := add(
+                signatureLength,
+                add(bulkSignature, 0x20)
+            )
+            // Load the index and proof data into memory.
+            let indexAndProofData := mload(indexAndProofDataPointer)
+            // Mask for the index.
+            let maskedProofData := and(
+                indexAndProofData,
+                0x000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            )
+            // 256 - 24 = 232
+            // Create a new value the same as the old value, except that it uses
+            // the fake index.
+            let fakeIndexAndProofData := or(
+                maskedProofData,
+                // Shift the fake index left by 232 bits to produce a value to
+                // `or` with the `maskedProofData`.  For example:
+                // `0x000005000...`
+                shl(232, convertedIndex)
+            )
+            // Store the fake index and proof data at the
+            // indexAndProofDataPointer location.
+            mstore(indexAndProofDataPointer, fakeIndexAndProofData)
+        }
+
+        // Create an order using the `bulkSignature` that was modified in the
+        // assembly block above.
+        Order memory order = Order({
+            parameters: baseOrderParameters,
+            signature: bulkSignature
+        });
+
+        // This should wrap around and fulfill the order at the index equal to
+        // (the fake order index - (height ** 2)).
+        context.seaport.fulfillOrder{ value: 1 }(order, bytes32(0));
+    }
+
+    function testBulkSignatureSparseIndexOutOfBoundsFuzz(
+        SparseArgs memory sparseArgs
+    ) public {
+        sparseArgs.height = uint8(bound(sparseArgs.height, 1, 24));
+        sparseArgs.orderIndex = uint24(
+            bound(sparseArgs.orderIndex, 0, 2 ** uint256(sparseArgs.height) - 1)
+        );
+
+        test(
+            this.execBulkSignatureSparseIndexOutOfBounds,
+            Context({
+                seaport: consideration,
+                args: sparseArgs,
+                useCompact2098: false
+            })
+        );
+        test(
+            this.execBulkSignatureSparseIndexOutOfBounds,
+            Context({
+                seaport: referenceConsideration,
+                args: sparseArgs,
+                useCompact2098: false
+            })
+        );
+        test(
+            this.execBulkSignatureSparseIndexOutOfBounds,
+            Context({
+                seaport: consideration,
+                args: sparseArgs,
+                useCompact2098: true
+            })
+        );
+        test(
+            this.execBulkSignatureSparseIndexOutOfBounds,
+            Context({
+                seaport: referenceConsideration,
+                args: sparseArgs,
                 useCompact2098: true
             })
         );

--- a/test/foundry/BulkSignature.t.sol
+++ b/test/foundry/BulkSignature.t.sol
@@ -459,7 +459,7 @@ contract BulkSignatureTest is BaseOrderTest {
         // length.
         uint256 signatureLength = context.useCompact2098 ? 64 : 65;
         // Set up an index equal to orderIndex + tree height ** 2.
-        uint256 index = context.args.orderIndex + (context.args.height ** 2);
+        uint256 index = context.args.orderIndex + (2 ** context.args.height);
         uint24 convertedIndex = uint24(index);
 
         // Use assembly to swap in a fake index.

--- a/test/foundry/utils/EIP712MerkleTree.sol
+++ b/test/foundry/utils/EIP712MerkleTree.sol
@@ -40,18 +40,10 @@ contract EIP712MerkleTree is Test {
         merkle = new MerkleUnsorted();
     }
 
-    /// @dev same lookup seaport optimized does
-    function _lookupBulkOrderTypehash(
-        uint256 treeHeight
-    ) internal view returns (bytes32 typeHash) {
-        TypehashDirectory directory = _typehashDirectory;
-        assembly {
-            let typeHashOffset := add(1, shl(0x5, sub(treeHeight, 1)))
-            extcodecopy(directory, 0, typeHashOffset, 0x20)
-            typeHash := mload(0)
-        }
-    }
-
+    /// @dev Creates a single bulk signature: a base signature + a three byte
+    ///      index + a series of 32 byte proofs.  The height of the tree is
+    ///      determined by the length of the orderComponents array and only
+    ///      fills empty orders into the tree to make the length a power of 2.
     function signBulkOrder(
         ConsiderationInterface consideration,
         uint256 privateKey,
@@ -107,55 +99,10 @@ contract EIP712MerkleTree is Test {
             );
     }
 
-    function _getSignature(
-        ConsiderationInterface consideration,
-        uint256 privateKey,
-        bytes32 bulkOrderTypehash,
-        bytes32 root,
-        bytes32[] memory proof,
-        uint24 orderIndex,
-        bool useCompact2098
-    ) internal view returns (bytes memory) {
-        // bulkOrder hash is keccak256 of the specific bulk order typehash and
-        // the merkle root of the order hashes
-        bytes32 bulkOrderHash = keccak256(abi.encode(bulkOrderTypehash, root));
-
-        // get domain separator from the particular seaport instance
-        (, bytes32 domainSeparator, ) = consideration.information();
-
-        // declare out here to avoid stack too deep errors
-        bytes memory signature;
-        // avoid stacc 2 thicc
-        {
-            (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-                privateKey,
-                keccak256(
-                    abi.encodePacked(
-                        bytes2(0x1901),
-                        domainSeparator,
-                        bulkOrderHash
-                    )
-                )
-            );
-            // if useCompact2098 is true, encode yParity (v) into s
-            if (useCompact2098) {
-                uint256 yParity = (v == 27) ? 0 : 1;
-                bytes32 yAndS = bytes32(uint256(s) | (yParity << 255));
-                signature = abi.encodePacked(r, yAndS);
-            } else {
-                signature = abi.encodePacked(r, s, v);
-            }
-        }
-
-        // return the packed signature, order index, and proof
-        // encodePacked will pack everything tightly without lengths
-        // ie, long-style rsv signatures will have 1 byte for v
-        // orderIndex will be the next 3 bytes
-        // then proof will be each element one after another; its offset and
-        // length will not be encoded
-        return abi.encodePacked(signature, orderIndex, proof);
-    }
-
+    /// @dev Creates a single bulk signature: a base signature + a three byte
+    ///      index + a series of 32 byte proofs.  The height of the tree is
+    ///      determined by the height parameter and this function will fill
+    ///      empty orders into the tree until the specified height is reached.
     function signSparseBulkOrder(
         ConsiderationInterface consideration,
         uint256 privateKey,
@@ -230,5 +177,66 @@ contract EIP712MerkleTree is Test {
                 orderIndex,
                 useCompact2098
             );
+    }
+
+    /// @dev same lookup seaport optimized does
+    function _lookupBulkOrderTypehash(
+        uint256 treeHeight
+    ) internal view returns (bytes32 typeHash) {
+        TypehashDirectory directory = _typehashDirectory;
+        assembly {
+            let typeHashOffset := add(1, shl(0x5, sub(treeHeight, 1)))
+            extcodecopy(directory, 0, typeHashOffset, 0x20)
+            typeHash := mload(0)
+        }
+    }
+
+    function _getSignature(
+        ConsiderationInterface consideration,
+        uint256 privateKey,
+        bytes32 bulkOrderTypehash,
+        bytes32 root,
+        bytes32[] memory proof,
+        uint24 orderIndex,
+        bool useCompact2098
+    ) internal view returns (bytes memory) {
+        // bulkOrder hash is keccak256 of the specific bulk order typehash and
+        // the merkle root of the order hashes
+        bytes32 bulkOrderHash = keccak256(abi.encode(bulkOrderTypehash, root));
+
+        // get domain separator from the particular seaport instance
+        (, bytes32 domainSeparator, ) = consideration.information();
+
+        // declare out here to avoid stack too deep errors
+        bytes memory signature;
+        // avoid stacc 2 thicc
+        {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+                privateKey,
+                keccak256(
+                    abi.encodePacked(
+                        bytes2(0x1901),
+                        domainSeparator,
+                        bulkOrderHash
+                    )
+                )
+            );
+            // if useCompact2098 is true, encode yParity (v) into s
+            if (useCompact2098) {
+                uint256 yParity = (v == 27) ? 0 : 1;
+                bytes32 yAndS = bytes32(uint256(s) | (yParity << 255));
+                signature = abi.encodePacked(r, yAndS);
+            } else {
+                signature = abi.encodePacked(r, s, v);
+            }
+        }
+
+        // return the packed signature, order index, and proof
+        // encodePacked will pack everything tightly without lengths
+        // ie, long-style rsv signatures will have 1 byte for v
+        // orderIndex will be the next 3 bytes
+        // then proof will be each element one after another; its offset and
+        // length will not be encoded
+        return abi.encodePacked(signature, orderIndex, proof);
     }
 }


### PR DESCRIPTION
## Motivation

The desire for more clarity about the behavior of index overflows in bulk signatures.

## Solution

Add a test that shows that an index of (index + (tree height ** 2)) wraps around to the value of the index for trees of different heights.

I'm still wary that I'm doing something wrong and getting a spurious passing outcome.  Please review rigorously.
