### PR TITLE
Improve typehash lookup readability

### DIFF
--- a/contracts/lib/ConsiderationBase.sol
+++ b/contracts/lib/ConsiderationBase.sol
@@ -329,7 +329,7 @@ contract ConsiderationBase is
                                 BulkOrder_Typehash_Height_One
                             )
 
-                            // Exit the loop once typehash has been located.
+                            // Exit the function once typehash has been located.
                             leave
                         }
 
@@ -340,7 +340,7 @@ contract ConsiderationBase is
                             BulkOrder_Typehash_Height_Three
                         )
 
-                        // Exit the loop once typehash has been located.
+                        // Exit the function once typehash has been located.
                         leave
                     }
 
@@ -353,7 +353,7 @@ contract ConsiderationBase is
                             BulkOrder_Typehash_Height_Five
                         )
 
-                        // Exit the loop once typehash has been located.
+                        // Exit the function once typehash has been located.
                         leave
                     }
 
@@ -364,7 +364,7 @@ contract ConsiderationBase is
                         BulkOrder_Typehash_Height_Seven
                     )
 
-                    // Exit the loop once typehash has been located.
+                    // Exit the function once typehash has been located.
                     leave
                 }
 
@@ -381,7 +381,7 @@ contract ConsiderationBase is
                                 BulkOrder_Typehash_Height_Nine
                             )
 
-                            // Exit the loop once typehash has been located.
+                            // Exit the function once typehash has been located.
                             leave
                         }
 
@@ -392,7 +392,7 @@ contract ConsiderationBase is
                             BulkOrder_Typehash_Height_Eleven
                         )
 
-                        // Exit the loop once typehash has been located.
+                        // Exit the function once typehash has been located.
                         leave
                     }
 
@@ -405,7 +405,7 @@ contract ConsiderationBase is
                             BulkOrder_Typehash_Height_Thirteen
                         )
 
-                        // Exit the loop once typehash has been located.
+                        // Exit the function once typehash has been located.
                         leave
                     }
                     // Handle height fifteen and sixteen via branchless logic.
@@ -415,7 +415,7 @@ contract ConsiderationBase is
                         BulkOrder_Typehash_Height_Fifteen
                     )
 
-                    // Exit the loop once typehash has been located.
+                    // Exit the function once typehash has been located.
                     leave
                 }
 
@@ -430,7 +430,7 @@ contract ConsiderationBase is
                             BulkOrder_Typehash_Height_Seventeen
                         )
 
-                        // Exit the loop once typehash has been located.
+                        // Exit the function once typehash has been located.
                         leave
                     }
 
@@ -441,7 +441,7 @@ contract ConsiderationBase is
                         BulkOrder_Typehash_Height_Nineteen
                     )
 
-                    // Exit the loop once typehash has been located.
+                    // Exit the function once typehash has been located.
                     leave
                 }
 
@@ -454,7 +454,7 @@ contract ConsiderationBase is
                         BulkOrder_Typehash_Height_TwentyOne
                     )
 
-                    // Exit the loop once typehash has been located.
+                    // Exit the function once typehash has been located.
                     leave
                 }
 
@@ -465,7 +465,7 @@ contract ConsiderationBase is
                     BulkOrder_Typehash_Height_TwentyThree
                 )
 
-                // Exit the loop once typehash has been located.
+                // Exit the function once typehash has been located.
                 leave
             }
             function ternary(cond, ifTrue, ifFalse) -> c {

--- a/contracts/lib/ConsiderationBase.sol
+++ b/contracts/lib/ConsiderationBase.sol
@@ -300,232 +300,178 @@ contract ConsiderationBase is
      *      Note that values between one and twenty-four are supported, which is
      *      enforced by _isValidBulkOrderSize.
      *
-     * @param treeHeight The height of the bulk order tree. The value must be
+     * @param _treeHeight The height of the bulk order tree. The value must be
      *                   between one and twenty-four.
      *
-     * @return typeHash The EIP-712 typehash for the bulk order type with the
+     * @return _typeHash The EIP-712 typehash for the bulk order type with the
      *                  given height.
      */
-    function _lookupBulkOrderTypehash(
-        uint256 treeHeight
-    ) internal pure returns (bytes32 typeHash) {
+    function _lookupBulkOrderTypehash(uint256 _treeHeight)
+        internal
+        pure
+        returns (bytes32 _typeHash)
+    {
         // Utilize assembly to efficiently retrieve correct bulk order typehash.
         assembly {
-            // Progress until typehash is located; break before loop completes.
-            for {} 1 {} {
+            // Use a Yul function to enable use of the `leave` keyword
+            // to stop searching once the appropriate type hash is found.
+            function lookupTypeHash(treeHeight) -> typeHash {
                 // Handle tree heights one through eight.
-                if iszero(gt(treeHeight, 8)) {
+                if lt(treeHeight, 9) {
                     // Handle tree heights one through four.
-                    if iszero(gt(treeHeight, 4)) {
+                    if lt(treeHeight, 5) {
                         // Handle tree heights one and two.
-                        if iszero(gt(treeHeight, 2)) {
+                        if lt(treeHeight, 3) {
                             // Utilize branchless logic to determine typehash.
-                            typeHash := xor(
-                                BulkOrder_Typehash_Height_One,
-                                mul(
-                                    eq(treeHeight, 2),
-                                    xor(
-                                        BulkOrder_Typehash_Height_One,
-                                        BulkOrder_Typehash_Height_Two
-                                    )
-                                )
+                            typeHash := ternary(
+                                eq(treeHeight, 2),
+                                BulkOrder_Typehash_Height_Two,
+                                BulkOrder_Typehash_Height_One
                             )
 
                             // Exit the loop once typehash has been located.
-                            break
+                            leave
                         }
 
                         // Handle height three and four via branchless logic.
-                        typeHash := xor(
-                            BulkOrder_Typehash_Height_Three,
-                            mul(
-                                eq(treeHeight, 4),
-                                xor(
-                                    BulkOrder_Typehash_Height_Three,
-                                    BulkOrder_Typehash_Height_Four
-                                )
-                            )
+                        typeHash := ternary(
+                            eq(treeHeight, 4),
+                            BulkOrder_Typehash_Height_Four,
+                            BulkOrder_Typehash_Height_Three
                         )
 
                         // Exit the loop once typehash has been located.
-                        break
+                        leave
                     }
 
                     // Handle tree height five and six.
-                    if iszero(gt(treeHeight, 6)) {
+                    if lt(treeHeight, 7) {
                         // Utilize branchless logic to determine typehash.
-                        typeHash := xor(
-                            BulkOrder_Typehash_Height_Five,
-                            mul(
-                                eq(treeHeight, 6),
-                                xor(
-                                    BulkOrder_Typehash_Height_Five,
-                                    BulkOrder_Typehash_Height_Six
-                                )
-                            )
+                        typeHash := ternary(
+                            eq(treeHeight, 6),
+                            BulkOrder_Typehash_Height_Six,
+                            BulkOrder_Typehash_Height_Five
                         )
 
                         // Exit the loop once typehash has been located.
-                        break
+                        leave
                     }
 
                     // Handle height seven and eight via branchless logic.
-                    typeHash := xor(
-                        BulkOrder_Typehash_Height_Seven,
-                        mul(
-                            eq(treeHeight, 8),
-                            xor(
-                                BulkOrder_Typehash_Height_Seven,
-                                BulkOrder_Typehash_Height_Eight
-                            )
-                        )
+                    typeHash := ternary(
+                        eq(treeHeight, 8),
+                        BulkOrder_Typehash_Height_Eight,
+                        BulkOrder_Typehash_Height_Seven
                     )
 
                     // Exit the loop once typehash has been located.
-                    break
+                    leave
                 }
 
                 // Handle tree height nine through sixteen.
-                if iszero(gt(treeHeight, 16)) {
+                if lt(treeHeight, 17) {
                     // Handle tree height nine through twelve.
-                    if iszero(gt(treeHeight, 12)) {
+                    if lt(treeHeight, 13) {
                         // Handle tree height nine and ten.
-                        if iszero(gt(treeHeight, 10)) {
+                        if lt(treeHeight, 11) {
                             // Utilize branchless logic to determine typehash.
-                            typeHash := xor(
-                                BulkOrder_Typehash_Height_Nine,
-                                mul(
-                                    eq(treeHeight, 10),
-                                    xor(
-                                        BulkOrder_Typehash_Height_Nine,
-                                        BulkOrder_Typehash_Height_Ten
-                                    )
-                                )
+                            typeHash := ternary(
+                                eq(treeHeight, 10),
+                                BulkOrder_Typehash_Height_Ten,
+                                BulkOrder_Typehash_Height_Nine
                             )
 
                             // Exit the loop once typehash has been located.
-                            break
+                            leave
                         }
 
                         // Handle height eleven and twelve via branchless logic.
-                        typeHash := xor(
-                            BulkOrder_Typehash_Height_Eleven,
-                            mul(
-                                eq(treeHeight, 12),
-                                xor(
-                                    BulkOrder_Typehash_Height_Eleven,
-                                    BulkOrder_Typehash_Height_Twelve
-                                )
-                            )
+                        typeHash := ternary(
+                            eq(treeHeight, 12),
+                            BulkOrder_Typehash_Height_Twelve,
+                            BulkOrder_Typehash_Height_Eleven
                         )
 
                         // Exit the loop once typehash has been located.
-                        break
+                        leave
                     }
 
                     // Handle tree height thirteen and fourteen.
-                    if iszero(gt(treeHeight, 14)) {
+                    if lt(treeHeight, 15) {
                         // Utilize branchless logic to determine typehash.
-                        typeHash := xor(
-                            BulkOrder_Typehash_Height_Thirteen,
-                            mul(
-                                eq(treeHeight, 14),
-                                xor(
-                                    BulkOrder_Typehash_Height_Thirteen,
-                                    BulkOrder_Typehash_Height_Fourteen
-                                )
-                            )
+                        typeHash := ternary(
+                            eq(treeHeight, 14),
+                            BulkOrder_Typehash_Height_Fourteen,
+                            BulkOrder_Typehash_Height_Thirteen
                         )
 
                         // Exit the loop once typehash has been located.
-                        break
+                        leave
                     }
-
                     // Handle height fifteen and sixteen via branchless logic.
-                    typeHash := xor(
-                        BulkOrder_Typehash_Height_Fifteen,
-                        mul(
-                            eq(treeHeight, 16),
-                            xor(
-                                BulkOrder_Typehash_Height_Fifteen,
-                                BulkOrder_Typehash_Height_Sixteen
-                            )
-                        )
+                    typeHash := ternary(
+                        eq(treeHeight, 16),
+                        BulkOrder_Typehash_Height_Sixteen,
+                        BulkOrder_Typehash_Height_Fifteen
                     )
 
                     // Exit the loop once typehash has been located.
-                    break
+                    leave
                 }
 
                 // Handle tree height seventeen through twenty.
-                if iszero(gt(treeHeight, 20)) {
+                if lt(treeHeight, 21) {
                     // Handle tree height seventeen and eighteen.
-                    if iszero(gt(treeHeight, 18)) {
+                    if lt(treeHeight, 19) {
                         // Utilize branchless logic to determine typehash.
-                        typeHash := xor(
-                            BulkOrder_Typehash_Height_Seventeen,
-                            mul(
-                                eq(treeHeight, 18),
-                                xor(
-                                    BulkOrder_Typehash_Height_Seventeen,
-                                    BulkOrder_Typehash_Height_Eighteen
-                                )
-                            )
+                        typeHash := ternary(
+                            eq(treeHeight, 18),
+                            BulkOrder_Typehash_Height_Eighteen,
+                            BulkOrder_Typehash_Height_Seventeen
                         )
 
                         // Exit the loop once typehash has been located.
-                        break
+                        leave
                     }
 
                     // Handle height nineteen and twenty via branchless logic.
-                    typeHash := xor(
-                        BulkOrder_Typehash_Height_Nineteen,
-                        mul(
-                            eq(treeHeight, 20),
-                            xor(
-                                BulkOrder_Typehash_Height_Nineteen,
-                                BulkOrder_Typehash_Height_Twenty
-                            )
-                        )
+                    typeHash := ternary(
+                        eq(treeHeight, 20),
+                        BulkOrder_Typehash_Height_Twenty,
+                        BulkOrder_Typehash_Height_Nineteen
                     )
 
                     // Exit the loop once typehash has been located.
-                    break
+                    leave
                 }
 
                 // Handle tree height twenty-one and twenty-two.
-                if iszero(gt(treeHeight, 22)) {
+                if lt(treeHeight, 23) {
                     // Utilize branchless logic to determine typehash.
-                    typeHash := xor(
-                        BulkOrder_Typehash_Height_TwentyOne,
-                        mul(
-                            eq(treeHeight, 22),
-                            xor(
-                                BulkOrder_Typehash_Height_TwentyOne,
-                                BulkOrder_Typehash_Height_TwentyTwo
-                            )
-                        )
+                    typeHash := ternary(
+                        eq(treeHeight, 22),
+                        BulkOrder_Typehash_Height_TwentyTwo,
+                        BulkOrder_Typehash_Height_TwentyOne
                     )
 
                     // Exit the loop once typehash has been located.
-                    break
+                    leave
                 }
 
                 // Handle height twenty-three & twenty-four w/ branchless logic.
-                typeHash := xor(
-                    BulkOrder_Typehash_Height_TwentyThree,
-                    mul(
-                        eq(treeHeight, 24),
-                        xor(
-                            BulkOrder_Typehash_Height_TwentyThree,
-                            BulkOrder_Typehash_Height_TwentyFour
-                        )
-                    )
+                typeHash := ternary(
+                    eq(treeHeight, 24),
+                    BulkOrder_Typehash_Height_TwentyFour,
+                    BulkOrder_Typehash_Height_TwentyThree
                 )
 
                 // Exit the loop once typehash has been located.
-                break
+                leave
             }
+            function ternary(cond, ifTrue, ifFalse) -> c {
+                c := xor(ifFalse, mul(cond, xor(ifFalse, ifTrue)))
+            }
+            _typeHash := lookupTypeHash(_treeHeight)
         }
     }
 }

--- a/contracts/lib/ConsiderationBase.sol
+++ b/contracts/lib/ConsiderationBase.sol
@@ -301,10 +301,10 @@ contract ConsiderationBase is
      *      enforced by _isValidBulkOrderSize.
      *
      * @param _treeHeight The height of the bulk order tree. The value must be
-     *                   between one and twenty-four.
+     *                    between one and twenty-four.
      *
      * @return _typeHash The EIP-712 typehash for the bulk order type with the
-     *                  given height.
+     *                   given height.
      */
     function _lookupBulkOrderTypehash(uint256 _treeHeight)
         internal
@@ -324,9 +324,9 @@ contract ConsiderationBase is
                         if lt(treeHeight, 3) {
                             // Utilize branchless logic to determine typehash.
                             typeHash := ternary(
-                                eq(treeHeight, 2),
-                                BulkOrder_Typehash_Height_Two,
-                                BulkOrder_Typehash_Height_One
+                                eq(treeHeight, 1),
+                                BulkOrder_Typehash_Height_One,
+                                BulkOrder_Typehash_Height_Two
                             )
 
                             // Exit the function once typehash has been located.
@@ -335,9 +335,9 @@ contract ConsiderationBase is
 
                         // Handle height three and four via branchless logic.
                         typeHash := ternary(
-                            eq(treeHeight, 4),
-                            BulkOrder_Typehash_Height_Four,
-                            BulkOrder_Typehash_Height_Three
+                            eq(treeHeight, 3),
+                            BulkOrder_Typehash_Height_Three,
+                            BulkOrder_Typehash_Height_Four
                         )
 
                         // Exit the function once typehash has been located.
@@ -348,9 +348,9 @@ contract ConsiderationBase is
                     if lt(treeHeight, 7) {
                         // Utilize branchless logic to determine typehash.
                         typeHash := ternary(
-                            eq(treeHeight, 6),
-                            BulkOrder_Typehash_Height_Six,
-                            BulkOrder_Typehash_Height_Five
+                            eq(treeHeight, 5),
+                            BulkOrder_Typehash_Height_Five,
+                            BulkOrder_Typehash_Height_Six
                         )
 
                         // Exit the function once typehash has been located.
@@ -359,9 +359,9 @@ contract ConsiderationBase is
 
                     // Handle height seven and eight via branchless logic.
                     typeHash := ternary(
-                        eq(treeHeight, 8),
-                        BulkOrder_Typehash_Height_Eight,
-                        BulkOrder_Typehash_Height_Seven
+                        eq(treeHeight, 7),
+                        BulkOrder_Typehash_Height_Seven,
+                        BulkOrder_Typehash_Height_Eight
                     )
 
                     // Exit the function once typehash has been located.
@@ -376,9 +376,9 @@ contract ConsiderationBase is
                         if lt(treeHeight, 11) {
                             // Utilize branchless logic to determine typehash.
                             typeHash := ternary(
-                                eq(treeHeight, 10),
-                                BulkOrder_Typehash_Height_Ten,
-                                BulkOrder_Typehash_Height_Nine
+                                eq(treeHeight, 9),
+                                BulkOrder_Typehash_Height_Nine,
+                                BulkOrder_Typehash_Height_Ten
                             )
 
                             // Exit the function once typehash has been located.
@@ -387,9 +387,9 @@ contract ConsiderationBase is
 
                         // Handle height eleven and twelve via branchless logic.
                         typeHash := ternary(
-                            eq(treeHeight, 12),
-                            BulkOrder_Typehash_Height_Twelve,
-                            BulkOrder_Typehash_Height_Eleven
+                            eq(treeHeight, 11),
+                            BulkOrder_Typehash_Height_Eleven,
+                            BulkOrder_Typehash_Height_Twelve
                         )
 
                         // Exit the function once typehash has been located.
@@ -400,9 +400,9 @@ contract ConsiderationBase is
                     if lt(treeHeight, 15) {
                         // Utilize branchless logic to determine typehash.
                         typeHash := ternary(
-                            eq(treeHeight, 14),
-                            BulkOrder_Typehash_Height_Fourteen,
-                            BulkOrder_Typehash_Height_Thirteen
+                            eq(treeHeight, 13),
+                            BulkOrder_Typehash_Height_Thirteen,
+                            BulkOrder_Typehash_Height_Fourteen
                         )
 
                         // Exit the function once typehash has been located.
@@ -410,9 +410,9 @@ contract ConsiderationBase is
                     }
                     // Handle height fifteen and sixteen via branchless logic.
                     typeHash := ternary(
-                        eq(treeHeight, 16),
-                        BulkOrder_Typehash_Height_Sixteen,
-                        BulkOrder_Typehash_Height_Fifteen
+                        eq(treeHeight, 15),
+                        BulkOrder_Typehash_Height_Fifteen,
+                        BulkOrder_Typehash_Height_Sixteen
                     )
 
                     // Exit the function once typehash has been located.
@@ -425,9 +425,9 @@ contract ConsiderationBase is
                     if lt(treeHeight, 19) {
                         // Utilize branchless logic to determine typehash.
                         typeHash := ternary(
-                            eq(treeHeight, 18),
-                            BulkOrder_Typehash_Height_Eighteen,
-                            BulkOrder_Typehash_Height_Seventeen
+                            eq(treeHeight, 17),
+                            BulkOrder_Typehash_Height_Seventeen,
+                            BulkOrder_Typehash_Height_Eighteen
                         )
 
                         // Exit the function once typehash has been located.
@@ -436,9 +436,9 @@ contract ConsiderationBase is
 
                     // Handle height nineteen and twenty via branchless logic.
                     typeHash := ternary(
-                        eq(treeHeight, 20),
-                        BulkOrder_Typehash_Height_Twenty,
-                        BulkOrder_Typehash_Height_Nineteen
+                        eq(treeHeight, 19),
+                        BulkOrder_Typehash_Height_Nineteen,
+                        BulkOrder_Typehash_Height_Twenty
                     )
 
                     // Exit the function once typehash has been located.
@@ -449,9 +449,9 @@ contract ConsiderationBase is
                 if lt(treeHeight, 23) {
                     // Utilize branchless logic to determine typehash.
                     typeHash := ternary(
-                        eq(treeHeight, 22),
-                        BulkOrder_Typehash_Height_TwentyTwo,
-                        BulkOrder_Typehash_Height_TwentyOne
+                        eq(treeHeight, 21),
+                        BulkOrder_Typehash_Height_TwentyOne,
+                        BulkOrder_Typehash_Height_TwentyTwo
                     )
 
                     // Exit the function once typehash has been located.
@@ -460,17 +460,21 @@ contract ConsiderationBase is
 
                 // Handle height twenty-three & twenty-four w/ branchless logic.
                 typeHash := ternary(
-                    eq(treeHeight, 24),
-                    BulkOrder_Typehash_Height_TwentyFour,
-                    BulkOrder_Typehash_Height_TwentyThree
+                    eq(treeHeight, 23),
+                    BulkOrder_Typehash_Height_TwentyThree,
+                    BulkOrder_Typehash_Height_TwentyFour
                 )
 
                 // Exit the function once typehash has been located.
                 leave
             }
+
+            // Implement ternary conditional using branchless logic.
             function ternary(cond, ifTrue, ifFalse) -> c {
                 c := xor(ifFalse, mul(cond, xor(ifFalse, ifTrue)))
             }
+
+            // Look up the typehash using the supplied tree height.
             _typeHash := lookupTypeHash(_treeHeight)
         }
     }


### PR DESCRIPTION
Minor readability improvements.

Replace `iszero(gt(treeHeight, n))` with `lt(treeHeight, n+1)`
Use a yul function instead of a single-iteration for loop and replace `break` with `leave`.
Replace inlined branchless logic with a ternary yul function (still gets inlined by solc).

The difference is pretty negligible in terms of gas/code, but it is a bit easier to follow.