### PR TITLE
move loop invariant codes out of loop to save gas

### DIFF
--- a/contracts/helpers/TransferHelper.sol
+++ b/contracts/helpers/TransferHelper.sol
@@ -152,6 +152,7 @@ contract TransferHelper is TransferHelperInterface, TransferHelperErrors {
         bool callERC721Receiver;
         TransferHelperItem calldata item;
         uint256 numItemsInTransfer;
+        uint256 j;
 
         // Skip overflow checks: all for loops are indexed starting at zero.
         unchecked {
@@ -179,7 +180,7 @@ contract TransferHelper is TransferHelperInterface, TransferHelperErrors {
 
                 // Iterate over each item in the transfer to create a
                 // corresponding ConduitTransfer.
-                for (uint256 j = 0; j < numItemsInTransfer; ++j) {
+                for (j = 0; j < numItemsInTransfer; ++j) {
                     // Retrieve the item from the transfer.
                     item = transferItems[j];
 

--- a/contracts/helpers/TransferHelper.sol
+++ b/contracts/helpers/TransferHelper.sol
@@ -180,6 +180,7 @@ contract TransferHelper is TransferHelperInterface, TransferHelperErrors {
 
                 // Iterate over each item in the transfer to create a
                 // corresponding ConduitTransfer.
+                address recipient = transfer.recipient;
                 for (j = 0; j < numItemsInTransfer; ++j) {
                     // Retrieve the item from the transfer.
                     item = transferItems[j];
@@ -199,7 +200,7 @@ contract TransferHelper is TransferHelperInterface, TransferHelperErrors {
                             // onERC721Received for the given tokenId.
                             _checkERC721Receiver(
                                 conduit,
-                                transfer.recipient,
+                                recipient,
                                 item.identifier
                             );
                         }
@@ -211,7 +212,7 @@ contract TransferHelper is TransferHelperInterface, TransferHelperErrors {
                         item.itemType,
                         item.token,
                         msg.sender,
-                        transfer.recipient,
+                        recipient,
                         item.identifier,
                         item.amount
                     );

--- a/contracts/helpers/TransferHelper.sol
+++ b/contracts/helpers/TransferHelper.sol
@@ -124,13 +124,14 @@ contract TransferHelper is TransferHelperInterface, TransferHelperErrors {
 
         // Declare a variable to store the sum of all items across transfers.
         uint256 sumOfItemsAcrossAllTransfers;
+        TransferHelperItemsWithRecipient calldata transfer;
 
         // Skip overflow checks: all for loops are indexed starting at zero.
         unchecked {
             // Iterate over each transfer.
             for (uint256 i = 0; i < numTransfers; ++i) {
                 // Retrieve the transfer in question.
-                TransferHelperItemsWithRecipient calldata transfer = transfers[
+                transfer = transfers[
                     i
                 ];
 
@@ -147,36 +148,40 @@ contract TransferHelper is TransferHelperInterface, TransferHelperErrors {
 
         // Declare an index for storing ConduitTransfers in conduitTransfers.
         uint256 itemIndex;
+        TransferHelperItem[] calldata transferItems;
+        bool callERC721Receiver;
+        TransferHelperItem calldata item;
+        uint256 numItemsInTransfer;
 
         // Skip overflow checks: all for loops are indexed starting at zero.
         unchecked {
             // Iterate over each transfer.
             for (uint256 i = 0; i < numTransfers; ++i) {
                 // Retrieve the transfer in question.
-                TransferHelperItemsWithRecipient calldata transfer = transfers[
+                transfer = transfers[
                     i
                 ];
 
                 // Retrieve the items of the transfer in question.
-                TransferHelperItem[] calldata transferItems = transfer.items;
+                transferItems = transfer.items;
 
                 // Ensure recipient is not the zero address.
                 _checkRecipientIsNotZeroAddress(transfer.recipient);
 
                 // Create a boolean indicating whether validateERC721Receiver
                 // is true and recipient is a contract.
-                bool callERC721Receiver = transfer.validateERC721Receiver &&
+                callERC721Receiver = transfer.validateERC721Receiver &&
                     transfer.recipient.code.length != 0;
 
                 // Retrieve the total number of items in the transfer and
                 // place on stack.
-                uint256 numItemsInTransfer = transferItems.length;
+                numItemsInTransfer = transferItems.length;
 
                 // Iterate over each item in the transfer to create a
                 // corresponding ConduitTransfer.
                 for (uint256 j = 0; j < numItemsInTransfer; ++j) {
                     // Retrieve the item from the transfer.
-                    TransferHelperItem calldata item = transferItems[j];
+                    item = transferItems[j];
 
                     if (item.itemType == ConduitItemType.ERC20) {
                         // Ensure that the identifier of an ERC20 token is 0.


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Initializing variables before the loop instead of inside the loop can also save gas. In the example below, function test2 consumes 927 units less gas than function test1 when the length of payloads is 100.
```
    function test1(bytes[] calldata payloads) public {
        for(uint256 i = 0; i < payloads.length; i++) {
            bytes calldata a = payloads[i];
        }
    }

    function test2(bytes[] calldata payloads) public {
        bytes calldata a;
        for(uint256 i = 0; i < payloads.length; i++) {
            a = payloads[i];
        }
    }
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
Moving variable initialization out of loop to save gas.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
