### PR TITLE
add fraction-util without other changes

### DIFF
--- a/test/foundry/new/helpers/FractionUtil.sol
+++ b/test/foundry/new/helpers/FractionUtil.sol
@@ -1,0 +1,124 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+enum FractionStatus {
+    INVALID,
+    WHOLE_FILL,
+    WHOLE_FILL_GCD,
+    PARTIAL_FILL,
+    PARTIAL_FILL_GCD
+}
+
+struct FractionResults {
+    uint120 realizedNumerator;
+    uint120 realizedDenominator;
+    uint120 finalFilledNumerator;
+    uint120 finalFilledDenominator;
+    FractionStatus status;
+}
+
+library FractionUtil {
+    function _gcd(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 temp;
+        while (b != 0) {
+            temp = b;
+            b = a % b;
+            a = temp;
+        }
+        return a;
+    }
+
+    function getPartialFillResults(
+        uint120 currentStatusNumerator,
+        uint120 currentStatusDenominator,
+        uint120 numeratorToFill,
+        uint120 denominatorToFill
+    ) internal pure returns (FractionResults memory) {
+        uint256 finalNumerator;
+        uint256 finalDenominator;
+
+        // if the denominators are different, we need to convert the numerator to the same denominator
+        if (currentStatusDenominator != denominatorToFill) {
+            finalNumerator =
+                uint256(currentStatusNumerator) *
+                denominatorToFill +
+                uint256(numeratorToFill) *
+                currentStatusDenominator;
+
+            finalDenominator =
+                uint256(currentStatusDenominator) *
+                denominatorToFill;
+        } else {
+            // if the denominators are the same, we can just add the numerators
+            finalNumerator = uint256(currentStatusNumerator) + numeratorToFill;
+            finalDenominator = currentStatusDenominator;
+        }
+
+        uint256 realizedNumerator;
+        uint256 realizedDenominator;
+        bool partialFill;
+        if (finalNumerator > finalDenominator) {
+            partialFill = true;
+            // the numerator is larger than the denominator, so entire order is filled
+            finalNumerator = finalDenominator;
+            // the realized numerator is the remaining portion that was actually filled
+            realizedNumerator =
+                finalDenominator -
+                (uint256(currentStatusNumerator) * denominatorToFill);
+            realizedDenominator = finalDenominator;
+        } else {
+            partialFill = false;
+            realizedNumerator = numeratorToFill;
+            realizedDenominator = denominatorToFill;
+        }
+
+        bool applyGcd;
+        // reduce by gcd if necessary
+        if (finalDenominator > type(uint120).max) {
+            applyGcd = true;
+            // the denominator is too large to fit in a uint120, so we need to reduce it
+
+            if (partialFill) {
+                uint256 gcd = _gcd(realizedNumerator, finalDenominator);
+                finalNumerator /= gcd;
+                finalDenominator /= gcd;
+                // if the order was partially filled, we need to reduce the realized numerator and denominator as well
+                realizedNumerator /= gcd;
+                realizedDenominator /= gcd;
+            } else {
+                uint256 gcd = _gcd(finalNumerator, finalDenominator);
+                finalNumerator /= gcd;
+                finalDenominator /= gcd;
+            }
+        }
+
+        if (finalDenominator > type(uint120).max) {
+            return
+                FractionResults({
+                    realizedNumerator: 0,
+                    realizedDenominator: 0,
+                    finalFilledNumerator: 0,
+                    finalFilledDenominator: 0,
+                    status: FractionStatus.INVALID
+                });
+        }
+        FractionStatus status;
+        if (partialFill && applyGcd) {
+            status = FractionStatus.PARTIAL_FILL_GCD;
+        } else if (partialFill) {
+            status = FractionStatus.PARTIAL_FILL;
+        } else if (applyGcd) {
+            status = FractionStatus.WHOLE_FILL_GCD;
+        } else {
+            status = FractionStatus.WHOLE_FILL;
+        }
+        return
+            FractionResults({
+                realizedNumerator: uint120(realizedNumerator),
+                realizedDenominator: uint120(realizedDenominator),
+                finalFilledNumerator: uint120(finalNumerator),
+                finalFilledDenominator: uint120(finalDenominator),
+                status: status
+            });
+    }
+}

--- a/test/foundry/new/helpers/FractionUtil.t.sol
+++ b/test/foundry/new/helpers/FractionUtil.t.sol
@@ -141,7 +141,6 @@ contract FractionUtilTest is Test {
 
         uint120 numeratorToFill = 1;
         uint120 denominatorToFill = 2;
-        vm.breakpoint("a");
 
         FractionResults memory results3 = FractionUtil.getPartialFillResults(
             currentStatusNumerator,

--- a/test/foundry/new/helpers/FractionUtil.t.sol
+++ b/test/foundry/new/helpers/FractionUtil.t.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import { Test } from "forge-std/Test.sol";
+import {
+    FractionUtil,
+    FractionResults,
+    FractionStatus
+} from "./FractionUtil.sol";
+
+contract FractionUtilTest is Test {
+    function testGetWholeFillResults() public {
+        uint120 currentStatusNumerator = 2;
+        uint120 currentStatusDenominator = 3;
+        uint120 numeratorToFill = 1;
+        uint120 denominatorToFill = 4;
+
+        FractionResults memory results = FractionUtil.getPartialFillResults(
+            currentStatusNumerator,
+            currentStatusDenominator,
+            numeratorToFill,
+            denominatorToFill
+        );
+
+        assertEq(
+            results.realizedNumerator,
+            1,
+            "Realized numerator should be 1"
+        );
+        assertEq(
+            results.realizedDenominator,
+            4,
+            "Realized denominator should be 4"
+        );
+        assertEq(
+            results.finalFilledNumerator,
+            11,
+            "Final filled numerator should be 11"
+        );
+        assertEq(
+            results.finalFilledDenominator,
+            12,
+            "Final filled denominator should be 12"
+        );
+        assertEq(
+            uint256(results.status),
+            uint256(FractionStatus.WHOLE_FILL),
+            "Status should be WHOLE_FILL"
+        );
+    }
+
+    function testGetPartialFillResults() public {
+        // Test for PARTIAL_FILL
+        uint120 currentStatusNumerator1 = 2;
+        uint120 currentStatusDenominator1 = 3;
+        uint120 numeratorToFill1 = 1;
+        uint120 denominatorToFill1 = 2;
+
+        FractionResults memory results1 = FractionUtil.getPartialFillResults(
+            currentStatusNumerator1,
+            currentStatusDenominator1,
+            numeratorToFill1,
+            denominatorToFill1
+        );
+
+        assertEq(
+            results1.realizedNumerator,
+            2,
+            "Realized numerator should be 2"
+        );
+        assertEq(
+            results1.realizedDenominator,
+            6,
+            "Realized denominator should be 6"
+        );
+        assertEq(
+            results1.finalFilledNumerator,
+            6,
+            "Final filled numerator should be 6"
+        );
+        assertEq(
+            results1.finalFilledDenominator,
+            6,
+            "Final filled denominator should be 6"
+        );
+        assertEq(
+            uint256(results1.status),
+            uint256(FractionStatus.PARTIAL_FILL),
+            "Status should be PARTIAL_FILL"
+        );
+    }
+
+    function testGetWholeFillResultsGCD() public {
+        // Test for WHOLE_FILL_GCD
+        uint120 currentStatusDenominator = type(uint120).max -
+            (type(uint120).max % 3);
+        uint120 currentStatusNumerator = (currentStatusDenominator / 3) * 2;
+
+        uint120 numeratorToFill = 2;
+        uint120 denominatorToFill = 6;
+
+        FractionResults memory results2 = FractionUtil.getPartialFillResults(
+            currentStatusNumerator,
+            currentStatusDenominator,
+            numeratorToFill,
+            denominatorToFill
+        );
+
+        assertEq(
+            results2.realizedNumerator,
+            2,
+            "Realized numerator should be 2"
+        );
+        assertEq(
+            results2.realizedDenominator,
+            6,
+            "Realized denominator should be 6"
+        );
+        assertEq(
+            results2.finalFilledNumerator,
+            1,
+            "Final filled numerator should be 1"
+        );
+        assertEq(
+            results2.finalFilledDenominator,
+            1,
+            "Final filled denominator should be 1"
+        );
+        assertEq(
+            uint256(results2.status),
+            uint256(FractionStatus.WHOLE_FILL_GCD),
+            "Status should be WHOLE_FILL_GCD"
+        );
+    }
+
+    function testGetPartialFillResultsGCD() public {
+        // Test for PARTIAL_FILL_GCD
+        uint120 currentStatusDenominator = type(uint120).max -
+            (type(uint120).max % 3);
+        uint120 currentStatusNumerator = (currentStatusDenominator / 3) * 2;
+
+        uint120 numeratorToFill = 1;
+        uint120 denominatorToFill = 2;
+        vm.breakpoint("a");
+
+        FractionResults memory results3 = FractionUtil.getPartialFillResults(
+            currentStatusNumerator,
+            currentStatusDenominator,
+            numeratorToFill,
+            denominatorToFill
+        );
+
+        assertEq(
+            results3.realizedNumerator,
+            1,
+            "Realized numerator should be 1"
+        );
+        assertEq(
+            results3.realizedDenominator,
+            3,
+            "Realized denominator should be 3"
+        );
+        assertEq(
+            results3.finalFilledNumerator,
+            3,
+            "Final filled numerator should be 3"
+        );
+        assertEq(
+            results3.finalFilledDenominator,
+            3,
+            "Final filled denominator should be 3"
+        );
+        assertEq(
+            uint256(results3.status),
+            uint256(FractionStatus.PARTIAL_FILL_GCD),
+            "Status should be PARTIAL_FILL_GCD"
+        );
+    }
+
+    function testGetInvalidResults() public {
+        // Test for INVALID
+        // prime?s generated using Miller-Rabin test
+        uint120 currentStatusNumerator = 1;
+        // 2 ** 119 < prime1 < 2 ** 120
+        uint120 currentStatusDenominator = 664613997892457936451903530140172393;
+        uint120 numeratorToFill = 1;
+        // prime1 < prime2 < 2 ** 120
+        uint120 denominatorToFill = 664613997892457936451903530140172297;
+
+        FractionResults memory results4 = FractionUtil.getPartialFillResults(
+            currentStatusNumerator,
+            currentStatusDenominator,
+            numeratorToFill,
+            denominatorToFill
+        );
+
+        assertEq(
+            results4.realizedNumerator,
+            0,
+            "Realized numerator should be 0"
+        );
+        assertEq(
+            results4.realizedDenominator,
+            0,
+            "Realized denominator should be 0"
+        );
+        assertEq(
+            results4.finalFilledNumerator,
+            0,
+            "Final filled numerator should be 0"
+        );
+        assertEq(
+            results4.finalFilledDenominator,
+            0,
+            "Final filled denominator should be 0"
+        );
+        assertEq(
+            uint256(results4.status),
+            uint256(FractionStatus.INVALID),
+            "Status should be INVALID"
+        );
+    }
+}


### PR DESCRIPTION
pulled out fraction-util + the tests from https://github.com/ProjectOpenSea/seaport/pull/1180 as the other changes were breaking tests, should look to introduce those in a follow-on PR