### PR TITLE
contract generate failures

### DIFF
--- a/contracts/test/HashCalldataContractOfferer.sol
+++ b/contracts/test/HashCalldataContractOfferer.sol
@@ -245,6 +245,14 @@ contract HashCalldataContractOfferer is ContractOffererInterface {
             OffererZoneFailureReason.ContractOfferer_generateReverts
         ) {
             revert HashCalldataContractOffererGenerateOrderReverts();
+        } else if (
+            failureReasons[orderHash] ==
+            OffererZoneFailureReason.ContractOfferer_generateReturnsInvalidEncoding
+        ) {
+            assembly {
+                mstore(0, 0x12345678)
+                return(0, 0x20)
+            }
         }
 
         {

--- a/contracts/test/OffererZoneFailureReason.sol
+++ b/contracts/test/OffererZoneFailureReason.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 enum OffererZoneFailureReason {
     None,
     ContractOfferer_generateReverts, // Offerer generateOrder reverts
+    ContractOfferer_generateReturnsInvalidEncoding, // Bad encoding
     ContractOfferer_ratifyReverts, // Offerer ratifyOrder reverts
     ContractOfferer_InsufficientMinimumReceived, // too few minimum received items
     ContractOfferer_IncorrectMinimumReceived, // incorrect (insufficient amount, wrong token, etc.) minimum received items

--- a/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
+++ b/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
@@ -104,6 +104,7 @@ enum Failure {
     MissingItemAmount_OfferItem_FulfillAvailable, // Zero amount for offer item in fulfillAvailable
     MissingItemAmount_OfferItem, // Zero amount for offer item in all other methods
     MissingItemAmount_ConsiderationItem, // Zero amount for consideration item
+    InvalidContractOrder_generateReturnsInvalidEncoding, // Offerer generateOrder returns invalid data
     InvalidContractOrder_generateReverts, // Offerer generateOrder reverts
     InvalidContractOrder_ratifyReverts, // Offerer ratifyOrder reverts
     InvalidContractOrder_InsufficientMinimumReceived, // too few minimum received items
@@ -331,7 +332,8 @@ library FuzzMutationSelectorLib {
             );
 
         failuresAndFilters[i++] = Failure
-            .InvalidContractOrder_generateReverts
+            .InvalidContractOrder_generateReturnsInvalidEncoding
+            .and(Failure.InvalidContractOrder_generateReverts)
             .withOrder(
                 MutationFilters.ineligibleWhenNotContractOrderOrFulfillAvailable
             );
@@ -827,9 +829,20 @@ library FailureDetailsLib {
             .InvalidContractOrder
             .selector
             .withOrder(
+                "InvalidContractOrder_generateReturnsInvalidEncoding",
+                FuzzMutations
+                    .mutation_invalidContractOrderGenerateReturnsInvalidEncoding
+                    .selector,
+                details_withOrderHash
+            );
+
+        failureDetailsArray[i++] = ZoneInteractionErrors
+            .InvalidContractOrder
+            .selector
+            .withOrder(
                 "InvalidContractOrder_generateReverts",
                 FuzzMutations
-                    .mutation_invalidContractOrderGenerateReverts
+                    .mutation_invalidContractOrderGenerateReturnsInvalidEncoding
                     .selector,
                 details_withOrderHash
             );

--- a/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
+++ b/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
@@ -104,7 +104,7 @@ enum Failure {
     MissingItemAmount_OfferItem_FulfillAvailable, // Zero amount for offer item in fulfillAvailable
     MissingItemAmount_OfferItem, // Zero amount for offer item in all other methods
     MissingItemAmount_ConsiderationItem, // Zero amount for consideration item
-    //InvalidContractOrder_generateReverts, // Offerer generateOrder reverts
+    InvalidContractOrder_generateReverts, // Offerer generateOrder reverts
     InvalidContractOrder_ratifyReverts, // Offerer ratifyOrder reverts
     InvalidContractOrder_InsufficientMinimumReceived, // too few minimum received items
     InvalidContractOrder_IncorrectMinimumReceived, // incorrect (insufficient amount, wrong token, etc.) minimum received items
@@ -331,6 +331,12 @@ library FuzzMutationSelectorLib {
             );
 
         failuresAndFilters[i++] = Failure
+            .InvalidContractOrder_generateReverts
+            .withOrder(
+                MutationFilters.ineligibleWhenNotContractOrderOrFulfillAvailable
+            );
+
+        failuresAndFilters[i++] = Failure
             .InvalidContractOrder_ratifyReverts
             .and(Failure.InvalidContractOrder_InvalidMagicValue)
             .withOrder(
@@ -395,11 +401,9 @@ library FuzzMutationSelectorLib {
                 MutationFilters.ineligibleForPartialFillsNotEnabledForOrder
             );
 
-        failuresAndFilters[i++] = Failure
-            .InexactFraction
-            .withOrder(
-                MutationFilters.ineligibleForInexactFraction
-            );
+        failuresAndFilters[i++] = Failure.InexactFraction.withOrder(
+            MutationFilters.ineligibleForInexactFraction
+        );
 
         failuresAndFilters[i++] = Failure.Panic_PartialFillOverflow.withOrder(
             MutationFilters.ineligibleForPanic_PartialFillOverflow
@@ -817,6 +821,17 @@ library FailureDetailsLib {
                 FuzzMutations
                     .mutation_missingItemAmount_ConsiderationItem
                     .selector
+            );
+
+        failureDetailsArray[i++] = ZoneInteractionErrors
+            .InvalidContractOrder
+            .selector
+            .withOrder(
+                "InvalidContractOrder_generateReverts",
+                FuzzMutations
+                    .mutation_invalidContractOrderGenerateReverts
+                    .selector,
+                details_withOrderHash
             );
 
         failureDetailsArray[i++] = HashCalldataContractOfferer

--- a/test/foundry/new/helpers/FuzzMutations.sol
+++ b/test/foundry/new/helpers/FuzzMutations.sol
@@ -1559,6 +1559,23 @@ contract FuzzMutations is Test, FuzzExecutor {
         exec(context);
     }
 
+    function mutation_invalidContractOrderGenerateReturnsInvalidEncoding(
+        FuzzTestContext memory context,
+        MutationState memory mutationState
+    ) external {
+        AdvancedOrder memory order = mutationState.selectedOrder;
+        bytes32 orderHash = mutationState.selectedOrderHash;
+
+        HashCalldataContractOfferer(payable(order.parameters.offerer))
+            .setFailureReason(
+                orderHash,
+                OffererZoneFailureReason
+                    .ContractOfferer_generateReturnsInvalidEncoding
+            );
+
+        exec(context);
+    }
+
     function mutation_invalidContractOrderRatifyReverts(
         FuzzTestContext memory context,
         MutationState memory mutationState

--- a/test/foundry/new/helpers/FuzzMutations.sol
+++ b/test/foundry/new/helpers/FuzzMutations.sol
@@ -429,6 +429,34 @@ library MutationFilters {
         return ineligibleWhenUnavailable(context, orderIndex);
     }
 
+    function ineligibleWhenFulfillAvailable(
+        AdvancedOrder memory /* order */,
+        uint256 /* orderIndex */,
+        FuzzTestContext memory context
+    ) internal view returns (bool) {
+        bytes4 action = context.action();
+
+        if (
+            action == context.seaport.fulfillAvailableOrders.selector ||
+            action == context.seaport.fulfillAvailableAdvancedOrders.selector
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    function ineligibleWhenNotContractOrderOrFulfillAvailable(
+        AdvancedOrder memory order,
+        uint256 orderIndex,
+        FuzzTestContext memory context
+    ) internal view returns (bool) {
+        if (ineligibleWhenNotContractOrder(order)) {
+            return true;
+        }
+        return ineligibleWhenFulfillAvailable(order, orderIndex, context);
+    }
+
     function ineligibleWhenNotAvailableOrNotRestrictedOrder(
         AdvancedOrder memory order,
         uint256 orderIndex,
@@ -1514,6 +1542,22 @@ contract FuzzMutations is Test, FuzzExecutor {
     using MutationHelpersLib for FuzzTestContext;
     using MutationFilters for FuzzTestContext;
     using ConsiderationItemLib for ConsiderationItem;
+
+    function mutation_invalidContractOrderGenerateReverts(
+        FuzzTestContext memory context,
+        MutationState memory mutationState
+    ) external {
+        AdvancedOrder memory order = mutationState.selectedOrder;
+        bytes32 orderHash = mutationState.selectedOrderHash;
+
+        HashCalldataContractOfferer(payable(order.parameters.offerer))
+            .setFailureReason(
+                orderHash,
+                OffererZoneFailureReason.ContractOfferer_generateReverts
+            );
+
+        exec(context);
+    }
 
     function mutation_invalidContractOrderRatifyReverts(
         FuzzTestContext memory context,


### PR DESCRIPTION
Add failure cases for contract orders:
- Call to `generate` returns invalid data
- Call to `generate` reverts