### PR TITLE
fix: use fuzzargs in differential test

### DIFF
--- a/test/foundry/offerers/ContractOffersNativeTokenOfferItems.t.sol
+++ b/test/foundry/offerers/ContractOffersNativeTokenOfferItems.t.sol
@@ -79,17 +79,8 @@ contract ContractOffersNativeTokenOfferItems is
     function testEthForErc721(
         FuzzArgs memory args
     ) public validateInputs(args) {
-        test(
-            this.ethForErc721,
-            Context({
-                seaport: consideration,
-                args: FuzzArgs({ ethAmount: 1, nftId: 1 })
-            })
-        );
-        test(
-            this.ethForErc721,
-            Context({ seaport: referenceConsideration, args: args })
-        );
+        test(this.ethForErc721, Context(consideration,args));
+        test(this.ethForErc721, Context(referenceConsideration,args));
     }
 
     function ethForErc721(Context memory context) public stateless {


### PR DESCRIPTION
## Motivation

Found what appears to be a mistake in one of the differential tests - fuzzed args are being passed to the reference test, but fixed args are being passed to the consideration test. It seems like fuzzed args should be passed to both tests.

## Solution

Pass fuzzed args to both tests.
