### PR TITLE
fix _transferERC721() params description

### DIFF
--- a/contracts/lib/Executor.sol
+++ b/contracts/lib/Executor.sol
@@ -243,8 +243,8 @@ contract Executor is Verifiers, TokenTransferrer {
      * @param token       The ERC721 token to transfer.
      * @param from        The originator of the transfer.
      * @param to          The recipient of the transfer.
-     * @param identifier  The tokenId to transfer (must be 1 for ERC721).
-     * @param amount      The amount to transfer.
+     * @param identifier  The tokenId to transfer.
+     * @param amount      The amount to transfer (must be 1 for ERC721).
      * @param conduitKey  A bytes32 value indicating what corresponding conduit,
      *                    if any, to source token approvals from. The zero hash
      *                    signifies that no conduit should be used, with direct


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->
The description of parameters in [contracts/lib/Executor.sol](https://github.com/ProjectOpenSea/seaport/blob/8b4fe79f157352575b90c31050a1055d68881382/contracts/lib/Executor.sol#L246-L247) seems not correct. The `amount` of ERC-721 transfer should be one, not `identifier`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Move `(must be 1 for ERC721)` from `identifier` to `amount`.