### PR TITLE
Add failure cases

### DIFF
--- a/test/foundry/new/helpers/FuzzDerivers.sol
+++ b/test/foundry/new/helpers/FuzzDerivers.sol
@@ -64,6 +64,13 @@ library FuzzDerivers {
     using ExecutionHelper for OrderDetails;
     using FulfillmentDetailsHelper for FuzzTestContext;
 
+    function withDerivedCallValue(
+        FuzzTestContext memory context
+    ) internal view returns (FuzzTestContext memory) {
+        context.value = context.getNativeTokensToSupply();
+        return context;
+    }
+
     function withDerivedAvailableOrders(
         FuzzTestContext memory context
     ) internal view returns (FuzzTestContext memory) {
@@ -310,7 +317,7 @@ library FuzzDerivers {
                     caller,
                     context.fulfillerConduitKey,
                     recipient,
-                    context.getNativeTokensToSupply(),
+                    context.value,
                     address(context.seaport)
                 );
     }
@@ -329,7 +336,7 @@ library FuzzDerivers {
                 .getBasicExecutions(
                     caller,
                     context.fulfillerConduitKey,
-                    context.getNativeTokensToSupply(),
+                    context.value,
                     address(context.seaport)
                 );
     }
@@ -348,7 +355,7 @@ library FuzzDerivers {
             context.toFulfillmentDetails().getFulfillAvailableExecutions(
                 context.offerFulfillments,
                 context.considerationFulfillments,
-                context.getNativeTokensToSupply(),
+                context.value,
                 context.expectedAvailableOrders
             );
     }
@@ -366,7 +373,7 @@ library FuzzDerivers {
         return
             context.toFulfillmentDetails().getMatchExecutions(
                 context.fulfillments,
-                context.getNativeTokensToSupply()
+                context.value
             );
     }
 }

--- a/test/foundry/new/helpers/FuzzEngine.sol
+++ b/test/foundry/new/helpers/FuzzEngine.sol
@@ -330,6 +330,7 @@ contract FuzzEngine is
             .withDetectedRemainders()
             .withDerivedOrderDetails()
             .withDerivedFulfillments()
+            .withDerivedCallValue()
             .withDerivedExecutions()
             .withDerivedOrderDetails();
     }

--- a/test/foundry/new/helpers/FuzzEngineLib.sol
+++ b/test/foundry/new/helpers/FuzzEngineLib.sol
@@ -81,7 +81,9 @@ library FuzzEngineLib {
         revert("Unknown selector");
     }
 
-    function withDetectedRemainders(FuzzTestContext memory context) internal returns (FuzzTestContext memory) {
+    function withDetectedRemainders(
+        FuzzTestContext memory context
+    ) internal returns (FuzzTestContext memory) {
         (, , MatchComponent[] memory remainders) = context
             .testHelpers
             .getMatchedFulfillments(context.orders, context.criteriaResolvers);
@@ -377,12 +379,8 @@ library FuzzEngineLib {
 
         uint256 value = 0;
 
-        OrderDetails[] memory orderDetails = context.orders.getOrderDetails(
-            context.criteriaResolvers
-        );
-
-        for (uint256 i = 0; i < orderDetails.length; ++i) {
-            OrderDetails memory order = orderDetails[i];
+        for (uint256 i = 0; i < context.orderDetails.length; ++i) {
+            OrderDetails memory order = context.orderDetails[i];
             OrderParameters memory orderParams = context.orders[i].parameters;
 
             if (isMatch) {

--- a/test/foundry/new/helpers/FuzzExecutor.sol
+++ b/test/foundry/new/helpers/FuzzExecutor.sol
@@ -61,7 +61,6 @@ abstract contract FuzzExecutor is Test {
         // so it will be the same for each run of the test throughout the entire
         // lifecycle of the test.
         bytes4 _action = context.action();
-        uint256 value = context.getNativeTokensToSupply();
 
         // Execute the action.
         if (_action == context.seaport.fulfillOrder.selector) {
@@ -70,7 +69,7 @@ abstract contract FuzzExecutor is Test {
 
             if (context.caller != address(0)) vm.prank(context.caller);
             context.returnValues.fulfilled = context.seaport.fulfillOrder{
-                value: value
+                value: context.value
             }(order.toOrder(), context.fulfillerConduitKey);
         } else if (_action == context.seaport.fulfillAdvancedOrder.selector) {
             logCall("fulfillAdvancedOrder", logCalls);
@@ -79,7 +78,7 @@ abstract contract FuzzExecutor is Test {
             if (context.caller != address(0)) vm.prank(context.caller);
             context.returnValues.fulfilled = context
                 .seaport
-                .fulfillAdvancedOrder{ value: value }(
+                .fulfillAdvancedOrder{ value: context.value }(
                 order,
                 context.criteriaResolvers,
                 context.fulfillerConduitKey,
@@ -97,7 +96,7 @@ abstract contract FuzzExecutor is Test {
 
             if (context.caller != address(0)) vm.prank(context.caller);
             context.returnValues.fulfilled = context.seaport.fulfillBasicOrder{
-                value: value
+                value: context.value
             }(basicOrderParameters);
         } else if (
             _action ==
@@ -115,7 +114,7 @@ abstract contract FuzzExecutor is Test {
             if (context.caller != address(0)) vm.prank(context.caller);
             context.returnValues.fulfilled = context
                 .seaport
-                .fulfillBasicOrder_efficient_6GL6yc{ value: value }(
+                .fulfillBasicOrder_efficient_6GL6yc{ value: context.value }(
                 basicOrderParameters
             );
         } else if (_action == context.seaport.fulfillAvailableOrders.selector) {
@@ -124,7 +123,7 @@ abstract contract FuzzExecutor is Test {
             (
                 bool[] memory availableOrders,
                 Execution[] memory executions
-            ) = context.seaport.fulfillAvailableOrders{ value: value }(
+            ) = context.seaport.fulfillAvailableOrders{ value: context.value }(
                     context.orders.toOrders(),
                     context.offerFulfillments,
                     context.considerationFulfillments,
@@ -142,7 +141,9 @@ abstract contract FuzzExecutor is Test {
             (
                 bool[] memory availableOrders,
                 Execution[] memory executions
-            ) = context.seaport.fulfillAvailableAdvancedOrders{ value: value }(
+            ) = context.seaport.fulfillAvailableAdvancedOrders{
+                    value: context.value
+                }(
                     context.orders,
                     context.criteriaResolvers,
                     context.offerFulfillments,
@@ -158,7 +159,7 @@ abstract contract FuzzExecutor is Test {
             logCall("matchOrders", logCalls);
             if (context.caller != address(0)) vm.prank(context.caller);
             Execution[] memory executions = context.seaport.matchOrders{
-                value: value
+                value: context.value
             }(context.orders.toOrders(), context.fulfillments);
 
             context.returnValues.executions = executions;
@@ -166,7 +167,7 @@ abstract contract FuzzExecutor is Test {
             logCall("matchAdvancedOrders", logCalls);
             if (context.caller != address(0)) vm.prank(context.caller);
             Execution[] memory executions = context.seaport.matchAdvancedOrders{
-                value: value
+                value: context.value
             }(
                 context.orders,
                 context.criteriaResolvers,

--- a/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
+++ b/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
@@ -9,7 +9,8 @@ import { FuzzEngineLib } from "./FuzzEngineLib.sol";
 
 import {
     FailureEligibilityLib,
-    OrderEligibilityLib
+    OrderEligibilityLib,
+    Failarray
 } from "./FuzzMutationHelpers.sol";
 
 import { LibPRNG } from "solady/src/utils/LibPRNG.sol";
@@ -40,6 +41,7 @@ enum Failure {
 }
 
 library FuzzMutationSelectorLib {
+    using Failarray for Failure;
     using FuzzEngineLib for FuzzTestContext;
     using FailureDetailsLib for FuzzTestContext;
     using FailureEligibilityLib for FuzzTestContext;
@@ -78,8 +80,9 @@ library FuzzMutationSelectorLib {
                 MutationFilters.ineligibleForBadFraction
             )
         ) {
-            context.setIneligibleFailure(Failure.BadFraction_NoFill);
-            context.setIneligibleFailure(Failure.BadFraction_Overfill);
+            context.setIneligibleFailures(
+                Failure.BadFraction_NoFill.and(Failure.BadFraction_Overfill)
+            );
         }
 
         // Choose one of the remaining eligible failures.

--- a/test/foundry/new/helpers/FuzzSetup.sol
+++ b/test/foundry/new/helpers/FuzzSetup.sol
@@ -240,7 +240,6 @@ abstract contract FuzzSetup is Test, AmountDeriverHelper {
                 }
 
                 if (item.itemType == ItemType.ERC20) {
-
                     TestERC20(item.token).mint(offerer, item.amount);
                     vm.prank(offerer);
                     TestERC20(item.token).increaseAllowance(
@@ -408,18 +407,18 @@ abstract contract FuzzSetup is Test, AmountDeriverHelper {
         // supplied when orders are unavailable; however, this is generally
         // not known at the time of submission. Consider adding a fuzz param
         // for supplying the minimum possible native token value.
-        uint256 callValue = context.getNativeTokensToSupply();
+        context.value = context.getNativeTokensToSupply();
 
         Execution[] memory _executions = context.allExpectedExecutions;
         Execution[] memory executions = _executions;
 
-        if (callValue > 0) {
+        if (context.value > 0) {
             address caller = context.caller;
             if (caller == address(0)) caller = address(this);
             address seaport = address(context.seaport);
             executions = new Execution[](_executions.length + 1);
             executions[0] = ExecutionLib.empty().withOfferer(caller);
-            executions[0].item.amount = callValue;
+            executions[0].item.amount = context.value;
             executions[0].item.recipient = payable(seaport);
             for (uint256 i; i < _executions.length; i++) {
                 Execution memory execution = _executions[i].copy();

--- a/test/foundry/new/helpers/FuzzTestContextLib.sol
+++ b/test/foundry/new/helpers/FuzzTestContextLib.sol
@@ -135,6 +135,7 @@ struct FuzzTestContext {
      *      address before calling exec.
      */
     address caller;
+    uint256 value;
     /**
      * @dev A recipient address to be passed into fulfillAdvancedOrder,
      *      fulfillAvailableAdvancedOrders, or matchAdvancedOrders. Speciying a
@@ -310,6 +311,7 @@ library FuzzTestContextLib {
                 seaport: SeaportInterface(address(0)),
                 conduitController: ConduitControllerInterface(address(0)),
                 caller: address(0),
+                value: 0,
                 fuzzParams: FuzzParams({
                     seed: 0,
                     totalOrders: 0,


### PR DESCRIPTION
- Move call value to context
- Use `Failarray` helper in mutation selector lib
-  Add no fill, overfill, and bad signature V failure cases