### PR TITLE
fix: optimize pad to Reduce Gas Costs

### DIFF
--- a/script/NavigatorDeployer.s.sol
+++ b/script/NavigatorDeployer.s.sol
@@ -204,14 +204,15 @@ contract NavigatorDeployer is Script {
         return deploymentAddress;
     }
 
-    function pad(
-        string memory name,
-        uint256 n
-    ) internal pure returns (string memory) {
-        string memory padded = name;
-        while (bytes(padded).length < n) {
-            padded = string.concat(padded, " ");
+    function pad(string memory name, uint256 n) internal pure returns (string memory) {
+        uint256 len = bytes(name).length;
+        if (len >= n) {
+            return name;
         }
-        return padded;
+        bytes memory padding = new bytes(n - len);
+        for (uint256 i = 0; i < n - len; i++) {
+            padding[i] = " ";
+        }
+        return string(abi.encodePacked(name, padding));
     }
 }


### PR DESCRIPTION
## Motivation  
The `pad` function was using `while` and `string.concat`, which are not the most gas-efficient ways to handle string padding in Solidity. Since string operations are expensive, this approach led to unnecessary gas consumption.  

## Solution  
Replaced `while` and `string.concat` with `abi.encodePacked`, reducing redundant concatenations. This improves gas efficiency while maintaining the same functionality.

