### PR TITLE
remove expected available orders array from context

### DIFF
--- a/test/foundry/new/helpers/DebugUtil.sol
+++ b/test/foundry/new/helpers/DebugUtil.sol
@@ -13,7 +13,7 @@ import { console2 } from "forge-std/console2.sol";
 
 import { ArrayHelpers, MemoryPointer } from "seaport-sol/../ArrayHelpers.sol";
 
-import { OrderStatusEnum } from "seaport-sol/SpaceEnums.sol";
+import { OrderStatusEnum, UnavailableReason } from "seaport-sol/SpaceEnums.sol";
 
 import { ForgeEventsLib } from "./event-utils/ForgeEventsLib.sol";
 
@@ -135,7 +135,11 @@ function dumpContext(
             context.executionState.orderDetails.length
         );
 
-        for (uint256 i = 0; i < context.executionState.orderDetails.length; i++) {
+        for (
+            uint256 i = 0;
+            i < context.executionState.orderDetails.length;
+            i++
+        ) {
             orderHashes[i] = context.executionState.orderDetails[i].orderHash;
         }
 
@@ -289,10 +293,24 @@ function dumpContext(
         );
     }
     if (outputSelection.expectedAvailableOrders) {
+        bool[] memory expectedAvailableOrders = new bool[](
+            context.executionState.orderDetails.length
+        );
+
+        for (
+            uint256 i = 0;
+            i < context.executionState.orderDetails.length;
+            i++
+        ) {
+            expectedAvailableOrders[i] =
+                context.executionState.orderDetails[i].unavailableReason ==
+                UnavailableReason.AVAILABLE;
+        }
+
         jsonOut = Searializer.tojsonDynArrayBool(
             "root",
             "expectedAvailableOrders",
-            context.expectations.expectedAvailableOrders
+            expectedAvailableOrders
         );
     }
     // =====================================================================//

--- a/test/foundry/new/helpers/FuzzEngine.sol
+++ b/test/foundry/new/helpers/FuzzEngine.sol
@@ -360,20 +360,18 @@ contract FuzzEngine is
      *      Each `withDerived` function calculates a value from the generated
      *      orders and adds it to the test context.
      *
-     *      1. withDerivedAvailableOrders: calculate which orders are available
-     *      2. withDerivedCriteriaResolvers: calculate criteria resolvers
-     *      3. withDerivedOrderDetails: calculate order details
-     *      4. withDetectedRemainders: detect and calculate remainders
-     *      5. withDerivedFulfillments: calculate expected fulfillments
-     *      6. withDerivedCallValue: calculate expected call value
-     *      7. withDerivedExecutions: expected implicit/explicit executions
-     *      8. withDerivedOrderDetails: calculate order details
+     *      1. withDerivedCriteriaResolvers: calculate criteria resolvers
+     *      2. withDerivedOrderDetails: calculate order details
+     *      3. withDetectedRemainders: detect and calculate remainders
+     *      4. withDerivedFulfillments: calculate expected fulfillments
+     *      5. withDerivedCallValue: calculate expected call value
+     *      6. withDerivedExecutions: expected implicit/explicit executions
+     *      7. withDerivedOrderDetails: calculate order details
      *
      * @param context A Fuzz test context.
      */
     function runDerivers(FuzzTestContext memory context) internal {
         context = context
-            .withDerivedAvailableOrders()
             .withDerivedCriteriaResolvers()
             .withDerivedOrderDetails()
             .withDetectedRemainders()

--- a/test/foundry/new/helpers/FuzzTestContextLib.sol
+++ b/test/foundry/new/helpers/FuzzTestContextLib.sol
@@ -153,11 +153,11 @@ struct Expectations {
     Execution[] expectedImplicitPostExecutions;
     Execution[] expectedExplicitExecutions;
     Execution[] allExpectedExecutions;
-    /**
-     * @dev Whether an order is available and will be fulfilled. Indexes
-     *      correspond to order indexes in the orders array.
-     */
-    bool[] expectedAvailableOrders;
+    // /**
+    //  * @dev Whether an order is available and will be fulfilled. Indexes
+    //  *      correspond to order indexes in the orders array.
+    //  */
+    // bool[] expectedAvailableOrders;
     /**
      * @dev Expected event hashes. Encompasses all events that match watched
      *      topic0s.
@@ -407,7 +407,7 @@ library FuzzTestContextLib {
                     expectedExplicitExecutions: new Execution[](0),
                     allExpectedExecutions: new Execution[](0),
                     expectedResults: results,
-                    expectedAvailableOrders: new bool[](0),
+                    // expectedAvailableOrders: new bool[](0),
                     expectedTransferEventHashes: expectedTransferEventHashes,
                     expectedSeaportEventHashes: expectedSeaportEventHashes,
                     ineligibleOrders: new bool[](orders.length),
@@ -502,15 +502,11 @@ library FuzzTestContextLib {
         context.executionState.orders = orders.copy();
 
         // Bootstrap with all available to ease direct testing.
-        if (context.expectations.expectedAvailableOrders.length == 0) {
-            context.expectations.expectedAvailableOrders = new bool[](
-                orders.length
-            );
+        if (context.executionState.orderDetails.length == 0) {
             context.executionState.orderDetails = new OrderDetails[](
                 orders.length
             );
             for (uint256 i = 0; i < orders.length; ++i) {
-                context.expectations.expectedAvailableOrders[i] = true;
                 context
                     .executionState
                     .orderDetails[i]


### PR DESCRIPTION
This is mostly isolated to the removal on the title, but it also strips out `withDerivedAvailableOrders`, which contained an `assume` that we may have been relying on downstream.  I've run ~70k fuzz runs locally after removing it without issue (except the known 721 balance issue, which persists), so I suspect we've handled the issue that addressed elsewhere, but I just wanted to surface it for review and awareness if we start getting weird errors.