### PR TITLE
update oz lib to latest

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -37,7 +37,8 @@ runs = 1_000
 max_test_rejects = 1_000_000
 
 [profile.reference]
-solc = '0.8.13'
+#solc = '0.8.13'
+auto_detect_solc = true
 src = 'reference'
 out = 'reference-out'
 script = 'reference'

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc = '0.8.17'
+solc = '0.8.19'
 src = 'contracts'
 out = 'out'
 libs = ["node_modules", "lib"]
@@ -28,7 +28,7 @@ fs_permissions = [
 ]
 
 [profile.validator]
-solc = '0.8.17'
+solc = '0.8.19'
 src = 'contracts/helpers/order-validator'
 optimizer_runs = 1
 
@@ -37,8 +37,7 @@ runs = 1_000
 max_test_rejects = 1_000_000
 
 [profile.reference]
-#solc = '0.8.13'
-auto_detect_solc = true
+solc = '0.8.19'
 src = 'reference'
 out = 'reference-out'
 script = 'reference'


### PR DESCRIPTION
Having some [issues](https://github.com/ProjectOpenSea/seadrop/commit/b286ca1e303b6adfcbd6ad3a6cb0bcb01fe4b8c1) with foundry remappings, so would be great to get openzepplin-contracts lib updated to latest so can use it within seadrop directly without worrying about conflicting contract versions