### PR TITLE
SeaportValidator tests

### DIFF
--- a/contracts/helpers/order-validator/lib/ErrorsAndWarnings.sol
+++ b/contracts/helpers/order-validator/lib/ErrorsAndWarnings.sol
@@ -1,53 +1,196 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
+import {
+    ConsiderationIssue,
+    ERC20Issue,
+    ERC721Issue,
+    GenericIssue,
+    OfferIssue,
+    SignatureIssue,
+    TimeIssue,
+    IssueParser
+} from "./SeaportValidatorTypes.sol";
+
 struct ErrorsAndWarnings {
     uint16[] errors;
     uint16[] warnings;
 }
 
 library ErrorsAndWarningsLib {
-    function concat(ErrorsAndWarnings memory ew1, ErrorsAndWarnings memory ew2)
-        internal
-        pure
-    {
+    using IssueParser for ConsiderationIssue;
+    using IssueParser for ERC20Issue;
+    using IssueParser for ERC721Issue;
+    using IssueParser for GenericIssue;
+    using IssueParser for OfferIssue;
+    using IssueParser for SignatureIssue;
+    using IssueParser for TimeIssue;
+
+    function concat(
+        ErrorsAndWarnings memory ew1,
+        ErrorsAndWarnings memory ew2
+    ) internal pure {
         ew1.errors = concatMemory(ew1.errors, ew2.errors);
         ew1.warnings = concatMemory(ew1.warnings, ew2.warnings);
     }
 
-    function addError(ErrorsAndWarnings memory ew, uint16 err) internal pure {
+    function empty() internal pure returns (ErrorsAndWarnings memory) {
+        return ErrorsAndWarnings(new uint16[](0), new uint16[](0));
+    }
+
+    function addError(
+        uint16 err
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        ErrorsAndWarnings memory ew = ErrorsAndWarnings(
+            new uint16[](0),
+            new uint16[](0)
+        );
         ew.errors = pushMemory(ew.errors, err);
+        return ew;
     }
 
-    function addWarning(ErrorsAndWarnings memory ew, uint16 warn)
-        internal
-        pure
-    {
+    function addError(
+        ErrorsAndWarnings memory ew,
+        uint16 err
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        ew.errors = pushMemory(ew.errors, err);
+        return ew;
+    }
+
+    function addError(
+        ErrorsAndWarnings memory ew,
+        GenericIssue err
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addError(ew, err.parseInt());
+    }
+
+    function addError(
+        ErrorsAndWarnings memory ew,
+        ERC20Issue err
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addError(ew, err.parseInt());
+    }
+
+    function addError(
+        ErrorsAndWarnings memory ew,
+        ERC721Issue err
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addError(ew, err.parseInt());
+    }
+
+    function addError(
+        ErrorsAndWarnings memory ew,
+        ConsiderationIssue err
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addError(ew, err.parseInt());
+    }
+
+    function addError(
+        ErrorsAndWarnings memory ew,
+        OfferIssue err
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addError(ew, err.parseInt());
+    }
+
+    function addError(
+        ErrorsAndWarnings memory ew,
+        SignatureIssue err
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addError(ew, err.parseInt());
+    }
+
+    function addError(
+        ErrorsAndWarnings memory ew,
+        TimeIssue err
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addError(ew, err.parseInt());
+    }
+
+    function addWarning(
+        uint16 warn
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        ErrorsAndWarnings memory ew = ErrorsAndWarnings(
+            new uint16[](0),
+            new uint16[](0)
+        );
         ew.warnings = pushMemory(ew.warnings, warn);
+        return ew;
     }
 
-    function hasErrors(ErrorsAndWarnings memory ew)
-        internal
-        pure
-        returns (bool)
-    {
+    function addWarning(
+        ErrorsAndWarnings memory ew,
+        uint16 warn
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        ew.warnings = pushMemory(ew.warnings, warn);
+        return ew;
+    }
+
+    function addWarning(
+        ErrorsAndWarnings memory ew,
+        GenericIssue warn
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addWarning(ew, warn.parseInt());
+    }
+
+    function addWarning(
+        ErrorsAndWarnings memory ew,
+        ERC20Issue warn
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addWarning(ew, warn.parseInt());
+    }
+
+    function addWarning(
+        ErrorsAndWarnings memory ew,
+        ERC721Issue warn
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addWarning(ew, warn.parseInt());
+    }
+
+    function addWarning(
+        ErrorsAndWarnings memory ew,
+        OfferIssue warn
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addWarning(ew, warn.parseInt());
+    }
+
+    function addWarning(
+        ErrorsAndWarnings memory ew,
+        ConsiderationIssue warn
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addWarning(ew, warn.parseInt());
+    }
+
+    function addWarning(
+        ErrorsAndWarnings memory ew,
+        SignatureIssue warn
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addWarning(ew, warn.parseInt());
+    }
+
+    function addWarning(
+        ErrorsAndWarnings memory ew,
+        TimeIssue warn
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addWarning(ew, warn.parseInt());
+    }
+
+    function hasErrors(
+        ErrorsAndWarnings memory ew
+    ) internal pure returns (bool) {
         return ew.errors.length != 0;
     }
 
-    function hasWarnings(ErrorsAndWarnings memory ew)
-        internal
-        pure
-        returns (bool)
-    {
+    function hasWarnings(
+        ErrorsAndWarnings memory ew
+    ) internal pure returns (bool) {
         return ew.warnings.length != 0;
     }
 
     // Helper Functions
-    function concatMemory(uint16[] memory array1, uint16[] memory array2)
-        private
-        pure
-        returns (uint16[] memory)
-    {
+    function concatMemory(
+        uint16[] memory array1,
+        uint16[] memory array2
+    ) private pure returns (uint16[] memory) {
         if (array1.length == 0) {
             return array2;
         } else if (array2.length == 0) {
@@ -68,11 +211,10 @@ library ErrorsAndWarningsLib {
         return returnValue;
     }
 
-    function pushMemory(uint16[] memory uint16Array, uint16 newValue)
-        internal
-        pure
-        returns (uint16[] memory)
-    {
+    function pushMemory(
+        uint16[] memory uint16Array,
+        uint16 newValue
+    ) internal pure returns (uint16[] memory) {
         uint16[] memory returnValue = new uint16[](uint16Array.length + 1);
 
         for (uint256 i = 0; i < uint16Array.length; i++) {

--- a/contracts/helpers/order-validator/lib/ErrorsAndWarnings.sol
+++ b/contracts/helpers/order-validator/lib/ErrorsAndWarnings.sol
@@ -5,6 +5,7 @@ import {
     ConsiderationIssue,
     ERC20Issue,
     ERC721Issue,
+    ERC1155Issue,
     GenericIssue,
     OfferIssue,
     SignatureIssue,
@@ -21,6 +22,7 @@ library ErrorsAndWarningsLib {
     using IssueParser for ConsiderationIssue;
     using IssueParser for ERC20Issue;
     using IssueParser for ERC721Issue;
+    using IssueParser for ERC1155Issue;
     using IssueParser for GenericIssue;
     using IssueParser for OfferIssue;
     using IssueParser for SignatureIssue;
@@ -74,6 +76,13 @@ library ErrorsAndWarningsLib {
     function addError(
         ErrorsAndWarnings memory ew,
         ERC721Issue err
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addError(ew, err.parseInt());
+    }
+
+    function addError(
+        ErrorsAndWarnings memory ew,
+        ERC1155Issue err
     ) internal pure returns (ErrorsAndWarnings memory) {
         return addError(ew, err.parseInt());
     }
@@ -142,6 +151,13 @@ library ErrorsAndWarningsLib {
     function addWarning(
         ErrorsAndWarnings memory ew,
         ERC721Issue warn
+    ) internal pure returns (ErrorsAndWarnings memory) {
+        return addWarning(ew, warn.parseInt());
+    }
+
+    function addWarning(
+        ErrorsAndWarnings memory ew,
+        ERC1155Issue warn
     ) internal pure returns (ErrorsAndWarnings memory) {
         return addWarning(ew, warn.parseInt());
     }

--- a/test/foundry/new/SeaportValidator.t.sol
+++ b/test/foundry/new/SeaportValidator.t.sol
@@ -56,14 +56,21 @@ contract SeaportValidatorTest is BaseOrderTest {
     function setUp() public override {
         super.setUp();
         validator = new SeaportValidator(address(conduitController));
+
+        OrderLib
+            .empty()
+            .withParameters(
+                OrderComponentsLib.fromDefault(STANDARD).toOrderParameters()
+            )
+            .saveDefault(STANDARD);
     }
 
     function test_empty_isValidOrder() public {
-        Order memory order = OrderLib.empty();
         ErrorsAndWarnings memory actual = validator.isValidOrder(
-            order,
+            OrderLib.empty(),
             address(seaport)
         );
+
         ErrorsAndWarnings memory expected = ErrorsAndWarningsLib
             .empty()
             .addError(TimeIssue.EndTimeBeforeStartTime)
@@ -76,9 +83,8 @@ contract SeaportValidatorTest is BaseOrderTest {
     }
 
     function test_empty_isValidOrderReadOnly() public {
-        Order memory order = OrderLib.empty();
         ErrorsAndWarnings memory actual = validator.isValidOrderReadOnly(
-            order,
+            OrderLib.empty(),
             address(seaport)
         );
 
@@ -93,11 +99,8 @@ contract SeaportValidatorTest is BaseOrderTest {
     }
 
     function test_default_full_isValidOrder() public {
-        Order memory order = OrderLib.empty().withParameters(
-            OrderComponentsLib.fromDefault(STANDARD).toOrderParameters()
-        );
         ErrorsAndWarnings memory actual = validator.isValidOrder(
-            order,
+            OrderLib.fromDefault(STANDARD),
             address(seaport)
         );
 

--- a/test/foundry/new/SeaportValidator.t.sol
+++ b/test/foundry/new/SeaportValidator.t.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import {
+    ConsiderationIssue,
+    ErrorsAndWarnings,
+    GenericIssue,
+    ERC20Issue,
+    ERC721Issue,
+    IssueParser,
+    OfferIssue,
+    SeaportValidator,
+    SignatureIssue,
+    TimeIssue
+} from "../../../contracts/helpers/order-validator/SeaportValidator.sol";
+
+import {
+    OfferItemLib,
+    OrderParametersLib,
+    OrderComponentsLib,
+    OrderLib,
+    AdvancedOrderLib,
+    ItemType
+} from "seaport-sol/SeaportSol.sol";
+
+import {
+    OfferItem,
+    OrderParameters,
+    OrderComponents,
+    Order,
+    AdvancedOrder
+} from "seaport-sol/SeaportStructs.sol";
+
+import { BaseOrderTest } from "./BaseOrderTest.sol";
+
+contract SeaportValidatorTest is BaseOrderTest {
+    using OfferItemLib for OfferItem;
+    using OrderParametersLib for OrderParameters;
+    using OrderComponentsLib for OrderComponents;
+    using OrderLib for Order;
+    using AdvancedOrderLib for AdvancedOrder;
+
+    using IssueParser for ConsiderationIssue;
+    using IssueParser for ERC20Issue;
+    using IssueParser for ERC721Issue;
+    using IssueParser for GenericIssue;
+    using IssueParser for OfferIssue;
+    using IssueParser for SignatureIssue;
+    using IssueParser for TimeIssue;
+
+    SeaportValidator internal validator;
+
+    function setUp() public override {
+        super.setUp();
+        validator = new SeaportValidator(address(conduitController));
+    }
+
+    function test_empty_isValidOrder() public {
+        Order memory order = OrderLib.empty();
+        ErrorsAndWarnings memory validation = validator.isValidOrder(
+            order,
+            address(seaport)
+        );
+        uint16[] memory errors = validation.errors;
+        uint16[] memory warnings = validation.warnings;
+
+        assertEq(errors[0], TimeIssue.EndTimeBeforeStartTime.parseInt());
+        assertEq(errors[1], SignatureIssue.Invalid.parseInt());
+        assertEq(errors[2], GenericIssue.InvalidOrderFormat.parseInt());
+
+        assertEq(warnings[0], OfferIssue.ZeroItems.parseInt());
+        assertEq(warnings[1], ConsiderationIssue.ZeroItems.parseInt());
+    }
+
+    function test_empty_isValidOrderReadOnly() public {
+        Order memory order = OrderLib.empty();
+        ErrorsAndWarnings memory validation = validator.isValidOrderReadOnly(
+            order,
+            address(seaport)
+        );
+        uint16[] memory errors = validation.errors;
+        uint16[] memory warnings = validation.warnings;
+
+        assertEq(errors[0], TimeIssue.EndTimeBeforeStartTime.parseInt());
+        assertEq(errors[1], GenericIssue.InvalidOrderFormat.parseInt());
+
+        assertEq(warnings[0], OfferIssue.ZeroItems.parseInt());
+        assertEq(warnings[1], ConsiderationIssue.ZeroItems.parseInt());
+    }
+
+    function test_default_full_isValidOrder() public {
+        Order memory order = OrderLib.empty().withParameters(
+            OrderComponentsLib.fromDefault(STANDARD).toOrderParameters()
+        );
+        ErrorsAndWarnings memory validation = validator.isValidOrder(
+            order,
+            address(seaport)
+        );
+        uint16[] memory errors = validation.errors;
+        uint16[] memory warnings = validation.warnings;
+
+        assertEq(errors[0], SignatureIssue.Invalid.parseInt());
+        assertEq(errors[1], GenericIssue.InvalidOrderFormat.parseInt());
+
+        assertEq(warnings[0], TimeIssue.ShortOrder.parseInt());
+        assertEq(warnings[1], OfferIssue.ZeroItems.parseInt());
+    }
+
+    function test_default_full_isValidOrder_identifierNonZero() public {
+        OfferItem[] memory offer = new OfferItem[](1);
+        offer[0] = OfferItemLib
+            .empty()
+            .withItemType(ItemType.ERC20)
+            .withAmount(1)
+            .withIdentifierOrCriteria(1);
+        OrderParameters memory parameters = OrderComponentsLib
+            .fromDefault(STANDARD)
+            .toOrderParameters()
+            .withOffer(offer);
+        Order memory order = OrderLib.empty().withParameters(parameters);
+        ErrorsAndWarnings memory validation = validator.isValidOrder(
+            order,
+            address(seaport)
+        );
+        uint16[] memory errors = validation.errors;
+        uint16[] memory warnings = validation.warnings;
+
+        assertEq(errors[0], ERC20Issue.IdentifierNonZero.parseInt());
+        assertEq(errors[1], ERC20Issue.InvalidToken.parseInt());
+        assertEq(errors[2], SignatureIssue.Invalid.parseInt());
+        assertEq(errors[3], GenericIssue.InvalidOrderFormat.parseInt());
+
+        assertEq(warnings[0], TimeIssue.ShortOrder.parseInt());
+        assertEq(warnings[1], ConsiderationIssue.ZeroItems.parseInt());
+    }
+
+    function test_default_full_isValidOrder_invalidToken() public {
+        OfferItem[] memory offer = new OfferItem[](1);
+        offer[0] = OfferItemLib
+            .empty()
+            .withItemType(ItemType.ERC20)
+            .withAmount(1)
+            .withToken(address(0));
+        OrderParameters memory parameters = OrderComponentsLib
+            .fromDefault(STANDARD)
+            .toOrderParameters()
+            .withOffer(offer);
+        Order memory order = OrderLib.empty().withParameters(parameters);
+        ErrorsAndWarnings memory validation = validator.isValidOrder(
+            order,
+            address(seaport)
+        );
+        uint16[] memory errors = validation.errors;
+        uint16[] memory warnings = validation.warnings;
+
+        assertEq(errors[0], ERC20Issue.InvalidToken.parseInt());
+        assertEq(errors[1], SignatureIssue.Invalid.parseInt());
+        assertEq(errors[2], GenericIssue.InvalidOrderFormat.parseInt());
+
+        assertEq(warnings[0], TimeIssue.ShortOrder.parseInt());
+        assertEq(warnings[1], ConsiderationIssue.ZeroItems.parseInt());
+    }
+
+    function test_default_full_isValidOrder_amountNotOne() public {
+        OfferItem[] memory offer = new OfferItem[](1);
+        offer[0] = OfferItemLib
+            .empty()
+            .withItemType(ItemType.ERC721)
+            .withAmount(3);
+        OrderParameters memory parameters = OrderComponentsLib
+            .fromDefault(STANDARD)
+            .toOrderParameters()
+            .withOffer(offer);
+        Order memory order = OrderLib.empty().withParameters(parameters);
+        ErrorsAndWarnings memory validation = validator.isValidOrder(
+            order,
+            address(seaport)
+        );
+        uint16[] memory errors = validation.errors;
+        uint16[] memory warnings = validation.warnings;
+
+        assertEq(errors[0], ERC721Issue.AmountNotOne.parseInt());
+        assertEq(errors[1], ERC721Issue.InvalidToken.parseInt());
+        assertEq(errors[2], SignatureIssue.Invalid.parseInt());
+        assertEq(errors[3], GenericIssue.InvalidOrderFormat.parseInt());
+
+        assertEq(warnings[0], TimeIssue.ShortOrder.parseInt());
+        assertEq(warnings[1], ConsiderationIssue.ZeroItems.parseInt());
+    }
+
+    function test_default_full_isValidOrderReadOnly() public {
+        Order memory order = OrderLib.empty().withParameters(
+            OrderComponentsLib.fromDefault(STANDARD).toOrderParameters()
+        );
+        ErrorsAndWarnings memory validation = validator.isValidOrderReadOnly(
+            order,
+            address(seaport)
+        );
+        uint16[] memory errors = validation.errors;
+        uint16[] memory warnings = validation.warnings;
+
+        assertEq(errors[0], GenericIssue.InvalidOrderFormat.parseInt());
+
+        assertEq(warnings[0], TimeIssue.ShortOrder.parseInt());
+        assertEq(warnings[1], OfferIssue.ZeroItems.parseInt());
+    }
+}


### PR DESCRIPTION
Foothold for `SeaportValidator` unit tests.

- Add custom matcher for `ErrorsAndWarnings` (assert expected length and error order)
- Add builder for expected `ErrorsAndWarnings` (create a nice API for setting up errors)
- Extract and abstract order setup.
- Add tests for simple conditions.