### PR TITLE
Consideration length errors

### DIFF
--- a/scripts/plot_metrics.ts
+++ b/scripts/plot_metrics.ts
@@ -16,10 +16,12 @@ function plotMetrics() {
     counter.set(call, (counter.get(call) ?? 0) + 1);
   }
 
-  const data = Array.from(counter.entries()).map(([key, value]) => ({
-    key,
-    value,
-  }));
+  const data = Array.from(counter.entries())
+    .map(([key, value]) => ({
+      key,
+      value,
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
   const totalRuns = data.reduce((acc, item) => acc + item.value, 0);
 
   type Item = { key: string; value: number };

--- a/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
+++ b/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
@@ -69,6 +69,7 @@ enum Failure {
     BadContractSignature_MissingMagic, // 1271 call to offerer, no magic value returned
     ConsiderationLengthNotEqualToTotalOriginal_ExtraItems, // Tips on contract order or validate
     ConsiderationLengthNotEqualToTotalOriginal_MissingItems, // Tips on contract order or validate
+    MissingOriginalConsiderationItems, // Consideration array shorter than totalOriginalConsiderationItems
     InvalidTime_NotStarted, // Order with start time in the future
     InvalidTime_Expired, // Order with end time in the past
     InvalidConduit, // Order with invalid conduit
@@ -192,6 +193,12 @@ library FuzzMutationSelectorLib {
             .and(Failure.BadContractSignature_ModifiedOrder)
             .and(Failure.BadContractSignature_MissingMagic)
             .withOrder(MutationFilters.ineligibleForBadContractSignature);
+
+        failuresAndFilters[i++] = Failure
+            .MissingOriginalConsiderationItems
+            .withOrder(
+                MutationFilters.ineligibleForMissingOriginalConsiderationItems
+            );
 
         failuresAndFilters[i++] = Failure
             .ConsiderationLengthNotEqualToTotalOriginal_ExtraItems
@@ -494,6 +501,16 @@ library FailureDetailsLib {
                 "ConsiderationLengthNotEqualToTotalOriginal_MissingItens",
                 FuzzMutations
                     .mutation_considerationLengthNotEqualToTotalOriginal_MissingItems
+                    .selector
+            );
+
+        failureDetailsArray[i++] = ConsiderationEventsAndErrors
+            .MissingOriginalConsiderationItems
+            .selector
+            .withOrder(
+                "MissingOriginalConsiderationItems",
+                FuzzMutations
+                    .mutation_missingOriginalConsiderationItems
                     .selector
             );
 

--- a/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
+++ b/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
@@ -67,7 +67,8 @@ enum Failure {
     BadContractSignature_BadSignature, // 1271 call to offerer, signature tampered with
     BadContractSignature_ModifiedOrder, // Order with offerer with code tampered with
     BadContractSignature_MissingMagic, // 1271 call to offerer, no magic value returned
-    // ConsiderationLengthNotEqualToTotalOriginal, // Tips on contract order or validate
+    ConsiderationLengthNotEqualToTotalOriginal_ExtraItems, // Tips on contract order or validate
+    ConsiderationLengthNotEqualToTotalOriginal_MissingItems, // Tips on contract order or validate
     InvalidTime_NotStarted, // Order with start time in the future
     InvalidTime_Expired, // Order with end time in the past
     InvalidConduit, // Order with invalid conduit
@@ -191,6 +192,20 @@ library FuzzMutationSelectorLib {
             .and(Failure.BadContractSignature_ModifiedOrder)
             .and(Failure.BadContractSignature_MissingMagic)
             .withOrder(MutationFilters.ineligibleForBadContractSignature);
+
+        failuresAndFilters[i++] = Failure
+            .ConsiderationLengthNotEqualToTotalOriginal_ExtraItems
+            .withOrder(
+                MutationFilters
+                    .ineligibleForConsiderationLengthNotEqualToTotalOriginal
+            );
+
+        failuresAndFilters[i++] = Failure
+            .ConsiderationLengthNotEqualToTotalOriginal_MissingItems
+            .withOrder(
+                MutationFilters
+                    .ineligibleForConsiderationLengthNotEqualToTotalOriginal
+            );
 
         failuresAndFilters[i++] = Failure
             .InvalidFulfillmentComponentData
@@ -459,6 +474,26 @@ library FailureDetailsLib {
                 "BadContractSignature_MissingMagic",
                 FuzzMutations
                     .mutation_badContractSignature_MissingMagic
+                    .selector
+            );
+
+        failureDetailsArray[i++] = ConsiderationEventsAndErrors
+            .ConsiderationLengthNotEqualToTotalOriginal
+            .selector
+            .withOrder(
+                "ConsiderationLengthNotEqualToTotalOriginal_ExtraItems",
+                FuzzMutations
+                    .mutation_considerationLengthNotEqualToTotalOriginal_ExtraItems
+                    .selector
+            );
+
+        failureDetailsArray[i++] = ConsiderationEventsAndErrors
+            .ConsiderationLengthNotEqualToTotalOriginal
+            .selector
+            .withOrder(
+                "ConsiderationLengthNotEqualToTotalOriginal_MissingItens",
+                FuzzMutations
+                    .mutation_considerationLengthNotEqualToTotalOriginal_MissingItems
                     .selector
             );
 

--- a/test/foundry/new/helpers/FuzzMutations.sol
+++ b/test/foundry/new/helpers/FuzzMutations.sol
@@ -633,6 +633,26 @@ library MutationFilters {
         return false;
     }
 
+    function ineligibleForMissingOriginalConsiderationItems(
+        AdvancedOrder memory order,
+        uint256 orderIndex,
+        FuzzTestContext memory context
+    ) internal pure returns (bool) {
+        if (!context.expectations.expectedAvailableOrders[orderIndex]) {
+            return true;
+        }
+
+        if (order.parameters.orderType == OrderType.CONTRACT) {
+            return true;
+        }
+
+        if (order.parameters.consideration.length == 0) {
+            return true;
+        }
+
+        return false;
+    }
+
     // Determine if an order is unavailable, has been validated, has an offerer
     // with code, has an offerer equal to the caller, or is a contract order.
     function ineligibleForInvalidSignature(
@@ -1692,6 +1712,19 @@ contract FuzzMutations is Test, FuzzExecutor {
     }
 
     function mutation_considerationLengthNotEqualToTotalOriginal_MissingItems(
+        FuzzTestContext memory context,
+        MutationState memory mutationState
+    ) external {
+        uint256 orderIndex = mutationState.selectedOrderIndex;
+        AdvancedOrder memory order = context.executionState.orders[orderIndex];
+        order.parameters.totalOriginalConsiderationItems =
+            order.parameters.consideration.length +
+            1;
+
+        exec(context);
+    }
+
+    function mutation_missingOriginalConsiderationItems(
         FuzzTestContext memory context,
         MutationState memory mutationState
     ) external {

--- a/test/foundry/new/helpers/FuzzMutations.sol
+++ b/test/foundry/new/helpers/FuzzMutations.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
+import "forge-std/console.sol";
 import { dumpExecutions } from "./DebugUtil.sol";
 import { Test } from "forge-std/Test.sol";
 import { FuzzExecutor } from "./FuzzExecutor.sol";
@@ -34,7 +35,8 @@ import {
     AdvancedOrderLib,
     OrderParametersLib,
     ItemType,
-    BasicOrderType
+    BasicOrderType,
+    ConsiderationItemLib
 } from "seaport-sol/SeaportSol.sol";
 
 import { EOASignature, SignatureMethod, Offerer } from "./FuzzGenerators.sol";
@@ -605,6 +607,26 @@ library MutationFilters {
                 return true;
             }
         } catch {
+            return true;
+        }
+
+        return false;
+    }
+
+    function ineligibleForConsiderationLengthNotEqualToTotalOriginal(
+        AdvancedOrder memory order,
+        uint256 orderIndex,
+        FuzzTestContext memory context
+    ) internal pure returns (bool) {
+        if (!context.expectations.expectedAvailableOrders[orderIndex]) {
+            return true;
+        }
+
+        if (order.parameters.orderType != OrderType.CONTRACT) {
+            return true;
+        }
+
+        if (order.parameters.consideration.length == 0) {
             return true;
         }
 
@@ -1226,6 +1248,7 @@ contract FuzzMutations is Test, FuzzExecutor {
     using CheckHelpers for FuzzTestContext;
     using MutationHelpersLib for FuzzTestContext;
     using MutationFilters for FuzzTestContext;
+    using ConsiderationItemLib for ConsiderationItem;
 
     function mutation_invalidContractOrderRatifyReverts(
         FuzzTestContext memory context,
@@ -1651,6 +1674,32 @@ contract FuzzMutations is Test, FuzzExecutor {
         AdvancedOrder memory order = context.executionState.orders[orderIndex];
 
         EIP1271Offerer(payable(order.parameters.offerer)).returnEmpty();
+
+        exec(context);
+    }
+
+    function mutation_considerationLengthNotEqualToTotalOriginal_ExtraItems(
+        FuzzTestContext memory context,
+        MutationState memory mutationState
+    ) external {
+        uint256 orderIndex = mutationState.selectedOrderIndex;
+        AdvancedOrder memory order = context.executionState.orders[orderIndex];
+        order.parameters.totalOriginalConsiderationItems =
+            order.parameters.consideration.length -
+            1;
+
+        exec(context);
+    }
+
+    function mutation_considerationLengthNotEqualToTotalOriginal_MissingItems(
+        FuzzTestContext memory context,
+        MutationState memory mutationState
+    ) external {
+        uint256 orderIndex = mutationState.selectedOrderIndex;
+        AdvancedOrder memory order = context.executionState.orders[orderIndex];
+        order.parameters.totalOriginalConsiderationItems =
+            order.parameters.consideration.length +
+            1;
 
         exec(context);
     }


### PR DESCRIPTION
- `ConsiderationLengthNotEqualToTotalOriginal` for contract orders with too many/too few consideration items
- `MissingOriginalConsiderationItems` for non-contract orders with too few provided consideration items
-  Sort metrics alphabetically in visualizations