### PR TITLE
fix broken link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Seaport is a marketplace protocol for safely and efficiently buying and selling 
 
 Seaport is a marketplace protocol for safely and efficiently buying and selling NFTs. Each listing contains an arbitrary number of items that the offerer is willing to give (the "offer") along with an arbitrary number of items that must be received along with their respective receivers (the "consideration").
 
-See the [documentation](docs/SeaportDocumentation.md), the [interface](https://github.com/ProjectOpenSea/seaport-types/blob/main/src/interfaces/ConsiderationInterface.sol), and the full [interface documentation](https://docs.opensea.io/v2.0/reference/seaport-overview) for more information on Seaport.
+See the [documentation](docs/SeaportDocumentation.md), the [interface](https://github.com/ProjectOpenSea/seaport-types/blob/main/src/interfaces/ConsiderationInterface.sol), and the full [interface documentation](https://docs.opensea.io/docs/what-is-seaport) for more information on Seaport.
 
 This repository is also split into smaller repositories for easier use and integration:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Seaport is a marketplace protocol for safely and efficiently buying and selling 
 
 Seaport is a marketplace protocol for safely and efficiently buying and selling NFTs. Each listing contains an arbitrary number of items that the offerer is willing to give (the "offer") along with an arbitrary number of items that must be received along with their respective receivers (the "consideration").
 
-See the [documentation](docs/SeaportDocumentation.md), the [interface](https://github.com/ProjectOpenSea/seaport-types/blob/main/src/interfaces/ConsiderationInterface.sol), and the full [interface documentation](https://docs.opensea.io/docs/what-is-seaport) for more information on Seaport.
+See the [documentation](docs/SeaportDocumentation.md), the [interface](https://github.com/ProjectOpenSea/seaport-types/blob/main/src/interfaces/ConsiderationInterface.sol), and the full [interface documentation](https://docs.opensea.io/docs/seaport) for more information on Seaport.
 
 This repository is also split into smaller repositories for easier use and integration:
 

--- a/docs/Code4rena-Guidelines.md
+++ b/docs/Code4rena-Guidelines.md
@@ -86,7 +86,7 @@ A full suite of unit tests using Hardhat and Foundry have been provided in this 
 
 ## Information:
 
-[https://docs.opensea.io/v2.0/reference/seaport-overview](https://docs.opensea.io/v2.0/reference/seaport-overview)
+[https://docs.opensea.io/docs/what-is-seaport](https://docs.opensea.io/docs/what-is-seaport)
 
 ### Reference Implementation:
 

--- a/docs/Code4rena-Guidelines.md
+++ b/docs/Code4rena-Guidelines.md
@@ -86,7 +86,7 @@ A full suite of unit tests using Hardhat and Foundry have been provided in this 
 
 ## Information:
 
-[https://docs.opensea.io/docs/what-is-seaport](https://docs.opensea.io/docs/what-is-seaport)
+[https://docs.opensea.io/docs/seaport](https://docs.opensea.io/docs/seaport)
 
 ### Reference Implementation:
 


### PR DESCRIPTION
`https://docs.opensea.io/v2.0/reference/seaport-overview` - `https://docs.opensea.io/docs/what-is-seaport`

FIX LINK 

