### PR TITLE
add orderhash to orderdetails

### DIFF
--- a/contracts/helpers/sol/executions/ExecutionHelper.sol
+++ b/contracts/helpers/sol/executions/ExecutionHelper.sol
@@ -1165,7 +1165,8 @@ library ExecutionHelper {
                 conduitKey: order.conduitKey,
                 offer: order.offer.copy(),
                 consideration: order.consideration.copy(),
-                isContract: order.isContract
+                isContract: order.isContract,
+                orderHash: order.orderHash
             });
         }
     }

--- a/contracts/helpers/sol/fulfillments/lib/Structs.sol
+++ b/contracts/helpers/sol/fulfillments/lib/Structs.sol
@@ -74,6 +74,7 @@ struct OrderDetails {
     SpentItem[] offer;
     ReceivedItem[] consideration;
     bool isContract;
+    bytes32 orderHash;
 }
 
 /**

--- a/contracts/helpers/sol/fulfillments/match/MatchFulfillmentHelper.sol
+++ b/contracts/helpers/sol/fulfillments/match/MatchFulfillmentHelper.sol
@@ -39,7 +39,8 @@ contract MatchFulfillmentHelper is AmountDeriverHelper {
      * @return fulfillments
      */
     function getMatchedFulfillments(
-        Order[] memory orders
+        Order[] memory orders,
+        bytes32[] memory orderHashes
     )
         public
         returns (
@@ -48,7 +49,7 @@ contract MatchFulfillmentHelper is AmountDeriverHelper {
             MatchComponent[] memory remainingConsiderationComponents
         )
     {
-        OrderDetails[] memory orderDetails = toOrderDetails(orders);
+        OrderDetails[] memory orderDetails = toOrderDetails(orders, orderHashes);
 
         return getMatchedFulfillments(orderDetails);
     }
@@ -63,7 +64,8 @@ contract MatchFulfillmentHelper is AmountDeriverHelper {
      */
     function getMatchedFulfillments(
         AdvancedOrder[] memory orders,
-        CriteriaResolver[] memory resolvers
+        CriteriaResolver[] memory resolvers,
+        bytes32[] memory orderHashes
     )
         public
         returns (
@@ -72,7 +74,7 @@ contract MatchFulfillmentHelper is AmountDeriverHelper {
             MatchComponent[] memory remainingConsiderationComponents
         )
     {
-        OrderDetails[] memory details = toOrderDetails(orders, resolvers);
+        OrderDetails[] memory details = toOrderDetails(orders, resolvers, orderHashes);
         return getMatchedFulfillments(details);
     }
 

--- a/contracts/helpers/sol/lib/AdvancedOrderLib.sol
+++ b/contracts/helpers/sol/lib/AdvancedOrderLib.sol
@@ -742,7 +742,8 @@ library AdvancedOrderLib {
 
     function getOrderDetails(
         AdvancedOrder[] memory advancedOrders,
-        CriteriaResolver[] memory criteriaResolvers
+        CriteriaResolver[] memory criteriaResolvers,
+        bytes32[] memory orderHashes
     ) internal view returns (OrderDetails[] memory) {
         OrderDetails[] memory orderDetails = new OrderDetails[](
             advancedOrders.length
@@ -752,7 +753,8 @@ library AdvancedOrderLib {
             orderDetails[i] = toOrderDetails(
                 advancedOrders[i],
                 i,
-                criteriaResolvers
+                criteriaResolvers,
+                orderHashes[i]
             );
         }
 
@@ -762,7 +764,8 @@ library AdvancedOrderLib {
     function toOrderDetails(
         AdvancedOrder memory order,
         uint256 orderIndex,
-        CriteriaResolver[] memory resolvers
+        CriteriaResolver[] memory resolvers,
+        bytes32 orderHash
     ) internal view returns (OrderDetails memory) {
         (SpentItem[] memory offer, ReceivedItem[] memory consideration) = order
             .parameters
@@ -779,7 +782,8 @@ library AdvancedOrderLib {
                 conduitKey: order.parameters.conduitKey,
                 offer: offer,
                 consideration: consideration,
-                isContract: order.parameters.orderType == OrderType.CONTRACT
+                isContract: order.parameters.orderType == OrderType.CONTRACT,
+                orderHash: orderHash
             });
     }
 }

--- a/contracts/helpers/sol/lib/ZoneParametersLib.sol
+++ b/contracts/helpers/sol/lib/ZoneParametersLib.sol
@@ -34,6 +34,7 @@ import { OrderParametersLib } from "./OrderParametersLib.sol";
 import { StructCopier } from "./StructCopier.sol";
 
 import { AmountDeriverHelper } from "./fulfillment/AmountDeriverHelper.sol";
+
 import { OrderDetails } from "../fulfillments/lib/Structs.sol";
 
 interface FailingContractOfferer {
@@ -183,9 +184,16 @@ library ZoneParametersLib {
         ZoneDetails memory details,
         ZoneParametersStruct memory zoneParametersStruct
     ) internal view {
+        bytes32[] memory orderHashes = details.advancedOrders.getOrderHashes(
+            zoneParametersStruct.seaport
+        );
+
         details.orderDetails = zoneParametersStruct
             .advancedOrders
-            .getOrderDetails(zoneParametersStruct.criteriaResolvers);
+            .getOrderDetails(
+                zoneParametersStruct.criteriaResolvers,
+                orderHashes
+            );
     }
 
     function _applyOrderHashes(

--- a/test/foundry/new/FuzzEngine.t.sol
+++ b/test/foundry/new/FuzzEngine.t.sol
@@ -51,6 +51,7 @@ import { BaseOrderTest } from "./BaseOrderTest.sol";
 
 contract FuzzEngineTest is FuzzEngine {
     using AdvancedOrderLib for AdvancedOrder;
+    using AdvancedOrderLib for AdvancedOrder[];
     using ConsiderationItemLib for ConsiderationItem;
     using ConsiderationItemLib for ConsiderationItem[];
     using FulfillmentComponentLib for FulfillmentComponent;
@@ -1190,12 +1191,18 @@ contract FuzzEngineTest is FuzzEngine {
 
         Fulfillment[] memory fulfillments;
 
+        SeaportInterface seaport = getSeaport();
+
         {
             CriteriaResolver[] memory resolvers;
+            bytes32[] memory orderHashes = orders.getOrderHashes(
+                address(seaport)
+            );
 
             (fulfillments, , ) = matcher.getMatchedFulfillments(
                 orders,
-                resolvers
+                resolvers,
+                orderHashes
             );
         }
 
@@ -1203,11 +1210,7 @@ contract FuzzEngineTest is FuzzEngine {
         checks[0] = this.check_executionsPresent.selector;
 
         FuzzTestContext memory context = FuzzTestContextLib
-            .from({
-                orders: orders,
-                seaport: getSeaport(),
-                caller: offerer1.addr
-            })
+            .from({ orders: orders, seaport: seaport, caller: offerer1.addr })
             .withFuzzParams(
                 FuzzParams({
                     seed: 2,
@@ -1317,11 +1320,18 @@ contract FuzzEngineTest is FuzzEngine {
 
         Fulfillment[] memory fulfillments;
 
+        SeaportInterface seaport = getSeaport();
+
         {
+            bytes32[] memory orderHashes = advancedOrders.getOrderHashes(
+                address(seaport)
+            );
+
             CriteriaResolver[] memory resolvers;
             (fulfillments, , ) = matcher.getMatchedFulfillments(
                 advancedOrders,
-                resolvers
+                resolvers,
+                orderHashes
             );
         }
 
@@ -1331,7 +1341,7 @@ contract FuzzEngineTest is FuzzEngine {
         FuzzTestContext memory context = FuzzTestContextLib
             .from({
                 orders: advancedOrders,
-                seaport: getSeaport(),
+                seaport: seaport,
                 caller: offerer1.addr
             })
             .withFuzzParams(

--- a/test/foundry/new/helpers/FuzzChecks.sol
+++ b/test/foundry/new/helpers/FuzzChecks.sol
@@ -141,7 +141,10 @@ abstract contract FuzzChecks is Test {
                     .expectations
                     .expectedZoneCalldataHash[i];
 
-                bytes32 orderHash = context.executionState.orderHashes[i];
+                bytes32 orderHash = context
+                    .executionState
+                    .orderDetails[i]
+                    .orderHash;
 
                 // Use order hash to get the expected calldata hash from zone.
                 // TODO: fix this in cases where contract orders are part of
@@ -177,7 +180,10 @@ abstract contract FuzzChecks is Test {
             AdvancedOrder memory order = context.executionState.orders[i];
 
             if (order.parameters.orderType == OrderType.CONTRACT) {
-                bytes32 orderHash = context.executionState.orderHashes[i];
+                bytes32 orderHash = context
+                    .executionState
+                    .orderDetails[i]
+                    .orderHash;
 
                 bytes32 expectedGenerateOrderCalldataHash = expectedCalldataHashes[
                         i
@@ -327,7 +333,10 @@ abstract contract FuzzChecks is Test {
         for (uint256 i; i < context.executionState.orders.length; i++) {
             AdvancedOrder memory order = context.executionState.orders[i];
 
-            bytes32 orderHash = context.executionState.orderHashes[i];
+            bytes32 orderHash = context
+                .executionState
+                .orderDetails[i]
+                .orderHash;
 
             (, , uint256 totalFilled, uint256 totalSize) = context
                 .seaport
@@ -451,7 +460,10 @@ abstract contract FuzzChecks is Test {
                 context.executionState.preExecOrderStatuses[i] ==
                 OrderStatusEnum.VALIDATED
             ) {
-                bytes32 orderHash = context.executionState.orderHashes[i];
+                bytes32 orderHash = context
+                    .executionState
+                    .orderDetails[i]
+                    .orderHash;
                 (bool isValid, , , ) = context.seaport.getOrderStatus(
                     orderHash
                 );

--- a/test/foundry/new/helpers/FuzzDerivers.sol
+++ b/test/foundry/new/helpers/FuzzDerivers.sol
@@ -198,7 +198,10 @@ library FuzzDerivers {
         OrderDetails[] memory orderDetails = context
             .executionState
             .previewedOrders
-            .getOrderDetails(context.executionState.criteriaResolvers);
+            .getOrderDetails(
+                context.executionState.criteriaResolvers,
+                context.executionState.orderHashes
+            );
 
         context.executionState.orderDetails = orderDetails;
 

--- a/test/foundry/new/helpers/FuzzGenerators.sol
+++ b/test/foundry/new/helpers/FuzzGenerators.sol
@@ -348,7 +348,6 @@ library TestStateGenerator {
             );
 
             // TODO: fuzz on FulfillAvailableStrategy && MatchStrategy
-
         }
 
         return
@@ -478,7 +477,8 @@ library TestStateGenerator {
                 recipient: FulfillmentRecipient.ZERO,
                 conduit: ConduitChoice.NONE,
                 caller: Caller.TEST_CONTRACT,
-                strategy: FulfillmentGeneratorLib.getDefaultFulfillmentStrategy()
+                strategy: FulfillmentGeneratorLib
+                    .getDefaultFulfillmentStrategy()
             });
     }
 }
@@ -516,6 +516,8 @@ library AdvancedOrdersSpaceGenerator {
     ) internal returns (AdvancedOrder[] memory) {
         uint256 len = bound(space.orders.length, 0, 10);
         AdvancedOrder[] memory orders = new AdvancedOrder[](len);
+        // Instatiate early to avoid out of bounds errors.
+        context.orderHashes = new bytes32[](orders.length);
 
         // Build orders.
         _buildOrders(orders, space, context);
@@ -789,7 +791,10 @@ library AdvancedOrdersSpaceGenerator {
                 .testHelpers
                 .criteriaResolverHelper()
                 .deriveCriteriaResolvers(orders);
-            OrderDetails[] memory details = orders.getOrderDetails(resolvers);
+            OrderDetails[] memory details = orders.getOrderDetails(
+                resolvers,
+                context.orderHashes
+            );
             // Get the remainders.
             (, , remainders) = details.getMatchedFulfillments();
         }
@@ -942,7 +947,10 @@ library AdvancedOrdersSpaceGenerator {
                 .testHelpers
                 .criteriaResolverHelper()
                 .deriveCriteriaResolvers(orders);
-            OrderDetails[] memory details = orders.getOrderDetails(resolvers);
+            OrderDetails[] memory details = orders.getOrderDetails(
+                resolvers,
+                context.orderHashes
+            );
             // Get the remainders.
             (, , remainders) = details.getMatchedFulfillments();
 

--- a/test/foundry/new/helpers/FuzzHelpers.sol
+++ b/test/foundry/new/helpers/FuzzHelpers.sol
@@ -770,7 +770,10 @@ library FuzzHelpers {
             if (!context.expectations.expectedAvailableOrders[i]) {
                 orderHashes[i] = bytes32(0);
             } else {
-                orderHashes[i] = context.executionState.orderHashes[i];
+                orderHashes[i] = context
+                    .executionState
+                    .orderDetails[i]
+                    .orderHash;
             }
         }
 

--- a/test/foundry/new/helpers/FuzzMutationHelpers.sol
+++ b/test/foundry/new/helpers/FuzzMutationHelpers.sol
@@ -648,7 +648,7 @@ library MutationContextDeriverLib {
             mutationState.selectedOrderIndex = orderIndex;
             mutationState.selectedOrderHash = context
                 .executionState
-                .orderHashes[orderIndex];
+                .orderDetails[orderIndex].orderHash;
             mutationState.side = Side(context.generatorContext.randEnum(0, 1));
             mutationState.selectedArbitraryAddress = address(
                 uint160(

--- a/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
+++ b/test/foundry/new/helpers/FuzzMutationSelectorLib.sol
@@ -1128,7 +1128,7 @@ library FailureDetailsLib {
     ) internal pure returns (bytes memory expectedRevertReason) {
         expectedRevertReason = abi.encodeWithSelector(
             errorSelector,
-            context.executionState.orderHashes[mutationState.selectedOrderIndex]
+            context.executionState.orderDetails[mutationState.selectedOrderIndex].orderHash
         );
     }
 

--- a/test/foundry/new/helpers/FuzzMutations.sol
+++ b/test/foundry/new/helpers/FuzzMutations.sol
@@ -330,7 +330,9 @@ library MutationFilters {
 
         OffererZoneFailureReason failureReason = HashCalldataContractOfferer(
             payable(order.parameters.offerer)
-        ).failureReasons(context.executionState.orderHashes[orderIndex]);
+        ).failureReasons(
+                context.executionState.orderDetails[orderIndex].orderHash
+            );
 
         return (failureReason ==
             OffererZoneFailureReason.ContractOfferer_generateReverts);
@@ -413,7 +415,7 @@ library MutationFilters {
         }
 
         (bool isValidated, , , ) = context.seaport.getOrderStatus(
-            context.executionState.orderHashes[orderIndex]
+            context.executionState.orderDetails[orderIndex].orderHash
         );
 
         if (isValidated) {
@@ -1581,7 +1583,7 @@ library MutationFilters {
 
         (, , uint256 totalFilled, uint256 totalSize) = (
             context.seaport.getOrderStatus(
-                context.executionState.orderHashes[orderIndex]
+                context.executionState.orderDetails[orderIndex].orderHash
             )
         );
 
@@ -2818,9 +2820,12 @@ contract FuzzMutations is Test, FuzzExecutor {
                                 Side.OFFER,
                                 fulfillmentComponent.itemIndex,
                                 0,
-                                context.executionState.orderHashes[
-                                    fulfillmentComponent.orderIndex
-                                ]
+                                context
+                                    .executionState
+                                    .orderDetails[
+                                        fulfillmentComponent.orderIndex
+                                    ]
+                                    .orderHash
                             );
                     }
 

--- a/test/foundry/new/helpers/FuzzTestContextLib.sol
+++ b/test/foundry/new/helpers/FuzzTestContextLib.sol
@@ -520,7 +520,8 @@ library FuzzTestContextLib {
         return context;
     }
 
-    // NOTE: expects context.executionState.orders and context.seaport to already be set
+    // NOTE: expects context.executionState.orders and context.seaport to
+    //       already be set.
     function withOrderHashes(
         FuzzTestContext memory context
     ) internal view returns (FuzzTestContext memory) {

--- a/test/foundry/new/helpers/event-utils/OrderFulfilledEventsLib.sol
+++ b/test/foundry/new/helpers/event-utils/OrderFulfilledEventsLib.sol
@@ -101,7 +101,7 @@ library OrderFulfilledEventsLib {
                 orderParams.zone.toBytes32(), // topic2 - zone
                 keccak256(
                     abi.encode(
-                        context.executionState.orderHashes[orderIndex],
+                        details.orderHash,
                         context.executionState.recipient == address(0)
                             ? context.executionState.caller
                             : context.executionState.recipient,

--- a/test/foundry/new/helpers/sol/MatchFulfillmentHelper.t.sol
+++ b/test/foundry/new/helpers/sol/MatchFulfillmentHelper.t.sol
@@ -99,8 +99,13 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             )
         });
 
+        bytes32[] memory orderHashes = new bytes32[](1);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
-            .getMatchedFulfillments(SeaportArrays.Orders(order));
+            .getMatchedFulfillments(
+                SeaportArrays.Orders(order),
+                orderHashes
+            );
 
         assertEq(fulfillments.length, 1);
         assertEq(fulfillments[0], expectedFulfillment, "fulfillments[0]");
@@ -185,8 +190,13 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             })
         );
 
+        bytes32[] memory orderHashes = new bytes32[](2);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
-            .getMatchedFulfillments(SeaportArrays.Orders(order, otherOrder));
+            .getMatchedFulfillments(
+                SeaportArrays.Orders(order, otherOrder),
+                orderHashes
+            );
 
         assertEq(fulfillments.length, 2);
         assertEq(fulfillments[0], expectedFulfillments[0], "fulfillments[0]");
@@ -290,8 +300,13 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             })
         );
 
+        bytes32[] memory orderHashes = new bytes32[](2);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
-            .getMatchedFulfillments(SeaportArrays.Orders(otherOrder, order));
+            .getMatchedFulfillments(
+                SeaportArrays.Orders(otherOrder, order),
+                orderHashes
+            );
 
         assertEq(fulfillments.length, 2, "fulfillments.length");
         assertEq(fulfillments[0], expectedFulfillments[1], "fulfillments[0]");
@@ -396,8 +411,13 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             })
         );
 
+        bytes32[] memory orderHashes = new bytes32[](2);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
-            .getMatchedFulfillments(SeaportArrays.Orders(otherOrder, order));
+            .getMatchedFulfillments(
+                SeaportArrays.Orders(otherOrder, order),
+                orderHashes
+            );
 
         assertEq(fulfillments.length, 2, "fulfillments.length");
         assertEq(fulfillments[0], expectedFulfillments[1], "fulfillments[0]");
@@ -502,8 +522,13 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             })
         );
 
+        bytes32[] memory orderHashes = new bytes32[](2);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
-            .getMatchedFulfillments(SeaportArrays.Orders(otherOrder, order));
+            .getMatchedFulfillments(
+                SeaportArrays.Orders(otherOrder, order),
+                orderHashes
+            );
 
         assertEq(fulfillments.length, 2, "fulfillments.length");
         assertEq(fulfillments[0], expectedFulfillments[1], "fulfillments[0]");
@@ -610,12 +635,15 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             })
         );
 
+        bytes32[] memory orderHashes = new bytes32[](2);
+
         (
             Fulfillment[] memory fulfillments,
             MatchComponent[] memory leftoverOffer,
             MatchComponent[] memory leftoverConsideration
         ) = matcher.getMatchedFulfillments(
-                SeaportArrays.Orders(otherOrder, order)
+                SeaportArrays.Orders(otherOrder, order),
+                orderHashes
             );
 
         assertEq(fulfillments.length, 2, "fulfillments.length");
@@ -726,8 +754,13 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             })
         );
 
+        bytes32[] memory orderHashes = new bytes32[](2);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
-            .getMatchedFulfillments(SeaportArrays.Orders(otherOrder, order));
+            .getMatchedFulfillments(
+                SeaportArrays.Orders(otherOrder, order),
+                orderHashes
+            );
 
         assertEq(fulfillments.length, 2, "fulfillments.length");
         assertEq(fulfillments[0], expectedFulfillments[1], "fulfillments[0]");
@@ -848,8 +881,13 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             })
         );
 
+        bytes32[] memory orderHashes = new bytes32[](2);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
-            .getMatchedFulfillments(SeaportArrays.Orders(order, otherOrder));
+            .getMatchedFulfillments(
+                SeaportArrays.Orders(order, otherOrder),
+                orderHashes
+            );
 
         assertEq(fulfillments.length, 3, "fulfillments.length");
 
@@ -972,8 +1010,13 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             })
         );
 
+        bytes32[] memory orderHashes = new bytes32[](2);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
-            .getMatchedFulfillments(SeaportArrays.Orders(order, otherOrder));
+            .getMatchedFulfillments(
+                SeaportArrays.Orders(order, otherOrder),
+                orderHashes
+            );
 
         assertEq(fulfillments.length, 3, "fulfillments.length");
 
@@ -1101,8 +1144,13 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             })
         );
 
+        bytes32[] memory orderHashes = new bytes32[](2);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
-            .getMatchedFulfillments(SeaportArrays.Orders(order, otherOrder));
+            .getMatchedFulfillments(
+                SeaportArrays.Orders(order, otherOrder),
+                orderHashes
+            );
 
         assertEq(fulfillments.length, 3, "fulfillments.length");
 
@@ -1230,8 +1278,14 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
                 )
             })
         );
+
+        bytes32[] memory orderHashes = new bytes32[](2);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
-            .getMatchedFulfillments(SeaportArrays.Orders(order, otherOrder));
+            .getMatchedFulfillments(
+                SeaportArrays.Orders(order, otherOrder),
+                orderHashes
+            );
 
         assertEq(fulfillments.length, 3, "fulfillments.length");
 
@@ -1511,6 +1565,8 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
             );
         }
 
+        bytes32[] memory orderHashes = new bytes32[](4);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
             .getMatchedFulfillments(
                 SeaportArrays.Orders(
@@ -1518,7 +1574,8 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
                     otherOrderOne,
                     orderTwo,
                     otherOrderTwo
-                )
+                ),
+                orderHashes
             );
 
         if (!useDifferentConduitsBetweenOrderPairs) {
@@ -1680,8 +1737,14 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
                 )
             })
         );
+
+        bytes32[] memory orderHashes = new bytes32[](2);
+
         (Fulfillment[] memory fulfillments, , ) = matcher
-            .getMatchedFulfillments(SeaportArrays.Orders(order, otherOrder));
+            .getMatchedFulfillments(
+                SeaportArrays.Orders(order, otherOrder),
+                orderHashes
+            );
         assertEq(fulfillments.length, 3, "fulfillments.length");
 
         assertEq(fulfillments[0], expectedFulfillments[0], "fulfillments[0]");
@@ -1730,11 +1793,16 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
 
         // Note: there's no order 2.
 
+        bytes32[] memory orderHashes = new bytes32[](1);
+
         (
             ,
             MatchComponent[] memory remainingOffer,
             MatchComponent[] memory remainingConsideration
-        ) = matcher.getMatchedFulfillments(SeaportArrays.Orders(order1));
+        ) = matcher.getMatchedFulfillments(
+                SeaportArrays.Orders(order1),
+                orderHashes
+            );
 
         assertEq(remainingOffer.length, 2, "remainingOffer.length");
         assertEq(
@@ -1831,11 +1899,16 @@ contract MatchFulfillmentHelperTest is BaseOrderTest {
 
         // Note: there's no order 2.
 
+        bytes32[] memory orderHashes = new bytes32[](1);
+
         (
             ,
             MatchComponent[] memory remainingOffer,
             MatchComponent[] memory remainingConsideration
-        ) = matcher.getMatchedFulfillments(SeaportArrays.Orders(order1));
+        ) = matcher.getMatchedFulfillments(
+                SeaportArrays.Orders(order1),
+                orderHashes
+            );
 
         assertEq(remainingOffer.length, 0);
         assertEq(remainingConsideration.length, 0);

--- a/test/foundry/zone/TestTransferValidationZoneFuzz.t.sol
+++ b/test/foundry/zone/TestTransferValidationZoneFuzz.t.sol
@@ -1372,9 +1372,16 @@ contract TestTransferValidationZoneOffererTest is BaseOrderTest {
             );
         }
 
+        bytes32[] memory orderHashes = new bytes32[](
+            context.matchArgs.orderPairCount * 2
+        );
+
         // Build fulfillments.
         (infra.fulfillments, , ) = matchFulfillmentHelper
-            .getMatchedFulfillments(infra.orders);
+            .getMatchedFulfillments(
+                infra.orders,
+                orderHashes
+            );
 
         return (infra.orders, infra.fulfillments);
     }


### PR DESCRIPTION
Adds `orderHash` to `OrderDetails` and switches most instances where we use `context.executionState.orderHashes[i]` to `bytes32 orderHash = context.executionState .orderDetails[i] .orderHash` to make sure it's working properly.