### PR TITLE
tweak some expectEmits

### DIFF
--- a/test/foundry/FulfillBasicOrderTest.t.sol
+++ b/test/foundry/FulfillBasicOrderTest.t.sol
@@ -741,7 +741,7 @@ contract FulfillBasicOrderTest is BaseOrderTest, ConsiderationEventsAndErrors {
 
         vm.prank(alice);
 
-        vm.expectEmit(true, true, true, false, address(context.consideration));
+        vm.expectEmit(false, true, true, false, address(context.consideration));
         emit OrderCancelled(orderHash, alice, context.args.zone);
         context.consideration.cancel(myBaseOrderComponents);
 

--- a/test/foundry/FulfillOrderTest.t.sol
+++ b/test/foundry/FulfillOrderTest.t.sol
@@ -274,7 +274,7 @@ contract FulfillOrderTest is BaseOrderTest {
             startTime + 1000,
             false // don't round up offers
         );
-        vm.expectEmit(true, true, true, false, address(token1));
+        vm.expectEmit(true, true, false, true, address(token1));
         emit Transfer(alice, address(this), expectedAmount);
         context.consideration.fulfillOrder{ value: 1000 }(
             Order(orderParameters, signature),
@@ -350,7 +350,7 @@ contract FulfillOrderTest is BaseOrderTest {
             true // round up considerations
         );
         token1.mint(address(this), expectedAmount);
-        vm.expectEmit(true, true, true, false, address(token1));
+        vm.expectEmit(true, true, false, true, address(token1));
         emit Transfer(address(this), address(alice), expectedAmount);
         context.consideration.fulfillOrder(
             Order(orderParameters, signature),

--- a/test/foundry/NonReentrant.t.sol
+++ b/test/foundry/NonReentrant.t.sol
@@ -116,10 +116,10 @@ contract NonReentrantTest is BaseOrderTest {
             if (!reentering) {
                 shouldReenter = true;
                 vm.expectEmit(
+                    false,
+                    false,
+                    false,
                     true,
-                    false,
-                    false,
-                    false,
                     address(address(this))
                 );
                 emit BytesReason(abi.encodeWithSignature("NoReentrantCalls()"));
@@ -132,10 +132,10 @@ contract NonReentrantTest is BaseOrderTest {
             if (!reentering) {
                 shouldReenter = true;
                 vm.expectEmit(
+                    false,
+                    false,
+                    false,
                     true,
-                    false,
-                    false,
-                    false,
                     address(address(this))
                 );
                 emit BytesReason(abi.encodeWithSignature("NoReentrantCalls()"));
@@ -151,7 +151,7 @@ contract NonReentrantTest is BaseOrderTest {
                 uint256 value
             ) = prepareOrder(tokenId);
             if (!reentering) {
-                vm.expectEmit(true, false, false, true, address(this));
+                vm.expectEmit(false, false, false, true, address(this));
                 emit BytesReason(abi.encodeWithSignature("NoReentrantCalls()"));
             }
             currentConsideration.fulfillOrder{ value: value }(
@@ -166,7 +166,7 @@ contract NonReentrantTest is BaseOrderTest {
                 uint256 value
             ) = prepareAdvancedOrder(tokenId);
             if (!reentering) {
-                vm.expectEmit(true, false, false, true, address(this));
+                vm.expectEmit(false, false, false, true, address(this));
                 emit BytesReason(abi.encodeWithSignature("NoReentrantCalls()"));
             }
             currentConsideration.fulfillAdvancedOrder{ value: value }(
@@ -184,7 +184,7 @@ contract NonReentrantTest is BaseOrderTest {
                 uint256 maximumFulfilled
             ) = prepareAvailableOrders(tokenId);
             if (!reentering) {
-                vm.expectEmit(true, false, false, true, address(this));
+                vm.expectEmit(false, false, false, true, address(this));
                 emit BytesReason(abi.encodeWithSignature("NoReentrantCalls()"));
             }
             vm.prank(alice);
@@ -205,7 +205,7 @@ contract NonReentrantTest is BaseOrderTest {
                 uint256 maximumFulfilled
             ) = prepareFulfillAvailableAdvancedOrders(tokenId);
             if (!reentering) {
-                vm.expectEmit(true, false, false, true, address(this));
+                vm.expectEmit(false, false, false, true, address(this));
                 emit BytesReason(abi.encodeWithSignature("NoReentrantCalls()"));
             }
             vm.prank(alice);
@@ -224,7 +224,7 @@ contract NonReentrantTest is BaseOrderTest {
                 Fulfillment[] memory _fulfillments
             ) = prepareMatchOrders(tokenId);
             if (!reentering) {
-                vm.expectEmit(true, false, false, true, address(this));
+                vm.expectEmit(false, false, false, true, address(this));
                 emit BytesReason(abi.encodeWithSignature("NoReentrantCalls()"));
             }
             currentConsideration.matchOrders{ value: 1 }(
@@ -238,7 +238,7 @@ contract NonReentrantTest is BaseOrderTest {
                 Fulfillment[] memory _fulfillments
             ) = prepareMatchAdvancedOrders(tokenId);
             if (!reentering) {
-                vm.expectEmit(true, false, false, true, address(this));
+                vm.expectEmit(false, false, false, true, address(this));
                 emit BytesReason(abi.encodeWithSignature("NoReentrantCalls()"));
             }
             currentConsideration.matchAdvancedOrders{ value: 1 }(

--- a/test/foundry/TransferHelperMultipleRecipientsTest.sol
+++ b/test/foundry/TransferHelperMultipleRecipientsTest.sol
@@ -363,7 +363,7 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
                     // ERC1155 has three indexed topics plus data.
 
                     if (item.itemType == ConduitItemType.ERC20) {
-                        vm.expectEmit(true, true, true, true, item.token);
+                        vm.expectEmit(true, true, false, true, item.token);
 
                         emit Transfer(
                             from,
@@ -439,7 +439,7 @@ contract TransferHelperMultipleRecipientsTest is BaseOrderTest {
                     // but tokenId is indexed for 721 and not for ERC20 (so amount is data)
                     // ERC1155 has three indexed topics plus data.
                     if (item.itemType == ConduitItemType.ERC20) {
-                        vm.expectEmit(true, true, true, true, item.token);
+                        vm.expectEmit(true, true, false, true, item.token);
 
                         emit Transfer(
                             from,


### PR DESCRIPTION
Mostly just tweaks to make it easier to intuit the behavior of `vm.expectEmit`, but also fixes some silent successes.


