### PR TITLE
Add vm.assume metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ test/utils/eip712/gen.sol
 
 # fuzz metrics
 metrics.txt
-call-metrics.txt
-mutation-metrics.txt
+*-metrics.txt
 
 fuzz_debug.json

--- a/foundry.toml
+++ b/foundry.toml
@@ -21,6 +21,7 @@ fs_permissions = [
     { access = "read", path = "./reference-out" },
     { access = "write", path = "./call-metrics.txt" },
     { access = "write", path = "./mutation-metrics.txt" },
+    { access = "write", path = "./assume-metrics.txt" },
     { access = "write", path = "./fuzz_debug.json" }
 ]
 

--- a/test/foundry/new/ExpectedBalanceSerializer.sol
+++ b/test/foundry/new/ExpectedBalanceSerializer.sol
@@ -1,14 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-// import { Vm } from "forge-std/Vm.sol";
+// import { vm } from "./VmUtils.sol"";
 
 // import { ExpectedBalances } from  "./helpers/ExpectedBalances.sol";
-
-// address constant VM_ADDRESS = address(
-//     uint160(uint256(keccak256("hevm cheat code")))
-// );
-// Vm constant vm = Vm(VM_ADDRESS);
 
 // function tojsonAddress(
 //     string memory objectKey,

--- a/test/foundry/new/helpers/FuzzDerivers.sol
+++ b/test/foundry/new/helpers/FuzzDerivers.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.17;
 import { Test } from "forge-std/Test.sol";
 
 import { Vm } from "forge-std/Vm.sol";
+import { assume } from "./VmUtils.sol";
 
 import {
     AdvancedOrderLib,
@@ -73,7 +74,7 @@ library FuzzDerivers {
 
     function withDerivedAvailableOrders(
         FuzzTestContext memory context
-    ) internal view returns (FuzzTestContext memory) {
+    ) internal returns (FuzzTestContext memory) {
         // TODO: handle skipped orders due to generateOrder reverts
         bool[] memory expectedAvailableOrders = new bool[](
             context.executionState.orders.length
@@ -124,7 +125,10 @@ library FuzzDerivers {
             }
 
             // TEMP (TODO: handle upstream)
-            vm.assume(!(order.startTime == 0 && order.endTime == 0));
+            assume(
+                !(order.startTime == 0 && order.endTime == 0),
+                "zero_start_end_time"
+            );
 
             bool isAvailable = (block.timestamp < order.endTime && // not expired
                 block.timestamp >= order.startTime && // started
@@ -237,7 +241,6 @@ library FuzzDerivers {
         FuzzTestContext memory context
     )
         internal
-        view
         returns (
             Execution[] memory implicitExecutions,
             Execution[] memory explicitExecutions
@@ -277,7 +280,10 @@ library FuzzDerivers {
             ) = getFulfillAvailableExecutions(context);
 
             // TEMP (TODO: handle upstream)
-            vm.assume(explicitExecutions.length > 0);
+            assume(
+                explicitExecutions.length > 0,
+                "no_explicit_executions_fulfillAvailable"
+            );
 
             if (explicitExecutions.length == 0) {
                 revert(
@@ -295,7 +301,10 @@ library FuzzDerivers {
             );
 
             // TEMP (TODO: handle upstream)
-            vm.assume(explicitExecutions.length > 0);
+            assume(
+                explicitExecutions.length > 0,
+                "no_explicit_executions_match"
+            );
 
             if (explicitExecutions.length == 0) {
                 revert("FuzzDerivers: no explicit executions derived - match");
@@ -311,7 +320,7 @@ library FuzzDerivers {
      */
     function withDerivedExecutions(
         FuzzTestContext memory context
-    ) internal view returns (FuzzTestContext memory) {
+    ) internal returns (FuzzTestContext memory) {
         (
             Execution[] memory implicitExecutions,
             Execution[] memory explicitExecutions

--- a/test/foundry/new/helpers/FuzzDerivers.sol
+++ b/test/foundry/new/helpers/FuzzDerivers.sol
@@ -3,8 +3,7 @@ pragma solidity ^0.8.17;
 
 import { Test } from "forge-std/Test.sol";
 
-import { Vm } from "forge-std/Vm.sol";
-import { assume } from "./VmUtils.sol";
+import { vm, assume } from "./VmUtils.sol";
 
 import {
     AdvancedOrderLib,
@@ -53,9 +52,6 @@ import { CriteriaResolverHelper } from "./CriteriaResolverHelper.sol";
  *       `FuzzTestContext`.
  */
 library FuzzDerivers {
-    Vm private constant vm =
-        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
-
     using FuzzEngineLib for FuzzTestContext;
     using AdvancedOrderLib for AdvancedOrder;
     using AdvancedOrderLib for AdvancedOrder[];

--- a/test/foundry/new/helpers/FuzzEngine.sol
+++ b/test/foundry/new/helpers/FuzzEngine.sol
@@ -75,6 +75,8 @@ import { CheckHelpers, FuzzSetup } from "./FuzzSetup.sol";
 
 import { ExpectedEventsUtil } from "./event-utils/ExpectedEventsUtil.sol";
 
+import { logMutation } from "./Metrics.sol";
+
 /**
  * @notice Base test contract for FuzzEngine. Fuzz tests should inherit this.
  *         Includes the setup and helper functions from BaseOrderTest.
@@ -481,13 +483,6 @@ contract FuzzEngine is
         for (uint256 i; i < context.checks.length; ++i) {
             bytes4 selector = context.checks[i];
             check(context, selector);
-        }
-    }
-
-    function logMutation(string memory mutationName) internal {
-        if (vm.envOr("SEAPORT_COLLECT_FUZZ_METRICS", false)) {
-            string memory metric = string.concat(mutationName, ":1|c");
-            vm.writeLine("mutation-metrics.txt", metric);
         }
     }
 }

--- a/test/foundry/new/helpers/FuzzExecutor.sol
+++ b/test/foundry/new/helpers/FuzzExecutor.sol
@@ -31,6 +31,7 @@ import { FuzzTestContext } from "./FuzzTestContextLib.sol";
 import { FuzzEngineLib } from "./FuzzEngineLib.sol";
 import { FuzzHelpers } from "./FuzzHelpers.sol";
 
+import { logCall } from "./Metrics.sol";
 import { dumpExecutions } from "./DebugUtil.sol";
 
 abstract contract FuzzExecutor is Test {
@@ -234,12 +235,5 @@ abstract contract FuzzExecutor is Test {
 
     function exec(FuzzTestContext memory context) public {
         exec(context, false);
-    }
-
-    function logCall(string memory callName, bool enabled) internal {
-        if (enabled && vm.envOr("SEAPORT_COLLECT_FUZZ_METRICS", false)) {
-            string memory metric = string.concat(callName, ":1|c");
-            vm.writeLine("call-metrics.txt", metric);
-        }
     }
 }

--- a/test/foundry/new/helpers/FuzzGenerators.sol
+++ b/test/foundry/new/helpers/FuzzGenerators.sol
@@ -1698,7 +1698,7 @@ library SignatureGenerator {
         bytes32 s,
         Offerer offerer,
         FuzzGeneratorContext memory context
-    ) internal {
+    ) internal pure {
         address recovered = ecrecover(digest, v, r, s);
         if (recovered != offerer.generate(context) || recovered == address(0)) {
             revert("SignatureGenerator: Invalid signature");
@@ -2022,7 +2022,7 @@ library OffererGenerator {
     function generate(
         Offerer offerer,
         FuzzGeneratorContext memory context
-    ) internal returns (address) {
+    ) internal pure returns (address) {
         if (offerer == Offerer.TEST_CONTRACT) {
             return context.self;
         } else if (offerer == Offerer.ALICE) {

--- a/test/foundry/new/helpers/FuzzInscribers.sol
+++ b/test/foundry/new/helpers/FuzzInscribers.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { Vm } from "forge-std/Vm.sol";
+import { vm } from "./VmUtils.sol";
 
 import { AdvancedOrder, OrderStatus } from "seaport-sol/SeaportStructs.sol";
 
@@ -14,9 +14,6 @@ import { AdvancedOrderLib } from "seaport-sol/SeaportSol.sol";
  */
 library FuzzInscribers {
     using AdvancedOrderLib for AdvancedOrder;
-
-    Vm private constant vm =
-        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     uint256 constant wipeDenominatorMask =
         0x000000000000000000000000000000ffffffffffffffffffffffffffffffffff;

--- a/test/foundry/new/helpers/FuzzMutationHelpers.sol
+++ b/test/foundry/new/helpers/FuzzMutationHelpers.sol
@@ -7,7 +7,7 @@ import { FuzzTestContext, MutationState } from "./FuzzTestContextLib.sol";
 
 import { LibPRNG } from "solady/src/utils/LibPRNG.sol";
 
-import { Vm } from "forge-std/Vm.sol";
+import { vm } from "./VmUtils.sol";
 
 import {
     Failure,
@@ -19,9 +19,6 @@ import {
 import { assume } from "./VmUtils.sol";
 
 library FailureEligibilityLib {
-    Vm private constant vm =
-        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
-
     using LibPRNG for LibPRNG.PRNG;
 
     function ensureFilterSetForEachFailure(

--- a/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
+++ b/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
@@ -152,7 +152,6 @@ library FuzzMutationSelectorLib {
         FuzzTestContext memory context
     )
         public
-        view
         returns (
             string memory name,
             bytes4 mutationSelector,
@@ -397,7 +396,7 @@ library FailureDetailsLib {
 
     function details_InvalidConduit(
         FuzzTestContext memory context,
-        MutationState memory mutationState,
+        MutationState memory /* mutationState */,
         bytes4 errorSelector
     ) internal view returns (bytes memory expectedRevertReason) {
         bytes32 conduitKey = keccak256("invalid conduit");
@@ -442,7 +441,6 @@ library FailureDetailsLib {
         IneligibilityFilter[] memory failuresAndFilters
     )
         internal
-        view
         returns (
             string memory name,
             bytes4 mutationSelector,

--- a/test/foundry/new/helpers/FuzzMutations.sol
+++ b/test/foundry/new/helpers/FuzzMutations.sol
@@ -183,7 +183,7 @@ library MutationFilters {
         AdvancedOrder memory order,
         uint256 /* orderIndex */,
         FuzzTestContext memory context
-    ) internal view returns (bool) {
+    ) internal returns (bool) {
         bytes4 action = context.action();
         if (
             action == context.seaport.fulfillAvailableOrders.selector ||
@@ -289,7 +289,7 @@ library MutationFilters {
     }
 
     function ineligibleForCannotCancelOrder(
-        AdvancedOrder memory order,
+        AdvancedOrder memory /* order */,
         uint256 /* orderIndex */,
         FuzzTestContext memory context
     ) internal view returns (bool) {
@@ -324,7 +324,7 @@ library MutationFilters {
     }
 
     function ineligibleForOrderAlreadyFilled(
-        AdvancedOrder memory order,
+        AdvancedOrder memory /* order */,
         uint256 /* orderIndex */,
         FuzzTestContext memory context
     ) internal view returns (bool) {
@@ -373,6 +373,8 @@ library MutationFilters {
         if (order.numerator == 1 && order.denominator == 1) {
             return true;
         }
+
+        return false;
     }
 }
 

--- a/test/foundry/new/helpers/Labeler.sol
+++ b/test/foundry/new/helpers/Labeler.sol
@@ -1,13 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { Vm } from "forge-std/Vm.sol";
+import { vm } from "./VmUtils.sol";
 import { LibString } from "solady/src/utils/LibString.sol";
-
-address constant VM_ADDRESS = address(
-    uint160(uint256(keccak256("hevm cheat code")))
-);
-Vm constant vm = Vm(VM_ADDRESS);
 
 address constant LABELER_ADDRESS = address(
     uint160(uint256(keccak256(".labeler")))

--- a/test/foundry/new/helpers/Metrics.sol
+++ b/test/foundry/new/helpers/Metrics.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import { Vm } from "forge-std/Vm.sol";
+
+address constant VM_ADDRESS = address(
+    uint160(uint256(keccak256("hevm cheat code")))
+);
+Vm constant vm = Vm(VM_ADDRESS);
+
+function logCall(string memory name) {
+    logCall(name, true);
+}
+
+function logCall(string memory name, bool enabled) {
+    logCounter("call", name, enabled);
+}
+
+function logMutation(string memory name) {
+    logCounter("mutation", name, true);
+}
+
+function logAssume(string memory name) {
+    logCounter("assume", name, true);
+}
+
+function logCounter(string memory file, string memory metric, bool enabled) {
+    if (enabled && vm.envOr("SEAPORT_COLLECT_FUZZ_METRICS", false)) {
+        string memory counter = string.concat(metric, ":1|c");
+        vm.writeLine(string.concat(file, "-metrics.txt"), counter);
+    }
+}

--- a/test/foundry/new/helpers/Metrics.sol
+++ b/test/foundry/new/helpers/Metrics.sol
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { Vm } from "forge-std/Vm.sol";
-
-address constant VM_ADDRESS = address(
-    uint160(uint256(keccak256("hevm cheat code")))
-);
-Vm constant vm = Vm(VM_ADDRESS);
+import { vm } from "./VmUtils.sol";
 
 function logCall(string memory name) {
     logCall(name, true);

--- a/test/foundry/new/helpers/Searializer.sol
+++ b/test/foundry/new/helpers/Searializer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { Vm } from "forge-std/Vm.sol";
+import { Vm, vm } from "./VmUtils.sol";
 
 import {
     AdditionalRecipient,
@@ -41,11 +41,6 @@ import {
 } from "./ExpectedBalances.sol";
 
 import { withLabel } from "./Labeler.sol";
-
-address constant VM_ADDRESS = address(
-    uint160(uint256(keccak256("hevm cheat code")))
-);
-Vm constant vm = Vm(VM_ADDRESS);
 
 library Searializer {
     function tojsonBytes32(

--- a/test/foundry/new/helpers/VmUtils.sol
+++ b/test/foundry/new/helpers/VmUtils.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import { Vm } from "forge-std/Vm.sol";
+import { logAssume } from "./Metrics.sol";
+
+address constant VM_ADDRESS = address(
+    uint160(uint256(keccak256("hevm cheat code")))
+);
+Vm constant vm = Vm(VM_ADDRESS);
+
+function assume(bool condition, string memory name) {
+    if (!condition) {
+        logAssume(name);
+    }
+    vm.assume(condition);
+}

--- a/test/foundry/new/helpers/event-utils/EventSerializer.sol
+++ b/test/foundry/new/helpers/event-utils/EventSerializer.sol
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { Vm } from "forge-std/Vm.sol";
+import { vm } from "../VmUtils.sol";
 
 import { SpentItem, ReceivedItem } from "seaport-sol/SeaportStructs.sol";
 
 import { ItemType } from "seaport-sol/SeaportEnums.sol";
-
-Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
 struct ERC20TransferEvent {
     string kind;


### PR DESCRIPTION
Collect metrics on usage of `vm.assume`. Rather than using Foundry `vm.assume`, `import { assume } from './VmUtils.sol'` and use it just like `vm.assume` with an extra string argument:

```solidity
assume(frobs > 0, "no_frobs");
```

`"no_frobs"` will be collected as a counter metric in `assume-metrics.txt`.

Run `yarn test:fuzz:metrics assume-metrics.txt` to generate a visualization.

Also:
- Extract metrics loggers to `Metrics.sol` 
- Fixes some compiler warnings (unused args, mutability)