### PR TITLE
add safeguards to new lib

### DIFF
--- a/contracts/helpers/sol/lib/AdditionalRecipientLib.sol
+++ b/contracts/helpers/sol/lib/AdditionalRecipientLib.sol
@@ -17,6 +17,15 @@ library AdditionalRecipientLib {
         keccak256("seaport.AdditionalRecipientDefaults");
     bytes32 private constant ADDITIONAL_RECIPIENTS_MAP_POSITION =
         keccak256("seaport.AdditionalRecipientsDefaults");
+    bytes32 private constant EMPTY_ADDITIONAL_RECIPIENT =
+        keccak256(
+            abi.encode(
+                AdditionalRecipient({
+                    amount: 0,
+                    recipient: payable(address(0))
+                })
+            )
+        );
 
     /**
      * @dev Clears a default AdditionalRecipient from storage.
@@ -66,6 +75,10 @@ library AdditionalRecipientLib {
         mapping(string => AdditionalRecipient)
             storage additionalRecipientMap = _additionalRecipientMap();
         item = additionalRecipientMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_ADDITIONAL_RECIPIENT) {
+            revert("Empty AdditionalRecipient selected.");
+        }
     }
 
     /**
@@ -81,6 +94,10 @@ library AdditionalRecipientLib {
         mapping(string => AdditionalRecipient[])
             storage additionalRecipientsMap = _additionalRecipientsMap();
         items = additionalRecipientsMap[defaultName];
+
+        if (items.length == 0) {
+            revert("Empty AdditionalRecipient array selected.");
+        }
     }
 
     /**

--- a/contracts/helpers/sol/lib/AdvancedOrderLib.sol
+++ b/contracts/helpers/sol/lib/AdvancedOrderLib.sol
@@ -3,8 +3,11 @@ pragma solidity ^0.8.17;
 
 import {
     AdvancedOrder,
+    ConsiderationItem,
+    OfferItem,
     Order,
-    OrderParameters
+    OrderParameters,
+    OrderType
 } from "../../../lib/ConsiderationStructs.sol";
 
 import { OrderParametersLib } from "./OrderParametersLib.sol";
@@ -23,6 +26,30 @@ library AdvancedOrderLib {
         keccak256("seaport.AdvancedOrderDefaults");
     bytes32 private constant ADVANCED_ORDERS_MAP_POSITION =
         keccak256("seaport.AdvancedOrdersDefaults");
+    bytes32 private constant EMPTY_ADVANCED_ORDER =
+        keccak256(
+            abi.encode(
+                AdvancedOrder({
+                    parameters: OrderParameters({
+                        offerer: address(0),
+                        zone: address(0),
+                        offer: new OfferItem[](0),
+                        consideration: new ConsiderationItem[](0),
+                        orderType: OrderType(0),
+                        startTime: 0,
+                        endTime: 0,
+                        zoneHash: bytes32(0),
+                        salt: 0,
+                        conduitKey: bytes32(0),
+                        totalOriginalConsiderationItems: 0
+                    }),
+                    numerator: 0,
+                    denominator: 0,
+                    signature: new bytes(0),
+                    extraData: new bytes(0)
+                })
+            )
+        );
 
     using OrderParametersLib for OrderParameters;
 
@@ -77,6 +104,10 @@ library AdvancedOrderLib {
         mapping(string => AdvancedOrder)
             storage advancedOrderMap = _advancedOrderMap();
         item = advancedOrderMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_ADVANCED_ORDER) {
+            revert("Empty AdvancedOrder selected.");
+        }
     }
 
     /**
@@ -92,6 +123,10 @@ library AdvancedOrderLib {
         mapping(string => AdvancedOrder[])
             storage advancedOrdersMap = _advancedOrdersMap();
         items = advancedOrdersMap[defaultName];
+
+        if (items.length == 0) {
+            revert("Empty AdvancedOrder array selected.");
+        }
     }
 
     /**

--- a/contracts/helpers/sol/lib/BasicOrderParametersLib.sol
+++ b/contracts/helpers/sol/lib/BasicOrderParametersLib.sol
@@ -28,6 +28,31 @@ library BasicOrderParametersLib {
         keccak256("seaport.BasicOrderParametersDefaults");
     bytes32 private constant BASIC_ORDER_PARAMETERS_ARRAY_MAP_POSITION =
         keccak256("seaport.BasicOrderParametersArrayDefaults");
+    bytes32 private constant EMPTY_BASIC_ORDER_PARAMETERS =
+        keccak256(
+            abi.encode(
+                BasicOrderParameters({
+                    considerationToken: address(0),
+                    considerationIdentifier: 0,
+                    considerationAmount: 0,
+                    offerer: payable(address(0)),
+                    zone: address(0),
+                    offerToken: address(0),
+                    offerIdentifier: 0,
+                    offerAmount: 0,
+                    basicOrderType: BasicOrderType(0),
+                    startTime: 0,
+                    endTime: 0,
+                    zoneHash: bytes32(0),
+                    salt: 0,
+                    offererConduitKey: bytes32(0),
+                    fulfillerConduitKey: bytes32(0),
+                    totalOriginalAdditionalRecipients: 0,
+                    additionalRecipients: new AdditionalRecipient[](0),
+                    signature: ""
+                })
+            )
+        );
 
     /**
      * @dev Clears a default BasicOrderParameters from storage.
@@ -131,6 +156,10 @@ library BasicOrderParametersLib {
         mapping(string => BasicOrderParameters)
             storage orderParametersMap = _orderParametersMap();
         item = orderParametersMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_BASIC_ORDER_PARAMETERS) {
+            revert("Empty BasicOrderParameters selected.");
+        }
     }
 
     /**
@@ -146,6 +175,10 @@ library BasicOrderParametersLib {
         mapping(string => BasicOrderParameters[])
             storage orderParametersArrayMap = _orderParametersArrayMap();
         items = orderParametersArrayMap[defaultName];
+
+        if (items.length == 0) {
+            revert("Empty BasicOrderParameters array selected.");
+        }
     }
 
     /**

--- a/contracts/helpers/sol/lib/ConsiderationItemLib.sol
+++ b/contracts/helpers/sol/lib/ConsiderationItemLib.sol
@@ -22,6 +22,19 @@ library ConsiderationItemLib {
         keccak256("seaport.ConsiderationItemDefaults");
     bytes32 private constant CONSIDERATION_ITEMS_MAP_POSITION =
         keccak256("seaport.ConsiderationItemsDefaults");
+    bytes32 private constant EMPTY_CONSIDERATION_ITEM =
+        keccak256(
+            abi.encode(
+                ConsiderationItem({
+                    itemType: ItemType(0),
+                    token: address(0),
+                    identifierOrCriteria: 0,
+                    startAmount: 0,
+                    endAmount: 0,
+                    recipient: payable(address(0))
+                })
+            )
+        );
 
     /**
      * @dev Clears a ConsiderationItem from storage.
@@ -78,6 +91,10 @@ library ConsiderationItemLib {
         mapping(string => ConsiderationItem)
             storage considerationItemMap = _considerationItemMap();
         item = considerationItemMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_CONSIDERATION_ITEM) {
+            revert("Empty ConsiderationItem selected.");
+        }
     }
 
     /**
@@ -93,6 +110,10 @@ library ConsiderationItemLib {
         mapping(string => ConsiderationItem[])
             storage considerationItemsMap = _considerationItemsMap();
         items = considerationItemsMap[defaultsName];
+
+        if (items.length == 0) {
+            revert("Empty ConsiderationItem array selected.");
+        }
     }
 
     /**

--- a/contracts/helpers/sol/lib/CriteriaResolverLib.sol
+++ b/contracts/helpers/sol/lib/CriteriaResolverLib.sol
@@ -21,6 +21,18 @@ library CriteriaResolverLib {
         keccak256("seaport.CriteriaResolverDefaults");
     bytes32 private constant CRITERIA_RESOLVERS_MAP_POSITION =
         keccak256("seaport.CriteriaResolversDefaults");
+    bytes32 private constant EMPTY_CRITERIA_RESOLVER =
+        keccak256(
+            abi.encode(
+                CriteriaResolver({
+                    orderIndex: 0,
+                    side: Side(0),
+                    index: 0,
+                    identifier: 0,
+                    criteriaProof: new bytes32[](0)
+                })
+            )
+        );
 
     using ArrayLib for bytes32[];
 
@@ -66,14 +78,18 @@ library CriteriaResolverLib {
     /**
      * @dev Gets a default CriteriaResolver from storage.
      *
-     * @param defaultName the name of the default for retrieval
+     * @param item the name of the default for retrieval
      */
     function fromDefault(
         string memory defaultName
-    ) internal view returns (CriteriaResolver memory resolver) {
+    ) internal view returns (CriteriaResolver memory item) {
         mapping(string => CriteriaResolver)
             storage criteriaResolverMap = _criteriaResolverMap();
-        resolver = criteriaResolverMap[defaultName];
+        item = criteriaResolverMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_CRITERIA_RESOLVER) {
+            revert("Empty CriteriaResolver selected.");
+        }
     }
 
     /**
@@ -81,14 +97,18 @@ library CriteriaResolverLib {
      *
      * @param defaultsName the name of the default array for retrieval
      *
-     * @return resolvers the CriteriaResolvers retrieved from storage
+     * @return items the CriteriaResolvers retrieved from storage
      */
     function fromDefaultMany(
         string memory defaultsName
-    ) internal view returns (CriteriaResolver[] memory resolvers) {
+    ) internal view returns (CriteriaResolver[] memory items) {
         mapping(string => CriteriaResolver[])
             storage criteriaResolversMap = _criteriaResolversMap();
-        resolvers = criteriaResolversMap[defaultsName];
+        items = criteriaResolversMap[defaultsName];
+
+        if (items.length == 0) {
+            revert("Empty CriteriaResolver array selected.");
+        }
     }
 
     /**

--- a/contracts/helpers/sol/lib/ExecutionLib.sol
+++ b/contracts/helpers/sol/lib/ExecutionLib.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { Execution, ReceivedItem } from "../../../lib/ConsiderationStructs.sol";
+import {
+    Execution,
+    ItemType,
+    ReceivedItem
+} from "../../../lib/ConsiderationStructs.sol";
 
 import { ReceivedItemLib } from "./ReceivedItemLib.sol";
 
@@ -19,6 +23,22 @@ library ExecutionLib {
         keccak256("seaport.ExecutionDefaults");
     bytes32 private constant EXECUTIONS_MAP_POSITION =
         keccak256("seaport.ExecutionsDefaults");
+    bytes32 private constant EMPTY_EXECUTION =
+        keccak256(
+            abi.encode(
+                Execution({
+                    item: ReceivedItem({
+                        itemType: ItemType(0),
+                        token: address(0),
+                        identifier: 0,
+                        amount: 0,
+                        recipient: payable(address(0))
+                    }),
+                    offerer: address(0),
+                    conduitKey: bytes32(0)
+                })
+            )
+        );
 
     using ReceivedItemLib for ReceivedItem;
     using ReceivedItemLib for ReceivedItem[];
@@ -70,6 +90,10 @@ library ExecutionLib {
     ) internal view returns (Execution memory item) {
         mapping(string => Execution) storage executionMap = _executionMap();
         item = executionMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_EXECUTION) {
+            revert("Empty Execution selected.");
+        }
     }
 
     /**
@@ -84,6 +108,10 @@ library ExecutionLib {
     ) internal view returns (Execution[] memory items) {
         mapping(string => Execution[]) storage executionsMap = _executionsMap();
         items = executionsMap[defaultName];
+
+        if (items.length == 0) {
+            revert("Empty Execution array selected.");
+        }
     }
 
     /**

--- a/contracts/helpers/sol/lib/FulfillmentComponentLib.sol
+++ b/contracts/helpers/sol/lib/FulfillmentComponentLib.sol
@@ -63,14 +63,14 @@ library FulfillmentComponentLib {
      *
      * @param defaultName the name of the default for retrieval
      *
-     * @return component the FulfillmentComponent retrieved from storage
+     * @return item the FulfillmentComponent retrieved from storage
      */
     function fromDefault(
         string memory defaultName
-    ) internal view returns (FulfillmentComponent memory component) {
+    ) internal view returns (FulfillmentComponent memory item) {
         mapping(string => FulfillmentComponent)
             storage fulfillmentComponentMap = _fulfillmentComponentMap();
-        component = fulfillmentComponentMap[defaultName];
+        item = fulfillmentComponentMap[defaultName];
     }
 
     /**
@@ -78,14 +78,14 @@ library FulfillmentComponentLib {
      *
      * @param defaultName the name of the default for retrieval
      *
-     * @return components the FulfillmentComponents retrieved from storage
+     * @return items the FulfillmentComponents retrieved from storage
      */
     function fromDefaultMany(
         string memory defaultName
-    ) internal view returns (FulfillmentComponent[] memory components) {
+    ) internal view returns (FulfillmentComponent[] memory items) {
         mapping(string => FulfillmentComponent[])
             storage fulfillmentComponentMap = _fulfillmentComponentsMap();
-        components = fulfillmentComponentMap[defaultName];
+        items = fulfillmentComponentMap[defaultName];
     }
 
     /**

--- a/contracts/helpers/sol/lib/FulfillmentLib.sol
+++ b/contracts/helpers/sol/lib/FulfillmentLib.sol
@@ -48,14 +48,14 @@ library FulfillmentLib {
      *
      * @param defaultName the name of the default for retrieval
      *
-     * @return _fulfillment the Fulfillment retrieved from storage
+     * @return item the Fulfillment retrieved from storage
      */
     function fromDefault(
         string memory defaultName
-    ) internal view returns (Fulfillment memory _fulfillment) {
+    ) internal view returns (Fulfillment memory item) {
         mapping(string => Fulfillment)
             storage fulfillmentMap = _fulfillmentMap();
-        _fulfillment = fulfillmentMap[defaultName];
+        item = fulfillmentMap[defaultName];
     }
 
     /**
@@ -63,14 +63,14 @@ library FulfillmentLib {
      *
      * @param defaultName the name of the default for retrieval
      *
-     * @return _fulfillments the Fulfillment array retrieved from storage
+     * @return items the Fulfillment array retrieved from storage
      */
     function fromDefaultMany(
         string memory defaultName
-    ) internal view returns (Fulfillment[] memory _fulfillments) {
+    ) internal view returns (Fulfillment[] memory items) {
         mapping(string => Fulfillment[])
             storage fulfillmentsMap = _fulfillmentsMap();
-        _fulfillments = fulfillmentsMap[defaultName];
+        items = fulfillmentsMap[defaultName];
     }
 
     /**

--- a/contracts/helpers/sol/lib/OfferItemLib.sol
+++ b/contracts/helpers/sol/lib/OfferItemLib.sol
@@ -18,6 +18,18 @@ library OfferItemLib {
         keccak256("seaport.OfferItemDefaults");
     bytes32 private constant OFFER_ITEMS_MAP_POSITION =
         keccak256("seaport.OfferItemsDefaults");
+    bytes32 private constant EMPTY_OFFER_ITEM =
+        keccak256(
+            abi.encode(
+                OfferItem({
+                    itemType: ItemType(0),
+                    token: address(0),
+                    identifierOrCriteria: 0,
+                    startAmount: 0,
+                    endAmount: 0
+                })
+            )
+        );
 
     /**
      * @dev Clears an OfferItem from storage.
@@ -70,6 +82,10 @@ library OfferItemLib {
     ) internal view returns (OfferItem memory item) {
         mapping(string => OfferItem) storage offerItemMap = _offerItemMap();
         item = offerItemMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_OFFER_ITEM) {
+            revert("Empty OfferItem selected.");
+        }
     }
 
     /**
@@ -84,6 +100,10 @@ library OfferItemLib {
     ) internal view returns (OfferItem[] memory items) {
         mapping(string => OfferItem[]) storage offerItemsMap = _offerItemsMap();
         items = offerItemsMap[defaultsName];
+
+        if (items.length == 0) {
+            revert("Empty OfferItem array selected.");
+        }
     }
 
     /**

--- a/contracts/helpers/sol/lib/OrderComponentsLib.sol
+++ b/contracts/helpers/sol/lib/OrderComponentsLib.sol
@@ -36,6 +36,24 @@ library OrderComponentsLib {
         keccak256("seaport.OrderComponentsDefaults");
     bytes32 private constant ORDER_COMPONENTS_ARRAY_MAP_POSITION =
         keccak256("seaport.OrderComponentsArrayDefaults");
+    bytes32 private constant EMPTY_ORDER_COMPONENTS =
+        keccak256(
+            abi.encode(
+                OrderComponents({
+                    offerer: address(0),
+                    zone: address(0),
+                    offer: new OfferItem[](0),
+                    consideration: new ConsiderationItem[](0),
+                    orderType: OrderType(0),
+                    startTime: 0,
+                    endTime: 0,
+                    zoneHash: bytes32(0),
+                    salt: 0,
+                    conduitKey: bytes32(0),
+                    counter: 0
+                })
+            )
+        );
 
     /**
      * @dev Clears anOrderComponents from storage.
@@ -124,6 +142,10 @@ library OrderComponentsLib {
         mapping(string => OrderComponents)
             storage orderComponentsMap = _orderComponentsMap();
         item = orderComponentsMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_ORDER_COMPONENTS) {
+            revert("Empty OrderComponents selected.");
+        }
     }
 
     /**
@@ -139,6 +161,10 @@ library OrderComponentsLib {
         mapping(string => OrderComponents[])
             storage orderComponentsArrayMap = _orderComponentsArrayMap();
         items = orderComponentsArrayMap[defaultName];
+
+        if (items.length == 0) {
+            revert("Empty OrderComponents array selected.");
+        }
     }
 
     /**

--- a/contracts/helpers/sol/lib/OrderLib.sol
+++ b/contracts/helpers/sol/lib/OrderLib.sol
@@ -3,8 +3,11 @@ pragma solidity ^0.8.17;
 
 import {
     AdvancedOrder,
+    ConsiderationItem,
+    OfferItem,
     Order,
-    OrderParameters
+    OrderParameters,
+    OrderType
 } from "../../../lib/ConsiderationStructs.sol";
 
 import { OrderParametersLib } from "./OrderParametersLib.sol";
@@ -23,6 +26,27 @@ library OrderLib {
         keccak256("seaport.OrderDefaults");
     bytes32 private constant ORDERS_MAP_POSITION =
         keccak256("seaport.OrdersDefaults");
+    bytes32 private constant EMPTY_ORDER =
+        keccak256(
+            abi.encode(
+                Order({
+                    parameters: OrderParameters({
+                        offerer: address(0),
+                        zone: address(0),
+                        offer: new OfferItem[](0),
+                        consideration: new ConsiderationItem[](0),
+                        orderType: OrderType(0),
+                        startTime: 0,
+                        endTime: 0,
+                        zoneHash: bytes32(0),
+                        salt: 0,
+                        conduitKey: bytes32(0),
+                        totalOriginalConsiderationItems: 0
+                    }),
+                    signature: ""
+                })
+            )
+        );
 
     using OrderParametersLib for OrderParameters;
 
@@ -72,6 +96,10 @@ library OrderLib {
     ) internal view returns (Order memory item) {
         mapping(string => Order) storage orderMap = _orderMap();
         item = orderMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_ORDER) {
+            revert("Empty Order selected.");
+        }
     }
 
     /**
@@ -86,6 +114,11 @@ library OrderLib {
     ) internal view returns (Order[] memory) {
         mapping(string => Order[]) storage ordersMap = _ordersMap();
         Order[] memory items = ordersMap[defaultName];
+
+        if (items.length == 0) {
+            revert("Empty Order array selected.");
+        }
+
         return items;
     }
 

--- a/contracts/helpers/sol/lib/OrderParametersLib.sol
+++ b/contracts/helpers/sol/lib/OrderParametersLib.sol
@@ -34,6 +34,24 @@ library OrderParametersLib {
         keccak256("seaport.OrderParametersDefaults");
     bytes32 private constant ORDER_PARAMETERS_ARRAY_MAP_POSITION =
         keccak256("seaport.OrderParametersArrayDefaults");
+    bytes32 private constant EMPTY_ORDER_PARAMETERS =
+        keccak256(
+            abi.encode(
+                OrderParameters({
+                    offerer: address(0),
+                    zone: address(0),
+                    offer: new OfferItem[](0),
+                    consideration: new ConsiderationItem[](0),
+                    orderType: OrderType(0),
+                    startTime: 0,
+                    endTime: 0,
+                    zoneHash: bytes32(0),
+                    salt: 0,
+                    conduitKey: bytes32(0),
+                    totalOriginalConsiderationItems: 0
+                })
+            )
+        );
 
     /**
      * @dev Clears an OrderParameters from storage.
@@ -122,6 +140,10 @@ library OrderParametersLib {
         mapping(string => OrderParameters)
             storage orderParametersMap = _orderParametersMap();
         item = orderParametersMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_ORDER_PARAMETERS) {
+            revert("Empty OrderParameters selected.");
+        }
     }
 
     /**
@@ -137,6 +159,10 @@ library OrderParametersLib {
         mapping(string => OrderParameters[])
             storage orderParametersArrayMap = _orderParametersArrayMap();
         items = orderParametersArrayMap[defaultName];
+
+        if (items.length == 0) {
+            revert("Empty OrderParameters array selected.");
+        }
     }
 
     /**

--- a/contracts/helpers/sol/lib/ReceivedItemLib.sol
+++ b/contracts/helpers/sol/lib/ReceivedItemLib.sol
@@ -22,6 +22,18 @@ library ReceivedItemLib {
         keccak256("seaport.ReceivedItemDefaults");
     bytes32 private constant RECEIVED_ITEMS_MAP_POSITION =
         keccak256("seaport.ReceivedItemsDefaults");
+    bytes32 private constant EMPTY_RECEIVED_ITEM =
+        keccak256(
+            abi.encode(
+                ReceivedItem({
+                    itemType: ItemType(0),
+                    token: address(0),
+                    identifier: 0,
+                    amount: 0,
+                    recipient: payable(address(0))
+                })
+            )
+        );
 
     /**
      * @dev Clears a default ReceivedItem from storage.
@@ -102,6 +114,10 @@ library ReceivedItemLib {
         mapping(string => ReceivedItem)
             storage receivedItemMap = _receivedItemMap();
         item = receivedItemMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_RECEIVED_ITEM) {
+            revert("Empty ReceivedItem selected.");
+        }
     }
 
     /**
@@ -117,6 +133,10 @@ library ReceivedItemLib {
         mapping(string => ReceivedItem[])
             storage receivedItemsMap = _receivedItemsMap();
         items = receivedItemsMap[defaultsName];
+
+        if (items.length == 0) {
+            revert("Empty ReceivedItem array selected.");
+        }
     }
 
     /**

--- a/contracts/helpers/sol/lib/SpentItemLib.sol
+++ b/contracts/helpers/sol/lib/SpentItemLib.sol
@@ -17,6 +17,17 @@ library SpentItemLib {
         keccak256("seaport.SpentItemDefaults");
     bytes32 private constant SPENT_ITEMS_MAP_POSITION =
         keccak256("seaport.SpentItemsDefaults");
+    bytes32 private constant EMPTY_SPENT_ITEM =
+        keccak256(
+            abi.encode(
+                SpentItem({
+                    itemType: ItemType(0),
+                    token: address(0),
+                    identifier: 0,
+                    amount: 0
+                })
+            )
+        );
 
     /**
      * @dev Creates an empty SpentItem.
@@ -86,6 +97,10 @@ library SpentItemLib {
     ) internal view returns (SpentItem memory item) {
         mapping(string => SpentItem) storage spentItemMap = _spentItemMap();
         item = spentItemMap[defaultName];
+
+        if (keccak256(abi.encode(item)) == EMPTY_SPENT_ITEM) {
+            revert("Empty SpentItem selected.");
+        }
     }
 
     /**
@@ -100,6 +115,10 @@ library SpentItemLib {
     ) internal view returns (SpentItem[] memory items) {
         mapping(string => SpentItem[]) storage spentItemsMap = _spentItemsMap();
         items = spentItemsMap[defaultsName];
+
+        if (items.length == 0) {
+            revert("Empty SpentItem array selected.");
+        }
     }
 
     /**

--- a/test/foundry/helpers/sol/lib/AdditionalRecipientLib.t.sol
+++ b/test/foundry/helpers/sol/lib/AdditionalRecipientLib.t.sol
@@ -28,6 +28,14 @@ contract AdditionalRecipientLibTest is BaseTest {
         assertEq(additionalRecipient, defaultAdditionalRecipient);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty AdditionalRecipient selected.");
+        AdditionalRecipientLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty AdditionalRecipient array selected.");
+        AdditionalRecipientLib.fromDefaultMany("nonexistent");
+    }
+
     function testComposeEmpty(
         uint256 amount,
         address payable recipient

--- a/test/foundry/helpers/sol/lib/AdvancedOrderLib.t.sol
+++ b/test/foundry/helpers/sol/lib/AdvancedOrderLib.t.sol
@@ -40,6 +40,14 @@ contract AdvancedOrderLibTest is BaseTest {
         assertEq(advancedOrder, defaultAdvancedOrder);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty AdvancedOrder selected.");
+        AdvancedOrderLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty AdvancedOrder array selected.");
+        AdvancedOrderLib.fromDefaultMany("nonexistent");
+    }
+
     function testComposeEmpty(
         uint120 numerator,
         uint120 denominator,

--- a/test/foundry/helpers/sol/lib/BasicOrderParametersLib.t.sol
+++ b/test/foundry/helpers/sol/lib/BasicOrderParametersLib.t.sol
@@ -106,6 +106,14 @@ contract BasicOrderParametersLibTest is BaseTest {
         assertEq(basicOrderParameters, defaultBasicOrderParameters);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty BasicOrderParameters selected.");
+        BasicOrderParametersLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty BasicOrderParameters array selected.");
+        BasicOrderParametersLib.fromDefaultMany("nonexistent");
+    }
+
     function testCopy() public {
         AdditionalRecipient[] memory additionalRecipients = SeaportArrays
             .AdditionalRecipients(

--- a/test/foundry/helpers/sol/lib/ConsiderationItemLib.t.sol
+++ b/test/foundry/helpers/sol/lib/ConsiderationItemLib.t.sol
@@ -36,6 +36,14 @@ contract ConsiderationItemLibTest is BaseTest {
         assertEq(considerationItem, defaultConsiderationItem);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty ConsiderationItem selected.");
+        ConsiderationItemLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty ConsiderationItem array selected.");
+        ConsiderationItemLib.fromDefaultMany("nonexistent");
+    }
+
     function testComposeEmpty(
         uint8 itemType,
         address token,

--- a/test/foundry/helpers/sol/lib/CriteriaResolverLib.t.sol
+++ b/test/foundry/helpers/sol/lib/CriteriaResolverLib.t.sol
@@ -33,6 +33,14 @@ contract CriteriaResolverLibTest is BaseTest {
         assertEq(criteriaResolver, defaultCriteriaResolver);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty CriteriaResolver selected.");
+        CriteriaResolverLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty CriteriaResolver array selected.");
+        CriteriaResolverLib.fromDefaultMany("nonexistent");
+    }
+
     function testComposeEmpty(
         uint256 orderIndex,
         bool side,

--- a/test/foundry/helpers/sol/lib/ExecutionsLib.t.sol
+++ b/test/foundry/helpers/sol/lib/ExecutionsLib.t.sol
@@ -47,6 +47,14 @@ contract ExecutionLibTest is BaseTest {
         assertEq(execution, defaultExecution);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty Execution selected.");
+        ExecutionLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty Execution array selected.");
+        ExecutionLib.fromDefaultMany("nonexistent");
+    }
+
     function _fromBlob(
         ReceivedItemBlob memory blob
     ) internal view returns (ReceivedItem memory) {

--- a/test/foundry/helpers/sol/lib/OfferItemLib.t.sol
+++ b/test/foundry/helpers/sol/lib/OfferItemLib.t.sol
@@ -33,6 +33,14 @@ contract OfferItemLibTest is BaseTest {
         assertEq(offerItem, defaultOfferItem);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty OfferItem selected.");
+        OfferItemLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty OfferItem array selected.");
+        OfferItemLib.fromDefaultMany("nonexistent");
+    }
+
     function testComposeEmpty(
         uint8 itemType,
         address token,

--- a/test/foundry/helpers/sol/lib/OrderComponentsLib.t.sol
+++ b/test/foundry/helpers/sol/lib/OrderComponentsLib.t.sol
@@ -53,6 +53,14 @@ contract OrderComponentsLibTest is BaseTest {
         assertEq(orderComponents, defaultOrderComponents);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty OrderComponents selected.");
+        OrderComponentsLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty OrderComponents array selected.");
+        OrderComponentsLib.fromDefaultMany("nonexistent");
+    }
+
     function testCopy() public {
         OrderComponents memory orderComponents = OrderComponentsLib.empty();
         orderComponents = orderComponents.withOfferer(address(1));

--- a/test/foundry/helpers/sol/lib/OrderLib.t.sol
+++ b/test/foundry/helpers/sol/lib/OrderLib.t.sol
@@ -30,6 +30,14 @@ contract OrderLibTest is BaseTest {
         assertEq(order, defaultOrder);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty Order selected.");
+        OrderLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty Order array selected.");
+        OrderLib.fromDefaultMany("nonexistent");
+    }
+
     function testCopy() public {
         OrderParameters memory parameters = OrderParametersLib
             .empty()

--- a/test/foundry/helpers/sol/lib/OrderParametersLib.t.sol
+++ b/test/foundry/helpers/sol/lib/OrderParametersLib.t.sol
@@ -54,6 +54,14 @@ contract OrderParametersLibTest is BaseTest {
         assertEq(orderParameters, defaultOrderParameters);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty OrderParameters selected.");
+        OrderParametersLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty OrderParameters array selected.");
+        OrderParametersLib.fromDefaultMany("nonexistent");
+    }
+
     function testCopy() public {
         OrderParameters memory orderParameters = OrderParametersLib.empty();
         orderParameters = orderParameters.withOfferer(address(1));

--- a/test/foundry/helpers/sol/lib/ReceivedItemLib.t.sol
+++ b/test/foundry/helpers/sol/lib/ReceivedItemLib.t.sol
@@ -35,6 +35,14 @@ contract ReceivedItemLibTest is BaseTest {
         assertEq(receivedItem, defaultReceivedItem);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty ReceivedItem selected.");
+        ReceivedItemLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty ReceivedItem array selected.");
+        ReceivedItemLib.fromDefaultMany("nonexistent");
+    }
+
     function testComposeEmpty(
         uint8 itemType,
         address token,

--- a/test/foundry/helpers/sol/lib/SpentItemLib.t.sol
+++ b/test/foundry/helpers/sol/lib/SpentItemLib.t.sol
@@ -31,6 +31,14 @@ contract SpentItemLibTest is BaseTest {
         assertEq(spentItem, defaultSpentItem);
     }
 
+    function testRetrieveNonexistentDefault() public {
+        vm.expectRevert("Empty SpentItem selected.");
+        SpentItemLib.fromDefault("nonexistent");
+
+        vm.expectRevert("Empty SpentItem array selected.");
+        SpentItemLib.fromDefaultMany("nonexistent");
+    }
+
     function testComposeEmpty(
         uint8 itemType,
         address token,


### PR DESCRIPTION
## Motivation

I lost 45 minutes because I had forgotten to set up a bookend ConsiderationItem default to go with the OfferItem default I'd made.  It used to be that if you asked for a default you hadn't set up yet, you just got an empty one back.

## Solution

Spend 45 minutes adding in safeguards so that I don't lose 45 minutes again.  Note that I didn't do the fulfillment-related ones because 0s are commonly desirable for those.
