### PR TITLE
Fuzz ascending/descending offers

### DIFF
--- a/test/foundry/new/helpers/FuzzEngine.sol
+++ b/test/foundry/new/helpers/FuzzEngine.sol
@@ -112,6 +112,8 @@ contract FuzzEngine is
     using FuzzHelpers for AdvancedOrder[];
     using FuzzTestContextLib for FuzzTestContext;
 
+    uint256 constant JAN_1_2023_UTC = 1672531200;
+
     /**
      * @dev Generate a randomized `FuzzTestContext` from fuzz parameters and run
      *      a `FuzzEngine` test.
@@ -153,6 +155,7 @@ contract FuzzEngine is
     function generate(
         FuzzParams memory fuzzParams
     ) internal returns (FuzzTestContext memory) {
+        vm.warp(JAN_1_2023_UTC);
         // Set either the optimized version or the reference version of Seaport,
         // depending on the active profile.
         ConsiderationInterface seaport_ = getSeaport();

--- a/test/foundry/new/helpers/FuzzEngineLib.sol
+++ b/test/foundry/new/helpers/FuzzEngineLib.sol
@@ -3,7 +3,12 @@ pragma solidity ^0.8.17;
 
 import "seaport-sol/SeaportSol.sol";
 
-import { Family, FuzzHelpers, Structure } from "./FuzzHelpers.sol";
+import {
+    Family,
+    FuzzHelpers,
+    Structure,
+    _locateCurrentAmount
+} from "./FuzzHelpers.sol";
 
 import { FuzzTestContext } from "./FuzzTestContextLib.sol";
 
@@ -83,7 +88,9 @@ library FuzzEngineLib {
 
         if (hasUnavailable) {
             if (invalidNativeOfferItemsLocated) {
-                revert("FuzzEngineLib: invalid native token + unavailable combination");
+                revert(
+                    "FuzzEngineLib: invalid native token + unavailable combination"
+                );
             }
 
             if (structure == Structure.ADVANCED) {
@@ -276,61 +283,5 @@ library FuzzEngineLib {
         }
 
         return value;
-    }
-
-    function _locateCurrentAmount(
-        uint256 startAmount,
-        uint256 endAmount,
-        uint256 startTime,
-        uint256 endTime,
-        bool roundUp
-    ) internal view returns (uint256 amount) {
-        // Only modify end amount if it doesn't already equal start amount.
-        if (startAmount != endAmount) {
-            // Declare variables to derive in the subsequent unchecked scope.
-            uint256 duration;
-            uint256 elapsed;
-            uint256 remaining;
-
-            // Skip underflow checks as startTime <= block.timestamp < endTime.
-            unchecked {
-                // Derive the duration for the order and place it on the stack.
-                duration = endTime - startTime;
-
-                // Derive time elapsed since the order started & place on stack.
-                elapsed = block.timestamp - startTime;
-
-                // Derive time remaining until order expires and place on stack.
-                remaining = duration - elapsed;
-            }
-
-            // Aggregate new amounts weighted by time with rounding factor.
-            uint256 totalBeforeDivision = ((startAmount * remaining) +
-                (endAmount * elapsed));
-
-            // Use assembly to combine operations and skip divide-by-zero check.
-            assembly {
-                // Multiply by iszero(iszero(totalBeforeDivision)) to ensure
-                // amount is set to zero if totalBeforeDivision is zero,
-                // as intermediate overflow can occur if it is zero.
-                amount := mul(
-                    iszero(iszero(totalBeforeDivision)),
-                    // Subtract 1 from the numerator and add 1 to the result if
-                    // roundUp is true to get the proper rounding direction.
-                    // Division is performed with no zero check as duration
-                    // cannot be zero as long as startTime < endTime.
-                    add(
-                        div(sub(totalBeforeDivision, roundUp), duration),
-                        roundUp
-                    )
-                )
-            }
-
-            // Return the current amount.
-            return amount;
-        }
-
-        // Return the original amount as startAmount == endAmount.
-        return endAmount;
     }
 }

--- a/test/foundry/new/helpers/FuzzEngineLib.sol
+++ b/test/foundry/new/helpers/FuzzEngineLib.sol
@@ -255,7 +255,7 @@ library FuzzEngineLib {
                             item.endAmount,
                             orderParams.startTime,
                             orderParams.endTime,
-                            true
+                            false
                         );
                     } else {
                         value += item.startAmount;
@@ -273,7 +273,7 @@ library FuzzEngineLib {
                             item.endAmount,
                             orderParams.startTime,
                             orderParams.endTime,
-                            false
+                            true
                         );
                     } else {
                         value += item.startAmount;

--- a/test/foundry/new/helpers/FuzzGenerators.sol
+++ b/test/foundry/new/helpers/FuzzGenerators.sol
@@ -174,7 +174,7 @@ library TestStateGenerator {
                     // TODO: support wildcard criteria, should be 0-1
                     criteria: Criteria(context.randEnum(0, 0)),
                     // TODO: Fixed amounts only, should be 0-2
-                    amount: Amount(context.randEnum(0, 0))
+                    amount: Amount(context.randEnum(0, 2))
                 });
             }
 
@@ -190,7 +190,7 @@ library TestStateGenerator {
                 tokenIndex: TokenIndex(context.randEnum(0, 2)),
                 criteria: Criteria(0),
                 // TODO: Fixed amounts only, should be 0-2
-                amount: Amount(context.randEnum(0, 0))
+                amount: Amount(context.randEnum(0, 2))
             });
 
             context.basicOfferSpace = offer[0];
@@ -1594,12 +1594,12 @@ library TimeGenerator {
             uint256 a = bound(
                 context.prng.next(),
                 context.timestamp + 1,
-                type(uint256).max
+                type(uint48).max
             );
             uint256 b = bound(
                 context.prng.next(),
                 context.timestamp + 1,
-                type(uint256).max
+                type(uint48).max
             );
             low = a < b ? a : b;
             high = a > b ? a : b;
@@ -1609,7 +1609,7 @@ library TimeGenerator {
             high = bound(
                 context.prng.next(),
                 context.timestamp + 1,
-                type(uint256).max
+                type(uint48).max
             );
         }
         if (time == Time.ONGOING) {
@@ -1617,7 +1617,7 @@ library TimeGenerator {
             high = bound(
                 context.prng.next(),
                 context.timestamp + 1,
-                type(uint256).max
+                type(uint48).max
             );
         }
         if (time == Time.EXACT_END) {
@@ -1653,8 +1653,8 @@ library AmountGenerator {
             return item.withStartAmount(1).withEndAmount(1);
         }
 
-        uint256 a = bound(context.prng.next(), 1, 1_000_000e18);
-        uint256 b = bound(context.prng.next(), 1, 1_000_000e18);
+        uint256 a = bound(context.prng.next(), 1, 100_000_000e18);
+        uint256 b = bound(context.prng.next(), 1, 100_000_000e18);
 
         // TODO: Work out a better way to handle this
         if (context.basicOrderCategory == BasicOrderCategory.BID) {
@@ -1690,8 +1690,8 @@ library AmountGenerator {
             return item.withStartAmount(1).withEndAmount(1);
         }
 
-        uint256 a = bound(context.prng.next(), 1, 1_000_000e18);
-        uint256 b = bound(context.prng.next(), 1, 1_000_000e18);
+        uint256 a = bound(context.prng.next(), 1, 100_000_000e18);
+        uint256 b = bound(context.prng.next(), 1, 100_000_000e18);
 
         uint256 high = a > b ? a : b;
         uint256 low = a < b ? a : b;

--- a/test/foundry/new/helpers/FuzzGenerators.sol
+++ b/test/foundry/new/helpers/FuzzGenerators.sol
@@ -324,7 +324,10 @@ library AdvancedOrdersSpaceGenerator {
                 OfferItem memory item = order.offer[j];
                 if (item.itemType == ItemType.NATIVE) {
                     // Generate a new offer and make sure it has no native items
-                    orders[i].parameters.offer[j] = space.orders[i].offer[j].generate(context, true);
+                    orders[i].parameters.offer[j] = space
+                        .orders[i]
+                        .offer[j]
+                        .generate(context, true);
                 }
             }
         }

--- a/test/foundry/new/helpers/FuzzGenerators.sol
+++ b/test/foundry/new/helpers/FuzzGenerators.sol
@@ -1539,12 +1539,12 @@ library TimeGenerator {
             uint256 a = bound(
                 context.prng.next(),
                 context.timestamp + 1,
-                type(uint48).max
+                type(uint40).max
             );
             uint256 b = bound(
                 context.prng.next(),
                 context.timestamp + 1,
-                type(uint48).max
+                type(uint40).max
             );
             low = a < b ? a : b;
             high = a > b ? a : b;
@@ -1554,7 +1554,7 @@ library TimeGenerator {
             high = bound(
                 context.prng.next(),
                 context.timestamp + 1,
-                type(uint48).max
+                type(uint40).max
             );
         }
         if (time == Time.ONGOING) {
@@ -1562,7 +1562,7 @@ library TimeGenerator {
             high = bound(
                 context.prng.next(),
                 context.timestamp + 1,
-                type(uint48).max
+                type(uint40).max
             );
         }
         if (time == Time.EXACT_END) {

--- a/test/foundry/new/helpers/FuzzGenerators.sol
+++ b/test/foundry/new/helpers/FuzzGenerators.sol
@@ -173,7 +173,6 @@ library TestStateGenerator {
                     tokenIndex: TokenIndex(context.randEnum(0, 1)),
                     // TODO: support wildcard criteria, should be 0-1
                     criteria: Criteria(context.randEnum(0, 0)),
-                    // TODO: Fixed amounts only, should be 0-2
                     amount: Amount(context.randEnum(0, 2))
                 });
             }
@@ -189,7 +188,6 @@ library TestStateGenerator {
                 ),
                 tokenIndex: TokenIndex(context.randEnum(0, 2)),
                 criteria: Criteria(0),
-                // TODO: Fixed amounts only, should be 0-2
                 amount: Amount(context.randEnum(0, 2))
             });
 

--- a/test/foundry/new/helpers/FuzzGenerators.sol
+++ b/test/foundry/new/helpers/FuzzGenerators.sol
@@ -41,7 +41,7 @@ import {
     TestConduit
 } from "./FuzzGeneratorContextLib.sol";
 
-import { FuzzHelpers } from "./FuzzHelpers.sol";
+import { FuzzHelpers, _locateCurrentAmount } from "./FuzzHelpers.sol";
 
 import { FuzzInscribers } from "./FuzzInscribers.sol";
 
@@ -798,62 +798,6 @@ library AdvancedOrdersSpaceGenerator {
             // Perform division without zero check.
             newValue := div(valueTimesNumerator, denominator)
         }
-    }
-
-    function _locateCurrentAmount(
-        uint256 startAmount,
-        uint256 endAmount,
-        uint256 startTime,
-        uint256 endTime,
-        bool roundUp
-    ) internal view returns (uint256 amount) {
-        // Only modify end amount if it doesn't already equal start amount.
-        if (startAmount != endAmount) {
-            // Declare variables to derive in the subsequent unchecked scope.
-            uint256 duration;
-            uint256 elapsed;
-            uint256 remaining;
-
-            // Skip underflow checks as startTime <= block.timestamp < endTime.
-            unchecked {
-                // Derive the duration for the order and place it on the stack.
-                duration = endTime - startTime;
-
-                // Derive time elapsed since the order started & place on stack.
-                elapsed = block.timestamp - startTime;
-
-                // Derive time remaining until order expires and place on stack.
-                remaining = duration - elapsed;
-            }
-
-            // Aggregate new amounts weighted by time with rounding factor.
-            uint256 totalBeforeDivision = ((startAmount * remaining) +
-                (endAmount * elapsed));
-
-            // Use assembly to combine operations and skip divide-by-zero check.
-            assembly {
-                // Multiply by iszero(iszero(totalBeforeDivision)) to ensure
-                // amount is set to zero if totalBeforeDivision is zero,
-                // as intermediate overflow can occur if it is zero.
-                amount := mul(
-                    iszero(iszero(totalBeforeDivision)),
-                    // Subtract 1 from the numerator and add 1 to the result if
-                    // roundUp is true to get the proper rounding direction.
-                    // Division is performed with no zero check as duration
-                    // cannot be zero as long as startTime < endTime.
-                    add(
-                        div(sub(totalBeforeDivision, roundUp), duration),
-                        roundUp
-                    )
-                )
-            }
-
-            // Return the current amount.
-            return amount;
-        }
-
-        // Return the original amount as startAmount == endAmount.
-        return endAmount;
     }
 
     function _handleInsertIfAllEmpty(


### PR DESCRIPTION
- Fuzz ascending/descending amounts for offer items
- Extract and share `_locateCurrentAmount` to `FuzzHelpers`
- Warp to a realistic timestamp (Jan 1 2023) before tests.
- Limit fuzzed timestamps to `type(uint40).max`