### PR TITLE
Use accounts in generator context

### DIFF
--- a/test/foundry/new/BaseOrderTest.sol
+++ b/test/foundry/new/BaseOrderTest.sol
@@ -28,6 +28,14 @@ import { ERC721Recipient } from "./helpers/ERC721Recipient.sol";
 import { ERC1155Recipient } from "./helpers/ERC1155Recipient.sol";
 import "seaport-sol/SeaportSol.sol";
 
+/**
+ * @dev used to store address and key outputs from makeAddrAndKey(name)
+ */
+struct Account {
+    address addr;
+    uint256 key;
+}
+
 /// @dev base test class for cases that depend on pre-deployed token contracts
 contract BaseOrderTest is
     BaseSeaportTest,
@@ -63,14 +71,6 @@ contract BaseOrderTest is
 
     struct Context {
         SeaportInterface seaport;
-    }
-
-    /**
-     * @dev used to store address and key outputs from makeAddrAndKey(name)
-     */
-    struct Account {
-        address addr;
-        uint256 key;
     }
 
     modifier onlyPayable(address _addr) {

--- a/test/foundry/new/FuzzGenerators.t.sol
+++ b/test/foundry/new/FuzzGenerators.t.sol
@@ -38,7 +38,7 @@ contract FuzzGeneratorsTest is BaseOrderTest {
     /// @dev Note: the GeneratorContext must be a struct in *memory* in order
     ///      for the PRNG to work properly, so we can't declare it as a storage
     ///      variable in setUp. Instead, use this function to create a context.
-    function createContext() internal view returns (GeneratorContext memory) {
+    function createContext() internal returns (GeneratorContext memory) {
         LibPRNG.PRNG memory prng = LibPRNG.PRNG({ state: 0 });
 
         uint256[] memory potential1155TokenIds = new uint256[](3);
@@ -56,21 +56,16 @@ contract FuzzGeneratorsTest is BaseOrderTest {
                 erc721s: erc721s,
                 erc1155s: erc1155s,
                 self: address(this),
-                offerer: offerer1.addr,
                 caller: address(this), // TODO: read recipient from TestContext
-                alice: offerer1.addr,
-                bob: offerer2.addr,
-                dillon: dillon.addr,
-                eve: eve.addr,
-                frank: frank.addr,
-                offererPk: offerer1.key,
-                alicePk: offerer1.key,
-                bobPk: offerer2.key,
-                dillonPk: dillon.key,
-                frankPk: frank.key,
-                evePk: eve.key,
-                starting721offerIndex: 0,
-                starting721considerationIndex: 0,
+                offerer: makeAccount("offerer"),
+                alice: makeAccount("alice"),
+                bob: makeAccount("bob"),
+                carol: makeAccount("carol"),
+                dillon: makeAccount("dillon"),
+                eve: makeAccount("eve"),
+                frank: makeAccount("frank"),
+                starting721offerIndex: 1,
+                starting721considerationIndex: 1,
                 potential1155TokenIds: potential1155TokenIds,
                 orderHashes: new bytes32[](0)
             });
@@ -223,7 +218,7 @@ contract FuzzGeneratorsTest is BaseOrderTest {
         );
         assertEq(
             orders[0].parameters.consideration[0].recipient,
-            offerer1.addr
+            context.offerer.addr
         );
 
         assertEq(

--- a/test/foundry/new/FuzzMain.t.sol
+++ b/test/foundry/new/FuzzMain.t.sol
@@ -23,10 +23,7 @@ contract FuzzMainTest is FuzzEngine {
     using FuzzHelpers for AdvancedOrder;
     using FuzzHelpers for AdvancedOrder[];
 
-    Account bob2 = makeAccount("bob2");
-    Account alice2 = makeAccount("alice2");
-
-    function createContext() internal view returns (GeneratorContext memory) {
+    function createContext() internal returns (GeneratorContext memory) {
         LibPRNG.PRNG memory prng = LibPRNG.PRNG({ state: 0 });
 
         uint256[] memory potential1155TokenIds = new uint256[](3);
@@ -44,19 +41,14 @@ contract FuzzMainTest is FuzzEngine {
                 erc721s: erc721s,
                 erc1155s: erc1155s,
                 self: address(this),
-                offerer: alice2.addr,
                 caller: address(this), // TODO: read recipient from TestContext
-                alice: alice2.addr,
-                bob: bob2.addr,
-                dillon: dillon.addr,
-                eve: eve.addr,
-                frank: frank.addr,
-                offererPk: alice2.key,
-                alicePk: alice2.key,
-                bobPk: bob2.key,
-                dillonPk: dillon.key,
-                evePk: eve.key,
-                frankPk: frank.key,
+                offerer: makeAccount("offerer"),
+                alice: makeAccount("alice"),
+                bob: makeAccount("bob"),
+                carol: makeAccount("carol"),
+                dillon: makeAccount("dillon"),
+                eve: makeAccount("eve"),
+                frank: makeAccount("frank"),
                 starting721offerIndex: 0,
                 starting721considerationIndex: 0,
                 potential1155TokenIds: potential1155TokenIds,
@@ -75,6 +67,7 @@ contract FuzzMainTest is FuzzEngine {
         maxConsiderationItems = bound(maxConsiderationItems, 1, 10);
 
         vm.warp(1679435965);
+
         GeneratorContext memory generatorContext = createContext();
         generatorContext.timestamp = block.timestamp;
 

--- a/test/foundry/new/FuzzSetup.t.sol
+++ b/test/foundry/new/FuzzSetup.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { BaseOrderTest } from "./BaseOrderTest.sol";
+import { Account, BaseOrderTest } from "./BaseOrderTest.sol";
 import "seaport-sol/SeaportSol.sol";
 
 import {

--- a/test/foundry/new/SelfRestricted.t.sol
+++ b/test/foundry/new/SelfRestricted.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { BaseOrderTest } from "./BaseOrderTest.sol";
+import { Account, BaseOrderTest } from "./BaseOrderTest.sol";
 import { ValidationOffererZone } from "./zones/ValidationOffererZone.sol";
 import "seaport-sol/SeaportSol.sol";
 

--- a/test/foundry/new/helpers/FuzzGenerators.sol
+++ b/test/foundry/new/helpers/FuzzGenerators.sol
@@ -29,6 +29,7 @@ import { TestERC1155 } from "../../../../contracts/test/TestERC1155.sol";
 import { TestERC20 } from "../../../../contracts/test/TestERC20.sol";
 import { TestERC721 } from "../../../../contracts/test/TestERC721.sol";
 
+import { Account } from "../BaseOrderTest.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 import "forge-std/console.sol";
@@ -77,19 +78,14 @@ struct GeneratorContext {
     TestERC721[] erc721s;
     TestERC1155[] erc1155s;
     address self;
-    address offerer;
     address caller;
-    address alice;
-    address bob;
-    address dillon;
-    address eve;
-    address frank;
-    uint256 offererPk;
-    uint256 alicePk;
-    uint256 bobPk;
-    uint256 dillonPk;
-    uint256 frankPk;
-    uint256 evePk;
+    Account offerer;
+    Account alice;
+    Account bob;
+    Account carol;
+    Account dillon;
+    Account eve;
+    Account frank;
     uint256 starting721offerIndex;
     uint256 starting721considerationIndex;
     uint256[] potential1155TokenIds;
@@ -532,15 +528,15 @@ library RecipientGenerator {
         GeneratorContext memory context
     ) internal pure returns (address) {
         if (recipient == Recipient.OFFERER) {
-            return context.offerer;
+            return context.offerer.addr;
         } else if (recipient == Recipient.RECIPIENT) {
             return context.caller;
         } else if (recipient == Recipient.DILLON) {
-            return context.dillon;
+            return context.dillon.addr;
         } else if (recipient == Recipient.EVE) {
-            return context.eve;
+            return context.eve.addr;
         } else if (recipient == Recipient.FRANK) {
-            return context.frank;
+            return context.frank.addr;
         } else {
             revert("Invalid recipient");
         }
@@ -609,9 +605,9 @@ library OffererGenerator {
         if (offerer == Offerer.TEST_CONTRACT) {
             return context.self;
         } else if (offerer == Offerer.ALICE) {
-            return context.alice;
+            return context.alice.addr;
         } else if (offerer == Offerer.BOB) {
-            return context.bob;
+            return context.bob.addr;
         } else {
             revert("Invalid offerer");
         }
@@ -624,9 +620,9 @@ library OffererGenerator {
         if (offerer == Offerer.TEST_CONTRACT) {
             return 0;
         } else if (offerer == Offerer.ALICE) {
-            return context.alicePk;
+            return context.alice.key;
         } else if (offerer == Offerer.BOB) {
-            return context.bobPk;
+            return context.bob.key;
         } else {
             revert("Invalid offerer");
         }


### PR DESCRIPTION
Refactor generator context to use `Account` structs rather than separate `address` and pk fields.