### PR TITLE
docs: point security reports at Bugcrowd in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,9 @@ Thank you for your Pull Request. Please provide a description above and review
 the requirements below.
 
 Bug fixes and new features should include tests.
+
+Do not report security vulnerabilities in a public pull request or issue. Use
+https://bugcrowd.com/engagements/opensea instead.
 -->
 
 ## Motivation


### PR DESCRIPTION
## Motivation

The template already keeps its guidance inside HTML comments, so none of it leaks into contributor PR bodies. What it does not say is where to send a security report, and a vulnerability filed as a public pull request or issue is disclosed the moment it is opened.

## Solution

One line added to the leading comment block, pointing at https://bugcrowd.com/engagements/opensea. Nothing else changes, and the rendered template is still just the Motivation and Solution headings.

Part of a sweep across the public OpenSea repos. The mirrored packages in opensea-devtools had the opposite problem: their template was plain markdown rather than a comment, so every community PR body opened with our own boilerplate. See opensea-sdk pull requests 1997 through 2000, all opened the same day, each beginning with "Thanks for opening a PR" before the author gets a word in.

Verified by stripping the HTML comments from the file and confirming the remainder is two headings and blank lines.

## CI status

The four Forge jobs are red, and they were red before this branch existed. They fail in `Install forge dependencies`, before a single contract compiles:

```
Updating dependencies in /home/runner/work/<repo>/<repo>/lib
Error: git checkout exited with code 1: error: pathspec 'v1.5.0' did not match any file(s) known to git
```

`.gitmodules` pins `lib/forge-std` with `branch = v1.5.0`, but v1.5.0 is a tag upstream, not a branch, and the Foundry nightly these workflows install can no longer resolve it from its shallow clone. The tag itself still exists at foundry-rs/forge-std, so this is toolchain drift rather than a deleted ref.

Every Seaport Test CI and seadrop Test CI run going back months has failed the same way, including dependabot branches that change nothing but a lockfile. Seaport's own main at 08013390, the base of this branch, failed on 2025-09-30. The Hardhat jobs, linters, CodeQL and Socket all pass here.

A markdown file cannot affect `forge install`. Repinning forge-std or freezing the Foundry version belongs in its own PR, since it touches the toolchain for an audited contract repo.
