### PR TITLE
fix shell command built from environment values OS Command Injection on utils()

### DIFF
--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
 
@@ -61,7 +61,7 @@ export function haveReportForCurrentCommit(): boolean {
 
 export function fileLastUpdate(filePath: string): number {
   let timestamp = parseInt(
-    execSync(`git log -1 --pretty="format:%ct" ${filePath}`)
+    execFileSync("git", ["log", "-1", `--pretty=format:%ct`, filePath])
       .toString()
       .trim() || "0"
   );


### PR DESCRIPTION
https://github.com/ProjectOpenSea/seaport/blob/687dfd72b80a0fbf30fc61008388bb7f508b6d70/scripts/utils.ts#L64-L64

fix the issue should avoid dynamically constructing the shell command with `filePath`. Instead, we can use `execFileSync` from the `child_process` module, which allows us to pass arguments to the command as an array. This approach ensures that the `filePath` is treated as a literal argument and not interpreted by the shell.

Specifically:
1. Replace the use of `execSync` with `execFileSync`.
2. Pass the `git` command and its arguments as separate elements in an array, ensuring `filePath` is treated safely.

The changes will be made in the `fileLastUpdate` function on line 64.


Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.

## POC
The following shows a dynamically constructed shell command that recursively removes a temporary directory that is located next to the currently executing JavaScript file. Such utilities are often found in custom build scripts.
```ts
var cp = require("child_process"),
  path = require("path");
function cleanupTemp() {
  let cmd = "rm -rf " + path.join(__dirname, "temp");
  cp.execSync(cmd); // BAD
}
```
The shell command will, however, fail to work as intended if the absolute path of the script's directory contains spaces. In that case, the shell command will interpret the absolute path as multiple paths, instead of a single path.

For instance, if the absolute path of the temporary directory is `/home/username/important opensea/temp`, then the shell command will recursively delete `/home/username/important` and `opensea/temp`, where the latter path gets resolved relative to the working directory of the JavaScript process.

Even worse, although less likely, a malicious user could provide the path `/home/username/; cat /etc/passwd #/important opensea/temp` in order to execute the command `cat /etc/passwd`.

To avoid such potentially catastrophic behaviors, provide the directory as an argument that does not get interpreted by a shell:
```ts
var cp = require("child_process"),
  path = require("path");
function cleanupTemp() {
  let cmd = "rm",
    args = ["-rf", path.join(__dirname, "temp")];
  cp.execFileSync(cmd, args); // GOOD
}
```
## References
[Command Injection](https://www.owasp.org/index.php/Command_Injection)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-88](https://cwe.mitre.org/data/definitions/88.html)