### PR TITLE
Dan/2023/03/check order status ii

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,8 @@ SEAPORT_COVERAGE=true forge coverage --report summary --report lcov && lcov -o l
 open html/index.html
 ```
 
+When working on the test suite based around `FuzzEngine.sol`, using `FOUNDRY_PROFILE=moat_debug` will cut compile times roughly in half.
+
 **Note** that Forge does not yet ignore specific filepaths when running coverage tests.
 
 For information on Foundry, including installation and testing, see the [Foundry Book](https://book.getfoundry.sh/).

--- a/test/foundry/new/FuzzMain.t.sol
+++ b/test/foundry/new/FuzzMain.t.sol
@@ -11,7 +11,8 @@ contract FuzzMainTest is FuzzEngine {
     /**
      * @dev FuzzEngine test for valid orders. Generates a random valid order
      *      configuration, selects and calls a Seaport method, and runs all
-     *      registered checks. This test should never revert.
+     *      registered checks. This test should never revert.  For more details
+     *      on the lifecycle of this test, see FuzzEngine.sol.
      */
     function test_fuzz_validOrders(
         uint256 seed,

--- a/test/foundry/new/helpers/FuzzChecks.sol
+++ b/test/foundry/new/helpers/FuzzChecks.sol
@@ -278,8 +278,29 @@ abstract contract FuzzChecks is Test {
     function check_expectedEventsEmitted(
         FuzzTestContext memory context
     ) public {
-        // bytes4 action = context.action();
-
         ExpectedEventsUtil.checkExpectedEvents(context);
+    }
+
+    /**
+     * @dev Check that the order status is in expected state.
+     *
+     * @param context A Fuzz test context.
+     */
+    function check_orderStatusFullyFilled(FuzzTestContext memory context) public {
+        for (uint256 i; i < context.orders.length; i++) {
+            AdvancedOrder memory order = context.orders[i];
+            uint256 counter = context.seaport.getCounter(
+                order.parameters.offerer
+            );
+            OrderComponents memory orderComponents = order
+                .parameters
+                .toOrderComponents(counter);
+            bytes32 orderHash = context.seaport.getOrderHash(orderComponents);
+            (, , uint256 totalFilled, uint256 totalSize) = context
+                .seaport
+                .getOrderStatus(orderHash);
+
+            assertEq(totalFilled, totalSize);
+        }
     }
 }

--- a/test/foundry/new/helpers/FuzzDerivers.sol
+++ b/test/foundry/new/helpers/FuzzDerivers.sol
@@ -43,6 +43,7 @@ abstract contract FuzzDerivers is
             action == context.seaport.fulfillAvailableOrders.selector ||
             action == context.seaport.fulfillAvailableAdvancedOrders.selector
         ) {
+            // TODO: Use `getAggregatedFulfillmentComponents` sometimes?
             (
                 FulfillmentComponent[][] memory offerFulfillments,
                 FulfillmentComponent[][] memory considerationFulfillments

--- a/test/foundry/new/helpers/FuzzGeneratorContextLib.sol
+++ b/test/foundry/new/helpers/FuzzGeneratorContextLib.sol
@@ -67,6 +67,10 @@ struct FuzzGeneratorContext {
 }
 
 library FuzzGeneratorContextLib {
+    /**
+     * @dev Create a new FuzzGeneratorContext.  Typically, the `from` function
+     * is likely to be preferable.
+     */
     function empty() internal returns (FuzzGeneratorContext memory) {
         LibPRNG.PRNG memory prng = LibPRNG.PRNG({ state: 0 });
 
@@ -113,6 +117,9 @@ library FuzzGeneratorContextLib {
             });
     }
 
+    /**
+     * @dev Create a new FuzzGeneratorContext from the given parameters.
+     */
     function from(
         Vm vm,
         SeaportInterface seaport,
@@ -121,15 +128,20 @@ library FuzzGeneratorContextLib {
         TestERC721[] memory erc721s,
         TestERC1155[] memory erc1155s
     ) internal returns (FuzzGeneratorContext memory) {
+        // Get a new PRNG lib.Account
         LibPRNG.PRNG memory prng = LibPRNG.PRNG({ state: 0 });
 
+        // Create a list of potential 1155 token IDs.
         uint256[] memory potential1155TokenIds = new uint256[](3);
         potential1155TokenIds[0] = 1;
         potential1155TokenIds[1] = 2;
         potential1155TokenIds[2] = 3;
 
+        // Create a new TestHelpers instance.  The helpers get passed around the
+        // test suite through the context.
         TestHelpers testHelpers = TestHelpers(address(this));
 
+        // Set up the conduits.
         TestConduit[] memory conduits = new TestConduit[](2);
         conduits[0] = _createConduit(conduitController, seaport, uint96(1));
         conduits[1] = _createConduit(conduitController, seaport, uint96(2));
@@ -170,6 +182,9 @@ library FuzzGeneratorContextLib {
             });
     }
 
+    /**
+     * @dev Internal helper used to create a new conduit based on the salt.
+     */
     function _createConduit(
         ConduitControllerInterface conduitController,
         SeaportInterface seaport,

--- a/test/foundry/new/helpers/FuzzSetup.sol
+++ b/test/foundry/new/helpers/FuzzSetup.sol
@@ -308,11 +308,59 @@ abstract contract FuzzSetup is Test, AmountDeriver {
      *
      * @param context The test context.
      */
-    function setUpExpectedEvents(FuzzTestContext memory context) public {
+    function registerExpectedEvents(FuzzTestContext memory context) public {
         context.registerCheck(FuzzChecks.check_executions.selector);
         ExpectedEventsUtil.setExpectedEventHashes(context);
         context.registerCheck(FuzzChecks.check_expectedEventsEmitted.selector);
         ExpectedEventsUtil.startRecordingLogs();
+    }
+
+    /**
+     *  @dev Set up the checks that will always be run.
+     *
+     * @param context The test context.
+     */
+    function registerCommonChecks(FuzzTestContext memory context) public pure {
+        context.registerCheck(FuzzChecks.check_orderStatusFullyFilled.selector);
+    }
+
+    /**
+     *  @dev Set up the function-specific checks.
+     *
+     * @param context The test context.
+     */
+    function registerFunctionSpecificChecks(
+        FuzzTestContext memory context
+    ) public {
+        bytes4 _action = context.action();
+        if (_action == context.seaport.fulfillOrder.selector) {
+            context.registerCheck(FuzzChecks.check_orderFulfilled.selector);
+        } else if (_action == context.seaport.fulfillAdvancedOrder.selector) {
+            context.registerCheck(FuzzChecks.check_orderFulfilled.selector);
+        } else if (_action == context.seaport.fulfillBasicOrder.selector) {
+            context.registerCheck(FuzzChecks.check_orderFulfilled.selector);
+        } else if (
+            _action ==
+            context.seaport.fulfillBasicOrder_efficient_6GL6yc.selector
+        ) {
+            context.registerCheck(FuzzChecks.check_orderFulfilled.selector);
+        } else if (_action == context.seaport.fulfillAvailableOrders.selector) {
+            context.registerCheck(FuzzChecks.check_allOrdersFilled.selector);
+        } else if (
+            _action == context.seaport.fulfillAvailableAdvancedOrders.selector
+        ) {
+            context.registerCheck(FuzzChecks.check_allOrdersFilled.selector);
+        } else if (_action == context.seaport.matchOrders.selector) {
+            // Add match-specific checks
+        } else if (_action == context.seaport.matchAdvancedOrders.selector) {
+            // Add match-specific checks
+        } else if (_action == context.seaport.cancel.selector) {
+            context.registerCheck(FuzzChecks.check_orderCancelled.selector);
+        } else if (_action == context.seaport.validate.selector) {
+            context.registerCheck(FuzzChecks.check_orderValidated.selector);
+        } else {
+            revert("FuzzEngine: Action not implemented");
+        }
     }
 
     /**


### PR DESCRIPTION
1) Adds a check registration step, which I believe makes sense structurally and will be useful as we start adding more checks, especially checks that require selection logic.
2) Adds an order status check.
3) incorporates https://github.com/ProjectOpenSea/seaport/pull/1082 (now closed in favor of this)