### PR TITLE
Fix broken link to config crate path

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -80,4 +80,4 @@ line_length = 80
 tab_width = 4
 bracket_spacing = true
 
-# See more config options https://github.com/gakonst/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config


### PR DESCRIPTION
**Description**
- Replace outdated link `https://github.com/gakonst/foundry/tree/master/config`
  with `https://github.com/foundry-rs/foundry/tree/master/crates/config`.
- Reflects repository restructure; the `/config` directory was moved to `crates/config`.
- Docs-only change—no code or build impact.