### PR TITLE
Add validation to fuzz engine

### DIFF
--- a/contracts/helpers/order-validator/lib/SeaportValidatorTypes.sol
+++ b/contracts/helpers/order-validator/lib/SeaportValidatorTypes.sol
@@ -493,4 +493,16 @@ library IssueStringHelpers {
             revert("IssueStringHelpers: Unknown issue code");
         }
     }
+
+    function toIssueString(
+        uint16[] memory issueCodes
+    ) internal pure returns (string memory issueString) {
+        for (uint256 i; i < issueCodes.length; i++) {
+            issueString = string.concat(
+                issueString,
+                "\n    ",
+                toIssueString(issueCodes[i])
+            );
+        }
+    }
 }

--- a/test/foundry/new/BaseOrderTest.sol
+++ b/test/foundry/new/BaseOrderTest.sol
@@ -117,6 +117,7 @@ contract BaseOrderTest is
         SeaportInterface seaport;
     }
 
+    SeaportValidatorHelper validatorHelper;
     SeaportValidator validator;
     FulfillAvailableHelper fulfill;
     MatchFulfillmentHelper matcher;
@@ -179,8 +180,13 @@ contract BaseOrderTest is
 
         _configureStructDefaults();
 
+        uint256 chainId = block.chainid;
+        vm.chainId(2);
+        validatorHelper = new SeaportValidatorHelper();
+        vm.chainId(chainId);
+
         validator = new SeaportValidator(
-            address(new SeaportValidatorHelper()),
+            address(validatorHelper),
             address(getConduitController())
         );
 

--- a/test/foundry/new/BaseOrderTest.sol
+++ b/test/foundry/new/BaseOrderTest.sol
@@ -180,6 +180,11 @@ contract BaseOrderTest is
 
         _configureStructDefaults();
 
+        // TODO: creator fee engine addresses are hardcoded by chainid in the
+        // SeaportValidatorHelper contract and stored as an immutable in the
+        // constructor. This kludge ensures the engine address is address(0),
+        // which will skip calls to the creator fee engine and fall back to
+        // creator fee checks using EIP-2981.
         uint256 chainId = block.chainid;
         vm.chainId(2);
         validatorHelper = new SeaportValidatorHelper();

--- a/test/foundry/new/BaseOrderTest.sol
+++ b/test/foundry/new/BaseOrderTest.sol
@@ -180,15 +180,7 @@ contract BaseOrderTest is
 
         _configureStructDefaults();
 
-        // TODO: creator fee engine addresses are hardcoded by chainid in the
-        // SeaportValidatorHelper contract and stored as an immutable in the
-        // constructor. This kludge ensures the engine address is address(0),
-        // which will skip calls to the creator fee engine and fall back to
-        // creator fee checks using EIP-2981.
-        uint256 chainId = block.chainid;
-        vm.chainId(2);
         validatorHelper = new SeaportValidatorHelper();
-        vm.chainId(chainId);
 
         validator = new SeaportValidator(
             address(validatorHelper),

--- a/test/foundry/new/BaseOrderTest.sol
+++ b/test/foundry/new/BaseOrderTest.sol
@@ -62,6 +62,11 @@ import { TestERC721 } from "../../../contracts/test/TestERC721.sol";
 
 import { TestERC1155 } from "../../../contracts/test/TestERC1155.sol";
 
+import {
+    SeaportValidatorHelper,
+    SeaportValidator
+} from "../../../contracts/helpers/order-validator/SeaportValidator.sol";
+
 /**
  * @dev used to store address and key outputs from makeAddrAndKey(name)
  */
@@ -112,6 +117,7 @@ contract BaseOrderTest is
         SeaportInterface seaport;
     }
 
+    SeaportValidator validator;
     FulfillAvailableHelper fulfill;
     MatchFulfillmentHelper matcher;
 
@@ -172,6 +178,11 @@ contract BaseOrderTest is
         allocateTokensAndApprovals(address(this), type(uint128).max);
 
         _configureStructDefaults();
+
+        validator = new SeaportValidator(
+            address(new SeaportValidatorHelper()),
+            address(getConduitController())
+        );
 
         fulfill = new FulfillAvailableHelper();
         matcher = new MatchFulfillmentHelper();

--- a/test/foundry/new/SeaportValidator.t.sol
+++ b/test/foundry/new/SeaportValidator.t.sol
@@ -558,13 +558,13 @@ contract SeaportValidatorTest is BaseOrderTest {
 
         ErrorsAndWarnings memory expected = ErrorsAndWarningsLib
             .empty()
-            .addError(ERC721Issue.NotApproved)
             .addError(ERC721Issue.NotOwner)
+            .addError(ERC721Issue.NotApproved)
             .addError(GenericIssue.InvalidOrderFormat)
             .addWarning(TimeIssue.ShortOrder)
             .addWarning(StatusIssue.ContractOrder)
-            .addWarning(SignatureIssue.ContractOrder)
-            .addWarning(ConsiderationIssue.ZeroItems);
+            .addWarning(ConsiderationIssue.ZeroItems)
+            .addWarning(SignatureIssue.ContractOrder);
 
         assertEq(actual, expected);
     }

--- a/test/foundry/new/SeaportValidator.t.sol
+++ b/test/foundry/new/SeaportValidator.t.sol
@@ -558,13 +558,13 @@ contract SeaportValidatorTest is BaseOrderTest {
 
         ErrorsAndWarnings memory expected = ErrorsAndWarningsLib
             .empty()
-            .addError(ERC721Issue.NotOwner)
             .addError(ERC721Issue.NotApproved)
+            .addError(ERC721Issue.NotOwner)
             .addError(GenericIssue.InvalidOrderFormat)
             .addWarning(TimeIssue.ShortOrder)
             .addWarning(StatusIssue.ContractOrder)
-            .addWarning(ConsiderationIssue.ZeroItems)
-            .addWarning(SignatureIssue.ContractOrder);
+            .addWarning(SignatureIssue.ContractOrder)
+            .addWarning(ConsiderationIssue.ZeroItems);
 
         assertEq(actual, expected);
     }

--- a/test/foundry/new/SeaportValidator.t.sol
+++ b/test/foundry/new/SeaportValidator.t.sol
@@ -70,9 +70,6 @@ contract SeaportValidatorTest is BaseOrderTest {
     using IssueStringHelpers for uint16;
     using ErrorsAndWarningsLib for ErrorsAndWarnings;
 
-    SeaportValidator internal validator;
-    SeaportValidatorHelper internal helper;
-
     string constant SINGLE_ERC20 = "SINGLE_ERC20";
     string constant SINGLE_ERC1155 = "SINGLE_ERC1155";
     string constant SINGLE_NATIVE = "SINGLE_NATIVE";
@@ -84,11 +81,6 @@ contract SeaportValidatorTest is BaseOrderTest {
 
     function setUp() public override {
         super.setUp();
-        helper = new SeaportValidatorHelper();
-        validator = new SeaportValidator(
-            address(helper),
-            address(conduitController)
-        );
 
         OrderLib
             .empty()

--- a/test/foundry/new/helpers/DebugUtil.sol
+++ b/test/foundry/new/helpers/DebugUtil.sol
@@ -57,6 +57,7 @@ struct ContextOutputSelection {
     bool erc721ExpectedBalances;
     bool erc1155ExpectedBalances;
     bool preExecOrderStatuses;
+    bool validationErrors;
 }
 
 using ForgeEventsLib for Vm.Log;
@@ -135,7 +136,11 @@ function dumpContext(
             context.executionState.orderDetails.length
         );
 
-        for (uint256 i = 0; i < context.executionState.orderDetails.length; i++) {
+        for (
+            uint256 i = 0;
+            i < context.executionState.orderDetails.length;
+            i++
+        ) {
             orderHashes[i] = context.executionState.orderDetails[i].orderHash;
         }
 
@@ -354,6 +359,13 @@ function dumpContext(
     //         balanceChecker.dumpERC1155Balances()
     //     );
     // }
+    if (outputSelection.validationErrors) {
+        jsonOut = Searializer.tojsonDynArrayValidationErrorsAndWarnings(
+            "root",
+            "validationErrors",
+            context.executionState.validationErrors
+        );
+    }
     vm.writeJson(jsonOut, "./fuzz_debug.json");
 }
 
@@ -416,6 +428,7 @@ function dumpExecutions(FuzzTestContext memory context) view {
     selection.executionsFilter = ItemType.ERC1155_WITH_CRITERIA; // no filter
     selection.orders = true;
     selection.preExecOrderStatuses = true;
+    selection.validationErrors = true;
     pureDumpContext()(context, selection);
     console2.log("Dumped executions and balances to ./fuzz_debug.json");
 }

--- a/test/foundry/new/helpers/FuzzEngine.sol
+++ b/test/foundry/new/helpers/FuzzEngine.sol
@@ -494,6 +494,12 @@ contract FuzzEngine is
         }
     }
 
+    /**
+     * @dev Validate the generated orders using SeaportValidator and save the
+     *      validation errors to the test context.
+     *
+     * @param context A Fuzz test context.
+     */
     function validate(FuzzTestContext memory context) internal {
         for (uint256 i; i < context.executionState.orders.length; ++i) {
             Order memory order = context.executionState.orders[i].toOrder();
@@ -511,26 +517,6 @@ contract FuzzEngine is
                     }),
                     order
                 );
-            if (context.expectations.expectedAvailableOrders[i]) {
-                assertEq(
-                    0,
-                    context.executionState.validationErrors[i].errors.length,
-                    string.concat(
-                        "Available order returned validation errors: ",
-                        context
-                            .executionState
-                            .validationErrors[i]
-                            .errors
-                            .toIssueString()
-                    )
-                );
-            } else {
-                assertGt(
-                    context.executionState.validationErrors[i].errors.length,
-                    0,
-                    "Unavailable order did not return validation error"
-                );
-            }
         }
     }
 

--- a/test/foundry/new/helpers/FuzzEngine.sol
+++ b/test/foundry/new/helpers/FuzzEngine.sol
@@ -511,7 +511,7 @@ contract FuzzEngine is
                         seaport: address(context.seaport),
                         primaryFeeRecipient: address(0),
                         primaryFeeBips: 0,
-                        checkCreatorFee: true,
+                        checkCreatorFee: false,
                         skipStrictValidation: true,
                         shortOrderDuration: 30 minutes,
                         distantOrderExpiration: 26 weeks

--- a/test/foundry/new/helpers/FuzzEngine.sol
+++ b/test/foundry/new/helpers/FuzzEngine.sol
@@ -255,6 +255,7 @@ contract FuzzEngine is
         runDerivers(context);
         runSetup(context);
         runCheckRegistration(context);
+        validate(context);
         execFailure(context);
         execSuccess(context);
         checkAll(context);
@@ -526,7 +527,6 @@ contract FuzzEngine is
      * @param context A Fuzz test context.
      */
     function execSuccess(FuzzTestContext memory context) internal {
-        validate(context);
         ExpectedEventsUtil.startRecordingLogs();
         exec(context, true);
     }

--- a/test/foundry/new/helpers/FuzzTestContextLib.sol
+++ b/test/foundry/new/helpers/FuzzTestContextLib.sol
@@ -64,6 +64,7 @@ import { Failure } from "./FuzzMutationSelectorLib.sol";
 import { FractionResults } from "./FractionUtil.sol";
 
 import {
+    ErrorsAndWarnings,
     SeaportValidatorInterface
 } from "../../../../contracts/helpers/order-validator/SeaportValidator.sol";
 
@@ -266,6 +267,10 @@ struct ExecutionState {
      */
     OrderStatusEnum[] preExecOrderStatuses;
     uint256 value;
+    /**
+     * @dev ErrorsAndWarnings returned from SeaportValidator.
+     */
+    ErrorsAndWarnings[] validationErrors;
 }
 
 /**
@@ -444,7 +449,8 @@ library FuzzTestContextLib {
                     offerFulfillments: componentsArray,
                     considerationFulfillments: componentsArray,
                     maximumFulfilled: 0,
-                    value: 0
+                    value: 0,
+                    validationErrors: new ErrorsAndWarnings[](orders.length)
                 }),
                 actualEvents: actualEvents,
                 testHelpers: TestHelpers(address(this)),
@@ -516,6 +522,9 @@ library FuzzTestContextLib {
                 orders.length
             );
             context.executionState.orderDetails = new OrderDetails[](
+                orders.length
+            );
+            context.executionState.validationErrors = new ErrorsAndWarnings[](
                 orders.length
             );
             for (uint256 i = 0; i < orders.length; ++i) {

--- a/test/foundry/new/helpers/FuzzTestContextLib.sol
+++ b/test/foundry/new/helpers/FuzzTestContextLib.sol
@@ -63,6 +63,10 @@ import { Failure } from "./FuzzMutationSelectorLib.sol";
 
 import { FractionResults } from "./FractionUtil.sol";
 
+import {
+    SeaportValidatorInterface
+} from "../../../../contracts/helpers/order-validator/SeaportValidator.sol";
+
 interface TestHelpers {
     function balanceChecker() external view returns (ExpectedBalances);
 
@@ -303,6 +307,10 @@ struct FuzzTestContext {
      */
     ConduitControllerInterface conduitController;
     /**
+     * @dev A SeaportValidator interface.
+     */
+    SeaportValidatorInterface seaportValidator;
+    /**
      * @dev A TestHelpers interface. These helper functions are used to generate
      *      accounts and fulfillments.
      */
@@ -384,6 +392,7 @@ library FuzzTestContextLib {
                 actionSelected: false,
                 seaport: SeaportInterface(address(0)),
                 conduitController: ConduitControllerInterface(address(0)),
+                seaportValidator: SeaportValidatorInterface(address(0)),
                 fuzzParams: FuzzParams({
                     seed: 0,
                     totalOrders: 0,
@@ -594,6 +603,24 @@ library FuzzTestContextLib {
         ConduitControllerInterface conduitController
     ) internal pure returns (FuzzTestContext memory) {
         context.conduitController = conduitController;
+        return context;
+    }
+
+    /**
+     * @dev Sets the SeaportValidatorInterface on a FuzzTestContext
+     *
+     * @param context           the FuzzTestContext to set the
+     *                          SeaportValidatorInterface of
+     * @param seaportValidator  the SeaportValidatorInterface to set
+     *
+     * @return _context the FuzzTestContext with the SeaportValidatorInterface
+     *                  set
+     */
+    function withSeaportValidator(
+        FuzzTestContext memory context,
+        SeaportValidatorInterface seaportValidator
+    ) internal pure returns (FuzzTestContext memory) {
+        context.seaportValidator = seaportValidator;
         return context;
     }
 

--- a/test/foundry/new/helpers/Searializer.sol
+++ b/test/foundry/new/helpers/Searializer.sol
@@ -996,11 +996,13 @@ library Searializer {
         uint256 length = value.length;
         string memory out;
         for (uint256 i; i < length; i++) {
-            out = tojsonDynArrayValidationErrorMessages(
-                obj,
-                vm.toString(i),
-                value[i].errors
-            );
+            if (value[i].errors.length > 0) {
+                out = tojsonDynArrayValidationErrorMessages(
+                    obj,
+                    vm.toString(i),
+                    value[i].errors
+                );
+            }
         }
         return vm.serializeString(objectKey, valueKey, out);
     }

--- a/test/foundry/new/helpers/Searializer.sol
+++ b/test/foundry/new/helpers/Searializer.sol
@@ -43,6 +43,14 @@ import {
 
 import { withLabel } from "./Labeler.sol";
 
+import {
+    ErrorsAndWarnings
+} from "../../../../contracts/helpers/order-validator/SeaportValidator.sol";
+
+import {
+    IssueStringHelpers
+} from "../../../../contracts/helpers/order-validator/lib/SeaportValidatorTypes.sol";
+
 /**
  * @notice A helper library to seralize test data as JSON.
  */
@@ -977,5 +985,36 @@ library Searializer {
             value.erc1155
         );
         return vm.serializeString(objectKey, valueKey, finalJson);
+    }
+
+    function tojsonDynArrayValidationErrorsAndWarnings(
+        string memory objectKey,
+        string memory valueKey,
+        ErrorsAndWarnings[] memory value
+    ) internal returns (string memory) {
+        string memory obj = string.concat(objectKey, valueKey);
+        uint256 length = value.length;
+        string memory out;
+        for (uint256 i; i < length; i++) {
+            out = tojsonDynArrayValidationErrorMessages(
+                obj,
+                vm.toString(i),
+                value[i].errors
+            );
+        }
+        return vm.serializeString(objectKey, valueKey, out);
+    }
+
+    function tojsonDynArrayValidationErrorMessages(
+        string memory objectKey,
+        string memory valueKey,
+        uint16[] memory value
+    ) internal returns (string memory) {
+        uint256 length = value.length;
+        string[] memory out = new string[](length);
+        for (uint256 i; i < length; i++) {
+            out[i] = IssueStringHelpers.toIssueString(value[i]);
+        }
+        return vm.serializeString(objectKey, valueKey, out);
     }
 }


### PR DESCRIPTION
Add `validate` step to `FuzzEngine` and store validation results in context.

- Wire up `SeaportValidator` to `FuzzEngine`
- Validate orders before `execSuccess` and add returned `ErrorsAndWarnings` (per order) to test context.
- Add a `uint16[].toIssueString()` helper to format an array of validator error codes as a list in test output.
- Serialize validator errors in `fuzz_debug.json`:
<img width="614" alt="Screenshot 2023-05-09 at 4 13 36 PM" src="https://github.com/ProjectOpenSea/seaport/assets/109845214/d7fdfd9a-20d4-41f8-bb7d-ccc6c3077f7f">
