### PR TITLE
fix amount tracking bug in reference order combiner

### DIFF
--- a/reference/lib/ReferenceOrderCombiner.sol
+++ b/reference/lib/ReferenceOrderCombiner.sol
@@ -311,6 +311,9 @@ contract ReferenceOrderCombiner is
 
                 // Modify the OrderToExecute Spent Item Amount.
                 orderToExecute.spentItems[j].amount = offerItem.startAmount;
+                // Modify the OrderToExecute Spent Item Original Amount.
+                orderToExecute.spentItemOriginalAmounts[j] = offerItem
+                    .startAmount;
             }
 
             // Retrieve array of consideration items for order in question.
@@ -362,6 +365,10 @@ contract ReferenceOrderCombiner is
                 // Modify the OrderToExecute Received item amount.
                 orderToExecute.receivedItems[j].amount = considerationItem
                     .startAmount;
+                // Modify the OrderToExecute Received item original amount.
+                orderToExecute.receivedItemOriginalAmounts[
+                    j
+                ] = considerationItem.startAmount;
             }
         }
 

--- a/test/foundry/zone/PostFulfillmentCheck.t.sol
+++ b/test/foundry/zone/PostFulfillmentCheck.t.sol
@@ -554,15 +554,14 @@ contract PostFulfillmentCheckTest is BaseOrderTest {
                 numTips: 0
             })
         );
-        // todo: fix ref impl
-        // test(
-        //     this.execFulfillAvailableAdvancedAscending,
-        //     Context({
-        //         consideration: referenceConsideration,
-        //         numOriginalAdditional: 0,
-        //         numTips: 0
-        //     })
-        // );
+        test(
+            this.execFulfillAvailableAdvancedAscending,
+            Context({
+                consideration: referenceConsideration,
+                numOriginalAdditional: 0,
+                numTips: 0
+            })
+        );
     }
 
     function execFulfillAvailableAdvancedAscending(


### PR DESCRIPTION
## Motivation

Desire for the reference contracts to exhibit the same behavior as the optimized contracts.

## Solution

Fixed the bug.  Thanks again, gang.
