### PR TITLE
Add a Forge script contract for deploying Seaport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ optimized-out
 reference-working
 offerers-out
 
+#foundry script run output files
+broadcast/
 
 .DS_Store
 

--- a/script/SeaportDeployer.s.sol
+++ b/script/SeaportDeployer.s.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.4;
+
+import "forge-std/Script.sol";
+
+import { Seaport } from "contracts/Seaport.sol";
+
+interface ImmutableCreate2Factory {
+    function safeCreate2(
+        bytes32 salt,
+        bytes calldata initializationCode
+    ) external payable returns (address deploymentAddress);
+}
+
+// NOTE: This script assumes that the CREATE2-related contracts have already been deployed.
+contract SeaportDeployer is Script {
+    ImmutableCreate2Factory private constant IMMUTABLE_CREATE2_FACTORY =
+        ImmutableCreate2Factory(0x0000000000FFe8B47B3e2130213B802212439497);
+    address private constant CONDUIT_CONTROLLER =
+        0x00000000F9490004C11Cef243f5400493c00Ad63;
+    address private constant SEAPORT_ADDRESS =
+        0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC;
+
+    function run() public {
+        // Utilizes the locally-defined PRIVATE_KEY environment variable to sign txs.
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+
+        // CREATE2 salt (20-byte caller or zero address + 12-byte salt).
+        bytes32 salt = 0x0000000000000000000000000000000000000000d4b6fcc21169b803f25d2210;
+
+        // Packed and ABI-encoded contract bytecode and constructor arguments.
+        // NOTE: The Seaport contract *must* be compiled using the optimized profile config.
+        bytes memory initCode = abi.encodePacked(
+            type(Seaport).creationCode,
+            abi.encode(CONDUIT_CONTROLLER)
+        );
+
+        // Deploy the Seaport contract via ImmutableCreate2Factory.
+        address seaport = IMMUTABLE_CREATE2_FACTORY.safeCreate2(salt, initCode);
+
+        // Verify that the deployed contract address matches what we're expecting.
+        assert(seaport == SEAPORT_ADDRESS);
+
+        vm.stopBroadcast();
+    }
+}

--- a/test/foundry/MatchAdvancedOrderUnspentOffer.t.sol
+++ b/test/foundry/MatchAdvancedOrderUnspentOffer.t.sol
@@ -219,7 +219,6 @@ contract MatchOrderUnspentOfferTest is BaseOrderTest {
         token1.mint(offerer, 10000);
         vm.prank(fulfiller);
         test721_1.setApprovalForAll(address(context.seaport), true);
-        vm.stopPrank();
         vm.prank(offerer);
         token1.approve(address(context.seaport), type(uint256).max);
 


### PR DESCRIPTION
## Motivation

Deploying the Seaport contract via `forge script` and a script contract may provide developers (especially those starting out and seeking to improve their contract development knowledge) with a finer-grain view of how contracts are deployed using the ImmutableCreate2Factory contract and the processes involved (e.g. computing the contract init code used in the `safeCreate2` method call).

## Solution

Add a thoroughly-documented SeaportDeployer contract which defines key contract variables (e.g. the ConduitController contract address used as a Seaport constructor argument) and other logic necessary for deploying a Seaport contract via the ImmutableCreate2Factory contract.

## Testing

I used the following process to test and verify that the script contract functions correctly:
1. Run a local fork of Ethereum mainnet at block 17129404 (after the prerequisite contracts were deployed but before the actual Seaport 1.5 contract was deployed): `anvil --fork-url $RPC_URL --fork-block-number 17129404`.
2. Set the private key environment variable (anvil test account): `PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"`.
3. Compile the contracts using the optimized Foundry profile and execute the script: `FOUNDRY_PROFILE=optimized forge script script/SeaportDeployer.s.sol:SeaportDeployer --rpc-url http://localhost:8545 --broadcast -vvvv`.