### PR TITLE
Fix: Trigger Accumulators Before Post Execution Hooks are called

### DIFF
--- a/contracts/lib/OrderCombiner.sol
+++ b/contracts/lib/OrderCombiner.sol
@@ -746,6 +746,9 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
             }
         }
 
+        // Trigger execution prior to post-execution checks.
+        _triggerIfArmed(accumulator);
+
         // Skip overflow checks as all for loops are indexed starting at zero.
         unchecked {
             // duplicate recipient address to stack to avoid stack-too-deep


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
When creating an order, you can supply a conduitKey, this key represents which Conduit the Consideration can communicate with to transfer the offerer's assets.

When the conduitKey is bytes32(0) seaport is the acting Conduit.

When this is the case, the transactions to settle the order are executed as they are processed inside the execution array loop atomically, when a conduitKey is set an accumulator(an array of transactions to execute) is armed and later triggered.

As of Seaport 1.2, there is a new post execution hook for restricted orders that gets triggered inside the order validity array loop.

When Seaport is the conduit, the order is atomically settled at the time of the validateOrder call, and if a conduitKey is set, then the order is not settled at the point of execution but after all the validateOrder calls have been made and the accumulator has been triggered.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

Trigger the accumulator first between the execution loop and order validity loop in addition to after


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
