### PR TITLE
Update SeaportRouter

### DIFF
--- a/contracts/helpers/SeaportRouter.sol
+++ b/contracts/helpers/SeaportRouter.sol
@@ -24,20 +24,20 @@ import {
  *         all consideration items across all listings are native tokens.
  */
 contract SeaportRouter is SeaportRouterInterface, ReentrancyGuard {
-    /// @dev The allowed v1.1 contract usable through this router.
-    address private immutable _SEAPORT_V1_1;
     /// @dev The allowed v1.4 contract usable through this router.
     address private immutable _SEAPORT_V1_4;
+    /// @dev The allowed v1.5 contract usable through this router.
+    address private immutable _SEAPORT_V1_5;
 
     /**
      * @dev Deploy contract with the supported Seaport contracts.
      *
-     * @param seaportV1point1 The address of the Seaport v1.1 contract.
      * @param seaportV1point4 The address of the Seaport v1.4 contract.
+     * @param seaportV1point5 The address of the Seaport v1.5 contract.
      */
-    constructor(address seaportV1point1, address seaportV1point4) {
-        _SEAPORT_V1_1 = seaportV1point1;
+    constructor(address seaportV1point4, address seaportV1point5) {
         _SEAPORT_V1_4 = seaportV1point4;
+        _SEAPORT_V1_5 = seaportV1point5;
     }
 
     /**
@@ -207,8 +207,8 @@ contract SeaportRouter is SeaportRouterInterface, ReentrancyGuard {
         returns (address[] memory seaportContracts)
     {
         seaportContracts = new address[](2);
-        seaportContracts[0] = _SEAPORT_V1_1;
-        seaportContracts[1] = _SEAPORT_V1_4;
+        seaportContracts[0] = _SEAPORT_V1_4;
+        seaportContracts[1] = _SEAPORT_V1_5;
     }
 
     /**
@@ -216,7 +216,7 @@ contract SeaportRouter is SeaportRouterInterface, ReentrancyGuard {
      */
     function _assertSeaportAllowed(address seaport) internal view {
         if (
-            _cast(seaport == _SEAPORT_V1_1) | _cast(seaport == _SEAPORT_V1_4) ==
+            _cast(seaport == _SEAPORT_V1_4) | _cast(seaport == _SEAPORT_V1_5) ==
             0
         ) {
             revert SeaportNotAllowed(seaport);

--- a/contracts/interfaces/SeaportRouterInterface.sol
+++ b/contracts/interfaces/SeaportRouterInterface.sol
@@ -18,6 +18,11 @@ import { Execution } from "../lib/ConsiderationStructs.sol";
  */
 interface SeaportRouterInterface {
     /**
+     * @dev Ignore reverting on "NoSpecifiedOrdersAvailable()" from Seaport.
+     */
+    error NoSpecifiedOrdersAvailable();
+
+    /**
      * @dev Advanced order parameters for use through the
      *      FulfillAvailableAdvancedOrdersParams struct.
      */


### PR DESCRIPTION
1. Fixes out-of-gas issues on large fulfillments by only ignoring error for `NoSpecifiedOrdersAvailable()`
2. Updates router code from `1.1<>1.4` to `1.4<>1.5`