### PR TITLE
Fuzz ascending/descending considerations

### DIFF
--- a/contracts/helpers/sol/lib/OrderParametersLib.sol
+++ b/contracts/helpers/sol/lib/OrderParametersLib.sol
@@ -500,6 +500,6 @@ library OrderParametersLib {
     ) internal view returns (bool) {
         return
             block.timestamp >= parameters.startTime &&
-            block.timestamp <= parameters.endTime;
+            block.timestamp < parameters.endTime;
     }
 }

--- a/contracts/helpers/sol/lib/OrderParametersLib.sol
+++ b/contracts/helpers/sol/lib/OrderParametersLib.sol
@@ -494,4 +494,12 @@ library OrderParametersLib {
         components.conduitKey = parameters.conduitKey;
         components.counter = counter;
     }
+
+    function isAvailable(
+        OrderParameters memory parameters
+    ) internal view returns (bool) {
+        return
+            block.timestamp >= parameters.startTime &&
+            block.timestamp <= parameters.endTime;
+    }
 }

--- a/contracts/helpers/sol/lib/fulfillment/AmountDeriverHelper.sol
+++ b/contracts/helpers/sol/lib/fulfillment/AmountDeriverHelper.sol
@@ -80,8 +80,10 @@ contract AmountDeriverHelper is AmountDeriver {
         view
         returns (SpentItem[] memory spent, ReceivedItem[] memory received)
     {
-        spent = getSpentItems(parameters);
-        received = getReceivedItems(parameters);
+        if (parameters.isAvailable()) {
+            spent = getSpentItems(parameters);
+            received = getReceivedItems(parameters);
+        }
     }
 
     function toOrderDetails(
@@ -146,10 +148,17 @@ contract AmountDeriverHelper is AmountDeriver {
         view
         returns (SpentItem[] memory spent, ReceivedItem[] memory received)
     {
-        spent = getSpentItems(parameters, numerator, denominator);
-        received = getReceivedItems(parameters, numerator, denominator);
+        if (parameters.isAvailable()) {
+            spent = getSpentItems(parameters, numerator, denominator);
+            received = getReceivedItems(parameters, numerator, denominator);
 
-        applyCriteriaResolvers(spent, received, orderIndex, criteriaResolvers);
+            applyCriteriaResolvers(
+                spent,
+                received,
+                orderIndex,
+                criteriaResolvers
+            );
+        }
     }
 
     function applyCriteriaResolvers(
@@ -275,16 +284,15 @@ contract AmountDeriverHelper is AmountDeriver {
             itemType: item.itemType,
             token: item.token,
             identifier: item.identifierOrCriteria,
-            amount: (
-                block.timestamp < startTime ||
-                block.timestamp >= endTime
-            ) ? 0 : _applyFraction({
-                numerator: numerator,
-                denominator: denominator,
-                item: item,
-                startTime: startTime,
-                endTime: endTime
-            })
+            amount: (block.timestamp < startTime || block.timestamp >= endTime)
+                ? 0
+                : _applyFraction({
+                    numerator: numerator,
+                    denominator: denominator,
+                    item: item,
+                    startTime: startTime,
+                    endTime: endTime
+                })
         });
     }
 
@@ -385,16 +393,15 @@ contract AmountDeriverHelper is AmountDeriver {
             itemType: considerationItem.itemType,
             token: considerationItem.token,
             identifier: considerationItem.identifierOrCriteria,
-            amount: (
-                block.timestamp < startTime ||
-                block.timestamp >= endTime
-            ) ? 0 : _applyFraction({
-                numerator: numerator,
-                denominator: denominator,
-                item: considerationItem,
-                startTime: startTime,
-                endTime: endTime
-            }),
+            amount: (block.timestamp < startTime || block.timestamp >= endTime)
+                ? 0
+                : _applyFraction({
+                    numerator: numerator,
+                    denominator: denominator,
+                    item: considerationItem,
+                    startTime: startTime,
+                    endTime: endTime
+                }),
             recipient: considerationItem.recipient
         });
     }

--- a/test/foundry/new/FuzzSetup.t.sol
+++ b/test/foundry/new/FuzzSetup.t.sol
@@ -370,7 +370,9 @@ contract FuzzSetupTest is BaseOrderTest, FuzzSetup {
         OrderParameters memory orderParams = OrderParametersLib
             .empty()
             .withOfferer(charlie.addr)
-            .withConsideration(considerationItems);
+            .withConsideration(considerationItems)
+            .withStartTime(block.timestamp)
+            .withEndTime(block.timestamp + 1);
         Order memory order = OrderLib.empty().withParameters(orderParams);
 
         AdvancedOrder[] memory orders = new AdvancedOrder[](1);

--- a/test/foundry/new/helpers/FuzzEngineLib.sol
+++ b/test/foundry/new/helpers/FuzzEngineLib.sol
@@ -248,7 +248,10 @@ library FuzzEngineLib {
             for (uint256 j = 0; j < orderParams.offer.length; ++j) {
                 OfferItem memory item = orderParams.offer[j];
 
-                if (item.itemType == ItemType.NATIVE) {
+                if (
+                    item.itemType == ItemType.NATIVE &&
+                    orderParams.isAvailable()
+                ) {
                     if (item.startAmount != item.endAmount) {
                         value += _locateCurrentAmount(
                             item.startAmount,
@@ -266,7 +269,10 @@ library FuzzEngineLib {
             for (uint256 j = 0; j < orderParams.consideration.length; ++j) {
                 ConsiderationItem memory item = orderParams.consideration[j];
 
-                if (item.itemType == ItemType.NATIVE) {
+                if (
+                    item.itemType == ItemType.NATIVE &&
+                    orderParams.isAvailable()
+                ) {
                     if (item.startAmount != item.endAmount) {
                         value += _locateCurrentAmount(
                             item.startAmount,

--- a/test/foundry/new/helpers/FuzzGenerators.sol
+++ b/test/foundry/new/helpers/FuzzGenerators.sol
@@ -222,7 +222,7 @@ library TestStateGenerator {
                     // TODO: support wildcard criteria, should be 0-1
                     criteria: Criteria(context.randEnum(0, 0)),
                     // TODO: Fixed amounts only, should be 0-2
-                    amount: Amount(context.randEnum(0, 0)),
+                    amount: Amount(context.randEnum(0, 2)),
                     recipient: Recipient(context.randEnum(0, 4))
                 });
             }
@@ -236,7 +236,7 @@ library TestStateGenerator {
                 tokenIndex: TokenIndex(context.randEnum(0, 2)),
                 criteria: Criteria(0),
                 // TODO: Fixed amounts only, should be 0-2
-                amount: Amount(context.randEnum(0, 0)),
+                amount: Amount(context.randEnum(0, 2)),
                 recipient: Recipient(0) // Always offerer
             });
 
@@ -247,7 +247,7 @@ library TestStateGenerator {
                     criteria: Criteria(0),
                     // TODO: Fixed amounts only, should be 0-2
                     // TODO: sum(amounts) must be less than offer amount
-                    amount: Amount(context.randEnum(0, 0)),
+                    amount: Amount(context.randEnum(0, 2)),
                     recipient: Recipient(context.randEnum(0, 4))
                 });
             }
@@ -578,10 +578,17 @@ library AdvancedOrdersSpaceGenerator {
         view
         returns (SpentItem[] memory spent, ReceivedItem[] memory received)
     {
-        spent = getSpentItems(parameters, numerator, denominator);
-        received = getReceivedItems(parameters, numerator, denominator);
+        if (parameters.isAvailable()) {
+            spent = getSpentItems(parameters, numerator, denominator);
+            received = getReceivedItems(parameters, numerator, denominator);
 
-        applyCriteriaResolvers(spent, received, orderIndex, criteriaResolvers);
+            applyCriteriaResolvers(
+                spent,
+                received,
+                orderIndex,
+                criteriaResolvers
+            );
+        }
     }
 
     function applyCriteriaResolvers(

--- a/test/foundry/new/helpers/FuzzHelpers.sol
+++ b/test/foundry/new/helpers/FuzzHelpers.sol
@@ -746,8 +746,6 @@ library FuzzHelpers {
     ) internal view returns (bytes32 orderHash) {
         // Get the orderHash using the tweaked OrderComponents.
         orderHash = getTipNeutralizedOrderHash(order, seaport);
-
-
     }
 
     /**

--- a/test/foundry/new/helpers/sol/MatchFulfillmentHelper.t.sol
+++ b/test/foundry/new/helpers/sol/MatchFulfillmentHelper.t.sol
@@ -1674,10 +1674,12 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
         });
     }
 
-    function testRemainingItems() public {
+    function testRemainingItems_availableOrder() public {
         Order memory order1 = Order({
             parameters: OrderParametersLib
                 .empty()
+                .withStartTime(block.timestamp)
+                .withEndTime(block.timestamp + 1)
                 .withOffer(
                     SeaportArrays.OfferItems(
                         OfferItemLib
@@ -1773,6 +1775,50 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             2,
             "remainingConsideration[1].amount"
         );
+    }
+
+    function testRemainingItems_unavailableOrder() public {
+        Order memory order1 = Order({
+            parameters: OrderParametersLib
+                .empty()
+                .withOffer(
+                    SeaportArrays.OfferItems(
+                        OfferItemLib
+                            .empty()
+                            .withToken(address(erc20s[0]))
+                            .withAmount(10),
+                        OfferItemLib
+                            .empty()
+                            .withToken(address(erc20s[0]))
+                            .withAmount(11)
+                    )
+                )
+                .withTotalConsideration(
+                    SeaportArrays.ConsiderationItems(
+                        ConsiderationItemLib
+                            .empty()
+                            .withToken(address(erc20s[1]))
+                            .withAmount(1),
+                        ConsiderationItemLib
+                            .empty()
+                            .withToken(address(erc20s[1]))
+                            .withAmount(2)
+                    )
+                )
+                .withOfferer(offerer1.addr),
+            signature: ""
+        });
+
+        // Note: there's no order 2.
+
+        (
+            ,
+            MatchComponent[] memory remainingOffer,
+            MatchComponent[] memory remainingConsideration
+        ) = matcher.getMatchedFulfillments(SeaportArrays.Orders(order1));
+
+        assertEq(remainingOffer.length, 0);
+        assertEq(remainingConsideration.length, 0);
     }
 
     function assertEq(


### PR DESCRIPTION
- Fuzz ascending/descending consideration item amounts
- Add `isAvailable` helper to `OrderParametersLib` 
- Skip calculating spent/received items for unavailable orders.