### PR TITLE
ci: try self-hosted runner for longer than default max duration

### DIFF
--- a/.github/workflows/long.yml
+++ b/.github/workflows/long.yml
@@ -1,0 +1,19 @@
+name: Long test
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  fuzz:
+    name: Run Forge Tests (via_ir = true; fuzz_runs = 100_000)
+    runs-on: large-runner
+    timeout-minutes: 420
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      # Sleep for 8hr, expect it to get cut off at hr 7
+      - name: Run tests
+        run: sleep 28800


### PR DESCRIPTION
Seeing [mixed things online](https://github.com/orgs/community/discussions/26679) about whether 6hr max job exec time is able to be surpassed

Since we might need to go multi-day for the MOAT, I'm giving this param a try: [timeout-minutes](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)

and we'll see if the job gets cut off at 6 or 7 hours