### PR TITLE
ci: MOAT runner branch

### DIFF
--- a/.github/actions/moat-runner/action.yml
+++ b/.github/actions/moat-runner/action.yml
@@ -1,0 +1,29 @@
+# A simple helper to eliminate boilerplate in the moat.yml workflow file.
+# Github somehow doesn't support yaml anchors 🤷‍♀️
+
+name: 'Run MOAT'
+description: 'Setup the Mother of All Tests and run it.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly
+
+    - name: Install forge dependencies
+      shell: bash
+      run: forge install
+
+    - name: Precompile reference using 0.8.13 and via-ir=false
+      shell: bash
+      run: FOUNDRY_PROFILE=reference forge build
+
+    - name: Precompile optimized using 0.8.17 and via-ir=true
+      shell: bash
+      run: FOUNDRY_PROFILE=optimized forge build
+
+    - name: Run tests
+      shell: bash
+      run: FOUNDRY_PROFILE=test forge test

--- a/.github/workflows/moat.yml
+++ b/.github/workflows/moat.yml
@@ -1,0 +1,47 @@
+name: MOAT
+
+# HACK: just open a PR and push to the branch to get it to run
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+# Common config applies to all shards
+env:
+  FOUNDRY_MATCH_PATH: test/foundry/new/FuzzMain.t.sol
+  FOUNDRY_MATCH_TEST: test_success
+  FOUNDRY_FUZZ_RUNS: 5000
+
+# Individual shards run the same test except for their seed
+jobs:
+  shard0:
+    runs-on: large-runner
+    name: "0xdeadbeef"
+    env:
+      FOUNDRY_FUZZ_SEED: "0xdeadbeef"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/moat-runner
+
+  shard1:
+    runs-on: large-runner
+    name: "0xdadb0d"
+    env:
+      FOUNDRY_FUZZ_SEED: "0xdadb0d"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/moat-runner
+    
+  shard2:
+    runs-on: large-runner
+    name: "0x8badf00d"
+    env:
+      FOUNDRY_FUZZ_SEED: "0x8badf00d"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/moat-runner


### PR DESCRIPTION
Not intended to actually get merged. Just a spot we can hold the workflow yaml.

When the MOAT is ready to run:
* merge `1.5` back into this branch to catch up to latest
* adjust # of shards (and runs per shard)

---

just hmu when its ready to be run / we have an idea of how many workers we want running in parallel

i can go bump # available k8s pods or whatever resource limits
