### PR TITLE
Test annotations + explicit named args

### DIFF
--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -277,7 +277,7 @@ contract FulfillOrderTest is BaseOrderTest {
      * @dev fulfillOrder should fill valid orders with ascending and descending offer item amounts
      *
      *      Arrange: Create a FULL_OPEN order with an ERC20 offer item and a fuzzed ascending/descending
-                     amount. Consider 1000 wei of native ETH.
+     *               amount. Consider 1000 wei of native ETH.
      *      Act:     Attempt to fill with fulfillOrder.
      *      Assert:  Should succeed and emit a Transfer event.
      */
@@ -391,8 +391,8 @@ contract FulfillOrderTest is BaseOrderTest {
     /**
      * @dev fulfillOrder should fill valid orders with ascending and descending consideration item amounts
      *
-     *      Arrange: Create a FULL_OPEN order with an ERC1155 offer item. Consider a fuzzed
-                     ascending/descending amount of ERC20 token.
+     *      Arrange: Create a FULL_OPEN order with an ERC1155 offer item. Consider a fuzzed ascending/descending
+     *               amount of ERC20 token.
      *      Act:     Attempt to fill with fulfillOrder.
      *      Assert:  Should succeed and emit a Transfer event.
      */


### PR DESCRIPTION
## Motivation
I found it a little difficult to get my bearings in the tests, and jumped around a lot looking up helper functions and structs. I started these annotations for myself, but maybe this pattern will be useful everywhere.

## Solution

- Add top-level comments to tests with a short summary of each test case. This includes a short summary of what it tests, plus a brief description of its "arrange," "act," "assert" steps.
- Use named args syntax for structs and calls to helper functions. This makes it easier to follow what each arg represents without having to jump outside the test context. 
- Add internal comments to tests where helpful.
- Factor out repeated references (like `startTime` in the ascending/descending offer/consideration tests)
