### PR TITLE
Revert "add seaport-core symlink for coverage reporting"

### DIFF
--- a/contracts/seaport-core
+++ b/contracts/seaport-core
@@ -1,1 +1,0 @@
-../lib/seaport-core


### PR DESCRIPTION
Reverts ProjectOpenSea/seaport#1237

seeing a bunch of errors in forge test CI after this:

```[FAIL. Reason: Setup failed: failed to read from "/home/runner/work/seaport/seaport/optimized-out/ConduitController.sol/ConduitController.json": No such file or directory (os error 2)]```