### PR TITLE
Dan/2023/03/small lib improvement proposal

### DIFF
--- a/contracts/helpers/sol/lib/OrderParametersLib.sol
+++ b/contracts/helpers/sol/lib/OrderParametersLib.sol
@@ -332,6 +332,7 @@ library OrderParametersLib {
         ConsiderationItem[] memory consideration
     ) internal pure returns (OrderParameters memory) {
         parameters.consideration = consideration;
+        parameters.totalOriginalConsiderationItems = consideration.length;
         return parameters;
     }
 

--- a/contracts/helpers/sol/lib/OrderParametersLib.sol
+++ b/contracts/helpers/sol/lib/OrderParametersLib.sol
@@ -332,6 +332,22 @@ library OrderParametersLib {
         ConsiderationItem[] memory consideration
     ) internal pure returns (OrderParameters memory) {
         parameters.consideration = consideration;
+        return parameters;
+    }
+
+    /**
+     * @dev Sets the consideration field of a OrderParameters struct in-place.
+     *
+     * @param parameters    the OrderParameters struct to modify
+     * @param consideration the new value for the consideration field
+     *
+     * @custom:return _parameters the modified OrderParameters struct
+     */
+    function withTotalConsideration(
+        OrderParameters memory parameters,
+        ConsiderationItem[] memory consideration
+    ) internal pure returns (OrderParameters memory) {
+        parameters.consideration = consideration;
         parameters.totalOriginalConsiderationItems = consideration.length;
         return parameters;
     }

--- a/contracts/helpers/sol/lib/OrderParametersLib.sol
+++ b/contracts/helpers/sol/lib/OrderParametersLib.sol
@@ -336,7 +336,8 @@ library OrderParametersLib {
     }
 
     /**
-     * @dev Sets the consideration field of a OrderParameters struct in-place.
+     * @dev Sets the consideration field of a OrderParameters struct in-place
+     *      and updates the totalOriginalConsiderationItems field accordingly.
      *
      * @param parameters    the OrderParameters struct to modify
      * @param consideration the new value for the consideration field


### PR DESCRIPTION
I propose adding `parameters.totalOriginalConsiderationItems = consideration.length;` to OrderParameterLib's `withConsideration`.

We could still override it with `.withTotalOriginalConsiderationItems(<wrong_value>)` if we wanted to for testing failure cases, but it'd be soooo nice to not have to remember to set it manually when you're going from parameters to components.

The order components lib's `toOrderParameters` handles it for you automatically when you go from OrderComponents to OrderParameters.  But if you set up the order params, then make the order components to get the hash, then pass your original order params into the order, you get "InvalidSigner".