### PR TITLE
Repo setup README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,15 @@ yarn profile
 
 ### Foundry Tests
 
-Seaport also includes a suite of fuzzing tests written in solidity with Foundry.
+Seaport also includes a suite of fuzzing tests written in Solidity with Foundry.
+
+Before running these tests, you will need to compile an optimized build by running:
+
+```bash
+FOUNDRY_PROFILE=optimized forge build
+```
+
+This should create an `optimized-out/` directory in your project root.
 
 To run tests with full traces and debugging with source, create an `.env` file with the following line:
 
@@ -397,7 +405,7 @@ FOUNDRY_PROFILE=debug
 
 You may then run tests with `forge test`, optionally specifying a level of verbosity (anywhere from one to five `v`'s, eg, `-vvv`)
 
-This will compile tests and contracts without `via-ir` enabled, which is must faster, but will not exactly match the deployed bytecode.
+This will compile tests and contracts without `via-ir` enabled, which is much faster, but will not exactly match the deployed bytecode.
 
 To run tests against the actual bytecode intended to be deployed on networks, you will need to pre-compile the contracts, and remove the `FOUNDRY_PROFILE` variable from your `.env` file. **Note** that informative error traces may not be available, and the Forge debugger will not show the accompanying source code.
 

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ To run Forge coverage tests and open the generated coverage report locally:
 
 ```bash
 brew install lcov
-SEAPORT_COVERAGE=true forge coverage --report summary --report lcov && genhtml lcov.info -o html --branch
+SEAPORT_COVERAGE=true forge coverage --report summary --report lcov && lcov -o lcov.info --remove lcov.info --rc lcov_branch_coverage=1 --rc lcov_function_coverage=1 "test/*" "script/*" && genhtml lcov.info -o html --branch
 open html/index.html
 ```
 


### PR DESCRIPTION
## Motivation

Two small updates from setting up the repo and working through the `README`.

1. A few of the Foundry tests read compiled artifacts from the `optimized-out` directory, so an optimized build is a prerequisite to running `forge test`. Tests fail if you run `forge test` from a fresh repo without running an optimized build first.
2. It's possible to filter out unwanted paths from the coverage report by using `lcov` to exclude them from the generated `lcov.info` file.

## Solution

1. Add the optimized build step under "Foundry Tests". 
2. Update the coverage command to filter `test/*` and `script/*` from the generated HTML coverage report. (Note that the one-line command in the README is now pretty long and might be worth extracting to a script.)

Here's an example coverage report with these changes:

<img width="896" alt="Screenshot 2023-03-10 at 4 32 44 PM" src="https://user-images.githubusercontent.com/109845214/224434655-3f7ef8d5-ff9d-4c5b-96c4-cdd536a7a94b.png">



