### PR TITLE
[DNM] Exclude selectors

### DIFF
--- a/test/foundry/new/FuzzEngine.t.sol
+++ b/test/foundry/new/FuzzEngine.t.sol
@@ -109,7 +109,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(1);
@@ -136,7 +137,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(1);
@@ -153,7 +155,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 1,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(1);
@@ -189,7 +192,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length);
@@ -216,7 +220,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(1);
@@ -241,7 +246,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 2,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(1);
@@ -258,7 +264,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 3,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(1);
@@ -295,7 +302,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length);
@@ -338,7 +346,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length);
@@ -370,7 +379,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(2);
@@ -390,7 +400,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 1,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(2);
@@ -410,7 +421,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 2,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(2);
@@ -427,7 +439,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 3,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(2);
@@ -489,7 +502,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length);
@@ -533,7 +547,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length)
@@ -618,7 +633,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 2,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length)
@@ -648,7 +664,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 3,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length)
@@ -764,7 +781,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(advancedOrders.length)
@@ -973,7 +991,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 1,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(advancedOrders.length);
@@ -1098,7 +1117,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 2,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length)
@@ -1218,7 +1238,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 3,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(advancedOrders.length)
@@ -1273,7 +1294,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 5,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length)
@@ -1327,7 +1349,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 4,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length)
@@ -1375,7 +1398,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length)
@@ -1425,7 +1449,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length)
@@ -1735,7 +1760,8 @@ contract FuzzEngineTest is FuzzEngine {
                         seed: 0,
                         totalOrders: 0,
                         maxOfferItems: 0,
-                        maxConsiderationItems: 0
+                        maxConsiderationItems: 0,
+                        excludeSelectors: new bytes4[](0)
                     })
                 );
 
@@ -1804,7 +1830,8 @@ contract FuzzEngineTest is FuzzEngine {
                     seed: 4,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 })
             )
             .withMaximumFulfilled(orders.length)

--- a/test/foundry/new/FuzzMain.t.sol
+++ b/test/foundry/new/FuzzMain.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
+import { SeaportInterface } from "seaport-sol/SeaportSol.sol";
 import { FuzzEngine } from "./helpers/FuzzEngine.sol";
 
 import { FuzzParams } from "./helpers/FuzzTestContextLib.sol";
@@ -12,7 +13,7 @@ contract FuzzMainTest is FuzzEngine {
      *      registered checks. This test should never revert.  For more details
      *      on the lifecycle of this test, see FuzzEngine.sol.
      */
-    function test_fuzz_validOrders(
+    function xtest_fuzz_validOrders(
         uint256 seed,
         uint256 orders,
         uint256 maxOfferItemsPerOrder,
@@ -27,7 +28,164 @@ contract FuzzMainTest is FuzzEngine {
                     maxConsiderationItemsPerOrder,
                     0,
                     10
-                )
+                ),
+                excludeSelectors: new bytes4[](0)
+            })
+        );
+    }
+
+    function test_fuzz_validManyOrders(
+        uint256 seed,
+        uint256 orders,
+        uint256 maxOfferItemsPerOrder,
+        uint256 maxConsiderationItemsPerOrder
+    ) public {
+        run(
+            FuzzParams({
+                seed: seed,
+                totalOrders: bound(orders, 2, 10),
+                maxOfferItems: bound(maxOfferItemsPerOrder, 0, 10),
+                maxConsiderationItems: bound(
+                    maxConsiderationItemsPerOrder,
+                    0,
+                    10
+                ),
+                excludeSelectors: new bytes4[](0)
+            })
+        );
+    }
+
+    function test_fuzz_validSingleOrders(
+        uint256 seed,
+        uint256 orders,
+        uint256 maxOfferItemsPerOrder,
+        uint256 maxConsiderationItemsPerOrder
+    ) public {
+        run(
+            FuzzParams({
+                seed: seed,
+                totalOrders: 1,
+                maxOfferItems: bound(maxOfferItemsPerOrder, 0, 10),
+                maxConsiderationItems: bound(
+                    maxConsiderationItemsPerOrder,
+                    0,
+                    10
+                ),
+                excludeSelectors: new bytes4[](0)
+            })
+        );
+    }
+
+    function test_fuzz_excludeSelectorsManyOrders(
+        uint256 seed,
+        uint256 orders,
+        uint256 maxOfferItemsPerOrder,
+        uint256 maxConsiderationItemsPerOrder
+    ) public {
+        bytes4[] memory excludeSelectors = new bytes4[](2);
+        excludeSelectors[0] = SeaportInterface
+            .fulfillAvailableAdvancedOrders
+            .selector;
+        excludeSelectors[1] = SeaportInterface.matchAdvancedOrders.selector;
+        run(
+            FuzzParams({
+                seed: seed,
+                totalOrders: bound(orders, 2, 10),
+                maxOfferItems: bound(maxOfferItemsPerOrder, 0, 10),
+                maxConsiderationItems: bound(
+                    maxConsiderationItemsPerOrder,
+                    0,
+                    10
+                ),
+                excludeSelectors: excludeSelectors
+            })
+        );
+    }
+
+    function test_fuzz_excludeSelectorsSingleOrders(
+        uint256 seed,
+        uint256 orders,
+        uint256 maxOfferItemsPerOrder,
+        uint256 maxConsiderationItemsPerOrder
+    ) public {
+        bytes4[] memory excludeSelectors = new bytes4[](2);
+        excludeSelectors[0] = SeaportInterface.fulfillAdvancedOrder.selector;
+        excludeSelectors[1] = SeaportInterface
+            .fulfillAvailableAdvancedOrders
+            .selector;
+        run(
+            FuzzParams({
+                seed: seed,
+                totalOrders: 1,
+                maxOfferItems: bound(maxOfferItemsPerOrder, 0, 10),
+                maxConsiderationItems: bound(
+                    maxConsiderationItemsPerOrder,
+                    0,
+                    10
+                ),
+                excludeSelectors: excludeSelectors
+            })
+        );
+    }
+
+    function test_fuzz_basicOnly(
+        uint256 seed,
+        uint256 orders,
+        uint256 maxOfferItemsPerOrder,
+        uint256 maxConsiderationItemsPerOrder
+    ) public {
+        bytes4[] memory excludeSelectors = new bytes4[](6);
+        excludeSelectors[0] = SeaportInterface
+            .fulfillAvailableAdvancedOrders
+            .selector;
+        excludeSelectors[1] = SeaportInterface.fulfillAdvancedOrder.selector;
+        excludeSelectors[2] = SeaportInterface.matchAdvancedOrders.selector;
+        excludeSelectors[3] = SeaportInterface.fulfillOrder.selector;
+        excludeSelectors[4] = SeaportInterface.matchOrders.selector;
+        excludeSelectors[5] = SeaportInterface.fulfillAvailableOrders.selector;
+        run(
+            FuzzParams({
+                seed: seed,
+                totalOrders: 1,
+                maxOfferItems: bound(maxOfferItemsPerOrder, 0, 10),
+                maxConsiderationItems: bound(
+                    maxConsiderationItemsPerOrder,
+                    0,
+                    10
+                ),
+                excludeSelectors: excludeSelectors
+            })
+        );
+    }
+
+    function test_fuzz_matchFulfillAvailableOnly(
+        uint256 seed,
+        uint256 orders,
+        uint256 maxOfferItemsPerOrder,
+        uint256 maxConsiderationItemsPerOrder
+    ) public {
+        bytes4[] memory excludeSelectors = new bytes4[](6);
+        excludeSelectors[0] = SeaportInterface.matchAdvancedOrders.selector;
+        excludeSelectors[1] = SeaportInterface.fulfillAdvancedOrder.selector;
+        excludeSelectors[2] = SeaportInterface
+            .fulfillAvailableAdvancedOrders
+            .selector;
+        excludeSelectors[3] = SeaportInterface.fulfillOrder.selector;
+        excludeSelectors[4] = SeaportInterface.fulfillBasicOrder.selector;
+        excludeSelectors[5] = SeaportInterface
+            .fulfillBasicOrder_efficient_6GL6yc
+            .selector;
+        run(
+            FuzzParams({
+                seed: seed,
+                totalOrders: bound(orders, 2, 10),
+                maxOfferItems: bound(maxOfferItemsPerOrder, 0, 10),
+                maxConsiderationItems: bound(
+                    maxConsiderationItemsPerOrder,
+                    0,
+                    10
+                ),
+                excludeSelectors: excludeSelectors
             })
         );
     }
@@ -38,7 +196,7 @@ contract FuzzMainTest is FuzzEngine {
         uint256 maxOfferItemsPerOrder = 0;
         uint256 maxConsiderationItemsPerOrder = 1;
         bytes memory callData = abi.encodeCall(
-            this.test_fuzz_validOrders,
+            this.xtest_fuzz_validOrders,
             (seed, orders, maxOfferItemsPerOrder, maxConsiderationItemsPerOrder)
         );
         (bool success, bytes memory result) = address(this).call(callData);

--- a/test/foundry/new/helpers/FuzzDerivers.sol
+++ b/test/foundry/new/helpers/FuzzDerivers.sol
@@ -63,7 +63,7 @@ library FuzzDerivers {
 
     function withDerivedCallValue(
         FuzzTestContext memory context
-    ) internal view returns (FuzzTestContext memory) {
+    ) internal returns (FuzzTestContext memory) {
         context.executionState.value = context.getNativeTokensToSupply();
         return context;
     }

--- a/test/foundry/new/helpers/FuzzMutations.sol
+++ b/test/foundry/new/helpers/FuzzMutations.sol
@@ -166,7 +166,7 @@ library MutationFilters {
         AdvancedOrder memory /* order */,
         uint256 /* orderIndex */,
         FuzzTestContext memory context
-    ) internal view returns (bool) {
+    ) internal returns (bool) {
         bytes4 action = context.action();
 
         if (
@@ -244,7 +244,7 @@ library MutationFilters {
         AdvancedOrder memory order,
         uint256 orderIndex,
         FuzzTestContext memory context
-    ) internal view returns (bool) {
+    ) internal returns (bool) {
         bytes4 action = context.action();
 
         if (
@@ -278,7 +278,7 @@ library MutationFilters {
         AdvancedOrder memory order,
         uint256 orderIndex,
         FuzzTestContext memory context
-    ) internal view returns (bool) {
+    ) internal returns (bool) {
         bytes4 action = context.action();
 
         if (action == context.seaport.fulfillAvailableAdvancedOrders.selector) {
@@ -292,7 +292,7 @@ library MutationFilters {
         AdvancedOrder memory /* order */,
         uint256 /* orderIndex */,
         FuzzTestContext memory context
-    ) internal view returns (bool) {
+    ) internal returns (bool) {
         bytes4 action = context.action();
 
         if (action != context.seaport.cancel.selector) {
@@ -306,7 +306,7 @@ library MutationFilters {
         AdvancedOrder memory order,
         uint256 /* orderIndex */,
         FuzzTestContext memory context
-    ) internal view returns (bool) {
+    ) internal returns (bool) {
         bytes4 action = context.action();
 
         if (
@@ -327,7 +327,7 @@ library MutationFilters {
         AdvancedOrder memory /* order */,
         uint256 /* orderIndex */,
         FuzzTestContext memory context
-    ) internal view returns (bool) {
+    ) internal returns (bool) {
         bytes4 action = context.action();
 
         if (
@@ -349,7 +349,7 @@ library MutationFilters {
         AdvancedOrder memory order,
         uint256 orderIndex,
         FuzzTestContext memory context
-    ) internal view returns (bool) {
+    ) internal returns (bool) {
         bytes4 action = context.action();
         if (order.parameters.orderType != OrderType.CONTRACT) {
             return true;

--- a/test/foundry/new/helpers/FuzzSetup.sol
+++ b/test/foundry/new/helpers/FuzzSetup.sol
@@ -490,7 +490,7 @@ abstract contract FuzzSetup is Test, AmountDeriverHelper {
      */
     function registerFunctionSpecificChecks(
         FuzzTestContext memory context
-    ) public view {
+    ) public {
         bytes4 _action = context.action();
         if (_action == context.seaport.fulfillOrder.selector) {
             context.registerCheck(FuzzChecks.check_orderFulfilled.selector);

--- a/test/foundry/new/helpers/FuzzTestContextLib.sol
+++ b/test/foundry/new/helpers/FuzzTestContextLib.sol
@@ -117,6 +117,7 @@ struct FuzzParams {
     uint256 totalOrders;
     uint256 maxOfferItems;
     uint256 maxConsiderationItems;
+    bytes4[] excludeSelectors;
 }
 
 struct ReturnValues {
@@ -336,7 +337,8 @@ library FuzzTestContextLib {
                     seed: 0,
                     totalOrders: 0,
                     maxOfferItems: 0,
-                    maxConsiderationItems: 0
+                    maxConsiderationItems: 0,
+                    excludeSelectors: new bytes4[](0)
                 }),
                 checks: new bytes4[](0),
                 returnValues: ReturnValues({
@@ -865,7 +867,8 @@ library FuzzTestContextLib {
                 seed: params.seed,
                 totalOrders: params.totalOrders,
                 maxOfferItems: params.maxOfferItems,
-                maxConsiderationItems: params.maxConsiderationItems
+                maxConsiderationItems: params.maxConsiderationItems,
+                excludeSelectors: _copyBytes4(params.excludeSelectors)
             });
     }
 }


### PR DESCRIPTION
⚠️ Don't merge, this is just an exploration of one (pretty naive) way to tweak the call distribution, by excluding selectors in specific tests. 

By excluding selectors from some tests and throwing away fuzz runs, we can ensure more runs cover specific functions:

<img width="871" alt="Screenshot 2023-04-17 at 4 50 35 PM" src="https://user-images.githubusercontent.com/109845214/232608052-6301f4b7-9693-48ae-a1ae-17bee68dc3bd.png">

But of course, it comes at a cost: since we're throwing away lots of fuzz runs, tests take longer to run.