### PR TITLE
update arbitrum and optimism testnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,31 +117,6 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](https://g
 [0x0000f00000627D293Ab4Dfb40082001724dB006F](https://etherscan.io/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
 
 </td></tr>
-<tr><td>Goerli</td><td>
-
-[0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://goerli.etherscan.io/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)
-
-</td><td>
-
-[0x00000000000001ad428e4906aE43D8F9852d0dD6](https://goerli.etherscan.io/address/0x00000000000001ad428e4906aE43D8F9852d0dD6#code)
-
-</td><td>
-
-[0x00000000006c3852cbEf3e08E8dF289169EdE581](https://goerli.etherscan.io/address/0x00000000006c3852cbEf3e08E8dF289169EdE581#code)
-
-</td><td>
-
-[0x00000000F9490004C11Cef243f5400493c00Ad63](https://goerli.etherscan.io/address/0x00000000F9490004C11Cef243f5400493c00Ad63#code)
-
-</td><td>
-
-[0x00e5F120f500006757E984F1DED400fc00370000](https://goerli.etherscan.io/address/0x00e5F120f500006757E984F1DED400fc00370000#code)
-
-</td><td>
-
-[0x0000f00000627D293Ab4Dfb40082001724dB006F](https://goerli.etherscan.io/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
-
-</td></tr>
 <tr><td>Sepolia</td><td>
 
 [0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://sepolia.etherscan.io/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)
@@ -242,7 +217,7 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](https://g
 [0x0000f00000627D293Ab4Dfb40082001724dB006F](https://optimistic.etherscan.io/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
 
 </td></tr>
-<tr><td>Optimistic Sepolia</td><td>
+<tr><td>Optimism Sepolia</td><td>
 
 [0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://sepolia-optimism.etherscan.io/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)
 
@@ -367,13 +342,9 @@ Not deployed
 [0x0000f00000627D293Ab4Dfb40082001724dB006F](https://basescan.org/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
 
 </td></tr>
-<tr><td>Base Goerli</td><td>
+<tr><td>Base Sepolia</td><td>
 
-[0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://goerli.basescan.org/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)
-
-</td><td>
-
-Not deployed
+[0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://sepolia.basescan.org/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)
 
 </td><td>
 
@@ -381,15 +352,19 @@ Not deployed
 
 </td><td>
 
-[0x00000000F9490004C11Cef243f5400493c00Ad63](https://goerli.basescan.org/address/0x00000000F9490004C11Cef243f5400493c00Ad63#code)
+Not deployed
 
 </td><td>
 
-[0x00e5F120f500006757E984F1DED400fc00370000](https://goerli.basescan.org/address/0x00e5F120f500006757E984F1DED400fc00370000#code)
+[0x00000000F9490004C11Cef243f5400493c00Ad63](https://sepolia.basescan.org/address/0x00000000f9490004c11cef243f5400493c00ad63)
 
 </td><td>
 
-[0x0000f00000627D293Ab4Dfb40082001724dB006F](https://goerli.basescan.org/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
+[0x00e5F120f500006757E984F1DED400fc00370000](https://sepolia.basescan.org/address/0x00e5f120f500006757e984f1ded400fc00370000)
+
+</td><td>
+
+[0x0000f00000627D293Ab4Dfb40082001724dB006F](https://sepolia.basescan.org/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
 
 </td></tr>
 <tr><td>Avalanche C-Chain</td><td>
@@ -718,6 +693,57 @@ Not deployed
 </td><td>
 
 Not deployed
+
+</td></tr>
+
+<tr><td>Zora</td><td>
+
+[0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://explorer.zora.energy/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)
+
+</td><td>
+
+Not deployed
+
+</td><td>
+
+Not deployed
+
+</td><td>
+
+[0x00000000F9490004C11Cef243f5400493c00Ad63](https://explorer.zora.energy/address/0x00000000f9490004c11cef243f5400493c00ad63)
+
+</td><td>
+
+[0x00e5F120f500006757E984F1DED400fc00370000](https://explorer.zora.energy/address/0x00e5f120f500006757e984f1ded400fc00370000)
+
+</td><td>
+
+[0x0000f00000627D293Ab4Dfb40082001724dB006F](https://explorer.zora.energy/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
+
+</td></tr>
+<tr><td>Zora Sepolia</td><td>
+
+[0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://sepolia.explorer.zora.energy/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)
+
+</td><td>
+
+Not deployed
+
+</td><td>
+
+Not deployed
+
+</td><td>
+
+[0x00000000F9490004C11Cef243f5400493c00Ad63](https://sepolia.explorer.zora.energy/address/0x00000000f9490004c11cef243f5400493c00ad63)
+
+</td><td>
+
+[0x00e5F120f500006757E984F1DED400fc00370000](https://sepolia.explorer.zora.energy/address/0x00e5f120f500006757e984f1ded400fc00370000)
+
+</td><td>
+
+[0x0000f00000627D293Ab4Dfb40082001724dB006F](https://sepolia.explorer.zora.energy/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
 
 </td></tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -292,29 +292,29 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](https://g
 [0x0000f00000627D293Ab4Dfb40082001724dB006F](https://arbiscan.io/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
 
 </td></tr>
-<tr><td>Arbitrum Goerli</td><td>
+<tr><td>Arbitrum Sepolia</td><td>
 
-[0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://goerli.arbiscan.io/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)
-
-</td><td>
-
-[0x00000000000001ad428e4906aE43D8F9852d0dD6](https://goerli.arbiscan.io/address/0x00000000000001ad428e4906aE43D8F9852d0dD6#code)
+[0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://sepolia.arbiscan.io/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)
 
 </td><td>
 
-[0x00000000006c3852cbEf3e08E8dF289169EdE581](https://goerli.arbiscan.io/address/0x00000000006c3852cbEf3e08E8dF289169EdE581#code)
+Not deployed
 
 </td><td>
 
-[0x00000000F9490004C11Cef243f5400493c00Ad63](https://goerli.arbiscan.io/address/0x00000000F9490004C11Cef243f5400493c00Ad63#code)
+Not deployed
 
 </td><td>
 
-[0x00e5F120f500006757E984F1DED400fc00370000](https://goerli.arbiscan.io/address/0x00e5F120f500006757E984F1DED400fc00370000#code)
+[0x00000000F9490004C11Cef243f5400493c00Ad63](https://sepolia.arbiscan.io/address/0x00000000F9490004C11Cef243f5400493c00Ad63#code)
 
 </td><td>
 
-[0x0000f00000627D293Ab4Dfb40082001724dB006F](https://goerli.arbiscan.io/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
+[0x00e5F120f500006757E984F1DED400fc00370000](https://sepolia.arbiscan.io/address/0x00e5F120f500006757E984F1DED400fc00370000#code)
+
+</td><td>
+
+Not deployed
 
 </td></tr>
 <tr><td>Arbitrum Nova</td><td>

--- a/README.md
+++ b/README.md
@@ -242,29 +242,29 @@ See the [documentation](docs/SeaportDocumentation.md), the [interface](https://g
 [0x0000f00000627D293Ab4Dfb40082001724dB006F](https://optimistic.etherscan.io/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
 
 </td></tr>
-<tr><td>Optimistic Goerli</td><td>
+<tr><td>Optimistic Sepolia</td><td>
 
-[0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://goerli-optimism.etherscan.io/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)
-
-</td><td>
-
-[0x00000000000001ad428e4906aE43D8F9852d0dD6](https://goerli-optimism.etherscan.io/address/0x00000000000001ad428e4906aE43D8F9852d0dD6#code)
+[0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC](https://sepolia-optimism.etherscan.io/address/0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC#code)
 
 </td><td>
 
-[0x00000000006c3852cbEf3e08E8dF289169EdE581](https://goerli-optimism.etherscan.io/address/0x00000000006c3852cbEf3e08E8dF289169EdE581#code)
+Not deployed
 
 </td><td>
 
-[0x00000000F9490004C11Cef243f5400493c00Ad63](https://goerli-optimism.etherscan.io/address/0x00000000F9490004C11Cef243f5400493c00Ad63#code)
+Not deployed
 
 </td><td>
 
-[0x00e5F120f500006757E984F1DED400fc00370000](https://goerli-optimism.etherscan.io/address/0x00e5F120f500006757E984F1DED400fc00370000#code)
+[0x00000000F9490004C11Cef243f5400493c00Ad63](https://sepolia-optimism.etherscan.io/address/0x00000000F9490004C11Cef243f5400493c00Ad63#code)
 
 </td><td>
 
-[0x0000f00000627D293Ab4Dfb40082001724dB006F](https://goerli-optimism.etherscan.io/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
+[0x00e5F120f500006757E984F1DED400fc00370000](https://sepolia-optimism.etherscan.io/address/0x00e5F120f500006757E984F1DED400fc00370000#code)
+
+</td><td>
+
+Not deployed
 
 </td></tr>
 <tr><td>Arbitrum</td><td>

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Not deployed
 
 </td><td>
 
-Not deployed
+[0x0000f00000627D293Ab4Dfb40082001724dB006F](https://sepolia.arbiscan.io/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
 
 </td></tr>
 <tr><td>Arbitrum Nova</td><td>

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Not deployed
 
 </td><td>
 
-Not deployed
+[0x0000f00000627D293Ab4Dfb40082001724dB006F](https://sepolia-optimism.etherscan.io/address/0x0000f00000627D293Ab4Dfb40082001724dB006F#code)
 
 </td></tr>
 <tr><td>Arbitrum</td><td>


### PR DESCRIPTION
arbitrum goerli is now [deprecated](https://docs.arbitrum.io/for-devs/concepts/public-chains#arbitrum-goerli). Arbitrum sepolia is now live with a fresh seaport 1.5 deployment.

also updates optimism testnet to sepolia
